### PR TITLE
Properly support 0x- and Qm-style deployment IDs

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/rules/clear.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/clear.ts
@@ -5,7 +5,12 @@ import { partition } from '@thi.ng/iterators'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters, validateDeploymentID } from '../../../command-helpers'
-import { setIndexingRule, printIndexingRules, parseDeploymentID } from '../../../rules'
+import {
+  setIndexingRule,
+  printIndexingRules,
+  parseDeploymentID,
+  parseIndexingRule,
+} from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules clear')} [options] global          <key1> ...
@@ -58,7 +63,7 @@ module.exports = {
     }
 
     // Turn the array into an object, add a `deployment` key
-    const inputRule = {
+    const inputRule = parseIndexingRule({
       ...Object.fromEntries(
         partition(
           2,
@@ -68,7 +73,7 @@ module.exports = {
         ),
       ),
       deployment,
-    }
+    })
 
     // Update the indexing rule according to the key/value pairs
     try {

--- a/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
@@ -5,7 +5,12 @@ import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters, validateDeploymentID } from '../../../command-helpers'
 import { IndexingDecisionBasis } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseDeploymentID } from '../../../rules'
+import {
+  setIndexingRule,
+  printIndexingRules,
+  parseDeploymentID,
+  parseIndexingRule,
+} from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules maybe')} [options] global
@@ -49,10 +54,10 @@ module.exports = {
       return
     }
 
-    const inputRule = {
+    const inputRule = parseIndexingRule({
       decisionBasis: IndexingDecisionBasis.RULES,
       deployment,
-    }
+    })
 
     // Update the indexing rule according to the key/value pairs
     try {

--- a/packages/indexer-cli/src/commands/indexer/rules/start.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/start.ts
@@ -5,7 +5,12 @@ import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters, validateDeploymentID } from '../../../command-helpers'
 import { IndexingDecisionBasis } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseDeploymentID } from '../../../rules'
+import {
+  setIndexingRule,
+  printIndexingRules,
+  parseDeploymentID,
+  parseIndexingRule,
+} from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules start')}  [options] global
@@ -51,10 +56,10 @@ module.exports = {
       return
     }
 
-    const inputRule = {
+    const inputRule = parseIndexingRule({
       deployment,
       decisionBasis: IndexingDecisionBasis.ALWAYS,
-    }
+    })
 
     // Update the indexing rule according to the key/value pairs
     try {

--- a/packages/indexer-cli/src/commands/indexer/rules/stop.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/stop.ts
@@ -5,7 +5,12 @@ import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters, validateDeploymentID } from '../../../command-helpers'
 import { IndexingDecisionBasis } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseDeploymentID } from '../../../rules'
+import {
+  setIndexingRule,
+  printIndexingRules,
+  parseDeploymentID,
+  parseIndexingRule,
+} from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules stop')}  [options] global
@@ -51,10 +56,10 @@ module.exports = {
       return
     }
 
-    const inputRule = {
+    const inputRule = parseIndexingRule({
       deployment,
       decisionBasis: IndexingDecisionBasis.NEVER,
-    }
+    })
 
     // Update the indexing rule according to the key/value pairs
     try {

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -100,6 +100,9 @@ const INDEXING_RULE_CONVERTERS_TO_GRAPHQL: Record<
   custom: nullPassThrough(JSON.stringify),
 }
 
+/**
+ * Parses a user-provided indexing rule into a normalized form.
+ */
 export const parseIndexingRule = (
   rule: Partial<IndexingRuleAttributes>,
 ): Partial<IndexingRuleAttributes> => {
@@ -112,6 +115,9 @@ export const parseIndexingRule = (
   return obj as Partial<IndexingRuleAttributes>
 }
 
+/**
+ * Formats an indexing rule for display in the console.
+ */
 export const formatIndexingRule = (
   rule: Partial<IndexingRuleAttributes>,
 ): Partial<IndexingRuleAttributes> => {
@@ -124,6 +130,10 @@ export const formatIndexingRule = (
   return obj as Partial<IndexingRuleAttributes>
 }
 
+/**
+ * Parses an indexing rule returned from the indexer management GraphQL
+ * API into normalized form.
+ */
 export const indexingRuleFromGraphQL = (
   rule: Partial<IndexingRuleAttributes>,
 ): Partial<IndexingRuleAttributes> => {
@@ -136,6 +146,10 @@ export const indexingRuleFromGraphQL = (
   return obj as Partial<IndexingRuleAttributes>
 }
 
+/**
+ * Converts a normalized indexing rule to a representation
+ * compatible with the indexer management GraphQL API.
+ */
 export const indexingRuleToGraphQL = (
   rule: Partial<IndexingRuleAttributes>,
 ): Partial<IndexingRuleAttributes> => {


### PR DESCRIPTION
The database validation in https://github.com/graphprotocol/indexer/blob/master/packages/indexer-common/src/indexer-management/models.ts#L107-L133 already prevents duplicates, but the changes made recently were rejecting `Qm` style deployment IDs on the command line.

This PR allows both `0x` and `Qm` style deployment IDs to be passed in. `Qm` is always used for displaying, while `0x` is always used for storing in the database.