### PR TITLE
Allow to clear/reset all fields of a rule at once

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/rules/clear.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/clear.ts
@@ -13,10 +13,10 @@ import {
 } from '../../../rules'
 
 const HELP = `
-${chalk.bold('graph indexer rules clear')} [options] global          <key1> ...
-${chalk.bold('graph indexer rules clear')} [options] <deployment-id> <key1> ...
-${chalk.bold('graph indexer rules reset')} [options] global          <key1> ...
-${chalk.bold('graph indexer rules reset')} [options] <deployment-id> <key1> ...
+${chalk.bold('graph indexer rules clear')} [options] global          [<key1> ...]
+${chalk.bold('graph indexer rules clear')} [options] <deployment-id> [<key1> ...]
+${chalk.bold('graph indexer rules reset')} [options] global          [<key1> ...]
+${chalk.bold('graph indexer rules reset')} [options] <deployment-id> [<key1> ...]
 
 ${chalk.dim('Options:')}
 
@@ -46,10 +46,19 @@ module.exports = {
       return
     }
 
+    // Clear all keys if none are provided
     if (keys.length === 0) {
-      print.error(`No keys provided for clearing`)
-      process.exitCode = 1
-      return
+      keys.push(
+        'allocationAmount',
+        'parallelAllocations',
+        'minSignal',
+        'maxSignal',
+        'minStake',
+        'maxAllocationPercentage',
+        'minAverageQueryFees',
+        'decisionBasis',
+        'custom',
+      )
     }
 
     const config = loadValidatedConfig()


### PR DESCRIPTION
This fixes #42 by clearing/resetting all fields of a rule if no keys are provided on the command line.

![image](https://user-images.githubusercontent.com/19324/93211003-e9397780-f760-11ea-8c72-cac1ed9f13a3.png)

_Note: This PR is based on #60 and should be rebased after #60 is merged.