### PR TITLE
receipt-manager: always send one message instead of an array of messages

### DIFF
--- a/packages/receipt-manager/package.json
+++ b/packages/receipt-manager/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@graphprotocol/common-ts": "^0.2.4",
     "@graphprotocol/statechannels": "^0.0.1",
-    "@statechannels/server-wallet": "^0.3.5"
+    "@statechannels/server-wallet": "^0.3.5",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@statechannels/devtools": "^0.3.5",
@@ -26,7 +27,6 @@
     "@typescript-eslint/parser": "^3.10.1",
     "eslint": "^7.7.0",
     "jest": "^26.4.2",
-    "lodash": "^4.17.20",
     "prettier": "^2.1.0",
     "ts-jest": "^26.2.0",
     "typescript": "^4.0.2"

--- a/packages/receipt-manager/src/__tests__/receipt-manager.test.ts
+++ b/packages/receipt-manager/src/__tests__/receipt-manager.test.ts
@@ -36,10 +36,10 @@ const logger = createLogger({ name: 'receipt-manager.test.ts' })
 
 let receiptManager: ReceiptManager
 
-function stateFromMessage(messages: WireMessage[] | undefined, index = 0): SignedState {
-  expect(messages).toBeDefined()
+function stateFromMessage(message: WireMessage | undefined, index = 0): SignedState {
+  expect(message).toBeDefined()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return (messages![index] as PayerMessage).data.signedStates![0]
+  return (message as PayerMessage).data.signedStates![index]
 }
 
 beforeAll(async () => {
@@ -97,7 +97,7 @@ describe('ReceiptManager', () => {
       mockSCAttestation(),
     )
 
-    const nextState = stateFromMessage([attestationMessage])
+    const nextState = stateFromMessage(attestationMessage)
     const appData = toJS(nextState.appData)
     expect(appData.constants).toEqual(mockAppData().constants)
     expect(appData.variable.responseCID).toEqual(mockSCAttestation().responseCID)
@@ -113,7 +113,7 @@ describe('ReceiptManager', () => {
     await receiptManager.inputStateChannelMessage(mockQueryRequestMessage())
     const outbound = await receiptManager.declineQuery(mockQueryRequestMessage())
 
-    const nextState = stateFromMessage([outbound])
+    const nextState = stateFromMessage(outbound)
     const appData = toJS(nextState.appData)
     expect(appData.constants).toEqual(mockAppData().constants)
     expect(appData.variable.stateType).toEqual(StateType.QueryDeclined)


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/gateway/pull/18#issuecomment-686779389