### PR TITLE
Allow to configure image type for worker nodes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,6 +58,7 @@ resource "google_container_node_pool" "default_pool" {
   node_config {
     preemptible  = false
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -82,6 +83,7 @@ resource "google_container_node_pool" "query_pool" {
   node_config {
     preemptible  = false
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -118,6 +120,7 @@ resource "google_container_node_pool" "index_pool" {
   node_config {
     preemptible  = false
     machine_type = var.machine_type
+    image_type   = var.image_type
 
     metadata = {
       disable-legacy-endpoints = "true"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,6 +32,12 @@ variable "machine_type" {
   description = "The type of machine to use for kubernetes nodes"
 }
 
+variable "image_type" {
+  type = string
+  default = "COS"
+  description = "The image type to use for kubernetes nodes"
+}
+
 variable "database_tier" {
   type = string
   default = "db-custom-4-4096"


### PR DESCRIPTION
This allows to switch the VM image for worker nodes away from the default ContainerOS.

We use it to switch to "COS_CONTAINERD" which is COS using containerd instead of docker.

Other people might want to use Ubuntu workers.

All options can be seen here: https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images

Defaults to the current value.