### PR TITLE
indexer-agent: Don't settle allocations before an epoch has passed

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -360,8 +360,12 @@ class Agent {
 
       // Make sure to settle all active allocations on the way out
       if (activeAllocations.length > 0) {
+        // We can only settle allocations that are at least one epoch old;
+        // try the others again later
         await pMap(
-          activeAllocations,
+          activeAllocations.filter(
+            allocation => allocation.createdAtEpoch < epoch,
+          ),
           async allocation => await this.network.settle(allocation),
           { concurrency: 1 },
         )


### PR DESCRIPTION
When a subgraph deployment is no longer worth allocating, we can only settle those allocations that are at least one epoch old; the others we have to retry again later. Otherwise we generate about 240 failed transactions per allocation per hour (assuming an epoch duration of around one hour) before settling succeeds, wasting a lot of ETH in the process.