### PR TITLE
Increase limit on size of channel-messages-inbox payload

### DIFF
--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -174,7 +174,7 @@ export const createApp = async ({
     '/channel-messages-inbox',
 
     // Accept JSON and parse it
-    bodyParser.json(),
+    bodyParser.json({limit: '5mb'}),
 
     async (req, res) => {
       try {


### PR DESCRIPTION
This is important to allow batched channel creation, since it can result
in payloads exceeding the default limit of 100kb.