### PR TITLE
Allow to configure secure boot for worker nodes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,6 +59,10 @@ resource "google_container_node_pool" "default_pool" {
     preemptible  = false
     machine_type = var.machine_type
 
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
+
     metadata = {
       disable-legacy-endpoints = "true"
     }
@@ -82,6 +86,10 @@ resource "google_container_node_pool" "query_pool" {
   node_config {
     preemptible  = false
     machine_type = var.machine_type
+
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -118,6 +126,10 @@ resource "google_container_node_pool" "index_pool" {
   node_config {
     preemptible  = false
     machine_type = var.machine_type
+
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
 
     metadata = {
       disable-legacy-endpoints = "true"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,6 +32,11 @@ variable "machine_type" {
   description = "The type of machine to use for kubernetes nodes"
 }
 
+variable "secure_boot" {
+  default = false
+  description = "Whether to enable secure boot for kubernetes nodes"
+}
+
 variable "database_tier" {
   type = string
   default = "db-custom-4-4096"


### PR DESCRIPTION
Secure boot is turned off by default but there's really no hard in using it: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot

It defauts to `false` so that people have to opt-in since it replaces all nodes.