### PR TITLE
indexer-agent: Avoid settling allocations repeatedly

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid settling allocations that are already settled on chain
 
 ## [0.2.5] - 2020-09-01
 ### Changed

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -536,6 +536,22 @@ export class Network {
     })
     try {
       logger.info(`Settle allocation`)
+
+      // Double-check whether the allocation is still active on chain, to
+      // avoid unnecessary transations.
+      // Note: We're checking the allocation state here, which is defined as
+      //
+      //     enum AllocationState { Null, Active, Closed, Finalized, Claimed }
+      //
+      // in the contracts.
+      const state = await this.contracts.staking.getAllocationState(
+        allocation.id,
+      )
+      if (state !== 1) {
+        logger.info(`Allocation already settled on chain`)
+        return true
+      }
+
       await Ethereum.executeTransaction(
         this.contracts.staking.settle(
           allocation.id,


### PR DESCRIPTION
Attempting to settle allocations that are already settled on chain can lead to unnecessary transactions that are guaranteed to fail and that still cost gas. Avoid this by double-checking the state of allocations before settling.