### PR TITLE
Fix metrics path for indexer service

### DIFF
--- a/k8s/base/indexer-service/deployment.yaml
+++ b/k8s/base/indexer-service/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: indexer-service
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/path: "/metrics"
+        prometheus.io/path: "/"
         prometheus.io/port: "7300"
     spec:
       # Temporary: Allow to pull private Docker images


### PR DESCRIPTION
The Prometheus annotation instructs it to query the Indexer Service on port 7300 under the standard `/metrics` path.

However Indexer Service currently serves its metrics under just `/`.