### PR TITLE
indexer-common: Validate indexing rule data

### DIFF
--- a/packages/indexer-common/src/indexer-management/models.ts
+++ b/packages/indexer-common/src/indexer-management/models.ts
@@ -120,15 +120,6 @@ export const defineIndexerManagementModels = (
               return
             }
 
-            // "Qm..." is ok
-            if (
-              bs58.decodeUnsafe(value) !== undefined &&
-              value.startsWith('Qm') &&
-              value.length === 46
-            ) {
-              return
-            }
-
             // "0x..." is ok
             if (utils.isHexString(value, 32)) {
               return


### PR DESCRIPTION
This adds a set of validations to the `IndexingRule` model to make sure no invalid data enters the database.

This PR is based on #43 and should be rebased after #43 is merged.