### PR TITLE
Add GitHub workflows for building Docker images

### DIFF
--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -1,0 +1,22 @@
+name: Indexer Agent Image
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push Indexer Agent image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: jannispohlmann
+          password: ${{secrets.dockerhub_token}}
+          repository: graphprotocol/indexer-agent
+          tags: latest
+          tag_with_sha: true
+          dockerfile: Dockerfile.indexer-agent
+          build_args: NPM_TOKEN=${{secrets.npm_token}}

--- a/.github/workflows/indexer-service-image.yml
+++ b/.github/workflows/indexer-service-image.yml
@@ -1,0 +1,22 @@
+name: Indexer Service Image
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push Indexer Service image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: jannispohlmann
+          password: ${{secrets.dockerhub_token}}
+          repository: graphprotocol/indexer-service
+          tags: latest
+          tag_with_sha: true
+          dockerfile: Dockerfile.indexer-service
+          build_args: NPM_TOKEN=${{secrets.npm_token}}

--- a/Dockerfile.indexer-agent
+++ b/Dockerfile.indexer-agent
@@ -7,6 +7,8 @@ ARG NPM_TOKEN
 
 ENV NODE_ENV production
 
+RUN apt-get update && apt-get install -y python build-essential
+
 WORKDIR /opt/indexer
 
 # Copy root files
@@ -21,10 +23,6 @@ COPY packages/indexer-agent/ ./packages/indexer-agent
 
 # Install dependencies; include dev dependencies
 RUN yarn --pure-lockfile --non-interactive --production=false
-
-# Build the indexer-agent
-WORKDIR /opt/indexer/packages/indexer-agent
-RUN yarn prepare
 
 ########################################################################
 # Runtime image

--- a/Dockerfile.indexer-service
+++ b/Dockerfile.indexer-service
@@ -7,6 +7,8 @@ ARG NPM_TOKEN
 
 ENV NODE_ENV production
 
+RUN apt-get update && apt-get install -y python build-essential
+
 WORKDIR /opt/indexer
 
 # Copy root files
@@ -21,10 +23,6 @@ COPY packages/indexer-service/ ./packages/indexer-service
 
 # Install dependencies; include dev dependencies
 RUN yarn --pure-lockfile --non-interactive --production=false
-
-# Build the indexer-service
-WORKDIR /opt/indexer/packages/indexer-service
-RUN yarn prepare
 
 ########################################################################
 # Runtime image


### PR DESCRIPTION
This adds GitHub workflows for building and pushing `graphprotocol/indexer-service` and `graphprotocol/indexer-agent` Docker images whenever something gets pushed to master. These have been created on Docker Hub but are marked as private there.