### PR TITLE
Add the proof of indexing placeholder parameter to settle()

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -475,7 +475,13 @@ export class Network {
         deployment: allocation.subgraphDeployment.id.display,
         createdAtEpoch: allocation.createdAtEpoch,
       })
-      await this.contracts.staking.settle(allocation.id)
+      // TODO: here is where we send the proof of indexing for the settled allocation
+      // The POI is received by the contract and emitted as event for future disputes
+      // The extra parameter to settle() is included in the lastest version of testnet
+      // contracts
+      // WARN: this is random placeholder to be filled with the real POI
+      const proofOfIndexing = utils.hexlify(utils.randomBytes(32))
+      await this.contracts.staking.settle(allocation.id, proofOfIndexing)
       this.logger.info(`Settled allocation`, {
         id: allocation.id,
         deployment: allocation.subgraphDeployment.id.display,


### PR DESCRIPTION
#### Why?
The settle() function now includes an extra `bytes32` parameter to pass the POI related to the allocation.

#### Implements
I created this PR so we don't forget to pass this param to settle(). I'm filling it with a random bytes32 for the moment as there are no disputes in phase1 and we can include the real POI later.

#### Note
DO NOT MERGE until the latest contracts are deployed and we bump the contracts repo version.