### PR TITLE
Allow to configure several Terraform parameters

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,7 @@ resource "google_container_node_pool" "default_pool" {
   node_config {
     preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     shielded_instance_config {
       enable_secure_boot = var.secure_boot
@@ -90,6 +91,7 @@ resource "google_container_node_pool" "query_pool" {
   node_config {
     preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     shielded_instance_config {
       enable_secure_boot = var.secure_boot
@@ -130,6 +132,7 @@ resource "google_container_node_pool" "index_pool" {
   node_config {
     preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     shielded_instance_config {
       enable_secure_boot = var.secure_boot

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,6 +48,12 @@ variable "release_channel" {
   description = "The release channel of the Kubernetes cluster"
 }
 
+variable "image_type" {
+  type = string
+  default = "COS"
+  description = "The image type to use for kubernetes nodes"
+}
+
 variable "database_tier" {
   type = string
   default = "db-custom-4-4096"


### PR DESCRIPTION
**Secure boot** is turned off by default but there's really no hard in using it: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot

It defauts to `false` so that people have to opt-in since it replaces all nodes.

**Release channel**: This adds a variable to specify the release channel of the Kubernetes cluster.

Release channels keep the cluster updated automatically based on a configurable frequency, such as rapid, regular and stable: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels

The previous config didn't use release channels and that's also the default in this PR. This currently maps to 1.15.

However, 1.15 matches the version in the "STABLE" release channel and we could think about making it the default. The update is in-place and doesn't require any node replacements.

**Image Type**: This allows to switch the VM image for worker nodes away from the default ContainerOS.

We use it to switch to "COS_CONTAINERD" which is COS using containerd instead of docker.

Other people might want to use Ubuntu workers.

All options can be seen here: https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images

Defaults to the current value.