### PR TITLE
Fix INDEXER_AGENT_INDEXER_GEO_COORDINATES env var (#58)

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -59,9 +59,15 @@ export default {
       })
       .options('indexer-geo-coordinates', {
         description: `Coordinates describing the Indexer's location using latitude and longitude`,
-        type: 'array',
+        type: 'string',
+        array: true,
         default: ['31.780715', '-41.179504'],
         group: 'Indexer Infrastructure',
+        coerce: arg =>
+          arg.reduce(
+            (acc: string[], value: string) => [...acc, ...value.split(' ')],
+            [],
+          ),
       })
       .option('network-subgraph-deployment', {
         description: 'Network subgraph deployment',


### PR DESCRIPTION
This fixes #58.

This makes it possible to pass in a single string for the coordinates, with latitude and longitude delimited by a space. Before it was only possible to pass in an array of values through the CLI, not through an environment variable.