### PR TITLE
terraform: Increase the default database size

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,7 +34,7 @@ variable "machine_type" {
 
 variable "database_tier" {
   type = string
-  default = "db-g1-small"
+  default = "db-custom-4-4096"
   description = "The type of machine to use for the database"
 }
 


### PR DESCRIPTION
Anything smaller than this is not really usable