### PR TITLE
[DO NOT MERGE] Update AllocationCreated attribute name changed

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -462,7 +462,7 @@ export class Network {
       deployment: new SubgraphDeploymentID(eventInputs.subgraphDeploymentID)
         .display,
       amountGRT: formatGRT(eventInputs.tokens),
-      channel: eventInputs.channelID,
+      channel: eventInputs.allocationID,
       channelPubKey: eventInputs.channelPubKey,
       epoch: eventInputs.epoch.toString(),
     })


### PR DESCRIPTION
#### Implements

This PR changes the attribute name used for `channelID` to `allocationID` in the `AllocationCreated` event.

#### Motivation

In the version of contracts to be deployed for phase1, all concept of `channelID` was changed to `allocationID`. This way it is less confusing as there might not always be a one-to-one relationship between state-channel identifier and allocation.

New event:
```
    event AllocationCreated(
        address indexed indexer,
        bytes32 indexed subgraphDeploymentID,
        uint256 epoch,
        uint256 tokens,
        address allocationID,
        bytes channelPubKey,
        uint256 price,
        address assetHolder
    );
```

#### Note

DO NOT MERGE until we deploy the latest version of phase1 contracts.

