### PR TITLE
Support https graph-node admin endpoint

### DIFF
--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -31,8 +31,14 @@ export class Indexer {
     this.indexerManagement = indexerManagement
     this.statuses = createClient({ url: statusEndpoint, fetch })
     this.logger = logger
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.rpc = jayson.Client.http(adminEndpoint as any)
+
+    if (adminEndpoint.startsWith('https')) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.rpc = jayson.Client.https(adminEndpoint as any)
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.rpc = jayson.Client.http(adminEndpoint as any)
+    }
     this.indexNodeIDs = indexNodeIDs
     this.defaultAllocationAmount = defaultAllocationAmount
   }


### PR DESCRIPTION
The indexer component now checks whether the graph-node admin endpoint is http or https and uses the corresponding jayson client instantiation function.