### PR TITLE
indexer-agent: Fix input validation of geo-coordinates

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -138,6 +138,12 @@ export default {
         ) {
           return `One of --network-subgraph-endpoint and --network-subgraph-deployment must be provided`
         }
+        if (argv['indexer-geo-coordinates']) {
+          const [geo1, geo2] = argv['indexer-geo-coordinates']
+          if (!+geo1 || !+geo2) {
+            return 'Invalid --indexer-geo-coordinates provided. Must be of format e.g.: 31.780715 -41.179504'
+          }
+        }
         return true
       })
   },


### PR DESCRIPTION
Fix input validation of geo-coordinates to avoid NaN values when commas are used as decimal separators, ending up encoded like zeroed geohash.