### PR TITLE
indexer-common: Fix clearing cost models

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
@@ -295,4 +295,34 @@ describe('Cost models', () => {
       inputs,
     )
   })
+
+  test('Clear model by passing in an empty model', async () => {
+    let input = {
+      deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      model: '{ votes } => 10 * $n',
+      variables: JSON.stringify({ n: 100 }),
+    }
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+    })
+
+    await client.mutation(SET_COST_MODEL_MUTATION, { costModel: input }).toPromise()
+
+    input = {
+      deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      model: '',
+      variables: '{}',
+    }
+
+    await client.mutation(SET_COST_MODEL_MUTATION, { costModel: input }).toPromise()
+
+    expect(
+      client.query(GET_COST_MODELS_QUERY).toPromise(),
+    ).resolves.toHaveProperty('data.costModels', [input])
+  })
 })

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -35,7 +35,10 @@ export default {
       where: { deployment: costModel.deployment },
     })
     model.deployment = costModel.deployment || model.deployment
-    model.model = costModel.model || model.model
+    model.model =
+      costModel.model !== null && costModel.model !== undefined
+        ? costModel.model
+        : model.model
     model.variables = costModel.variables || model.variables
     return (await model.save()).toGraphQL()
   },


### PR DESCRIPTION
Previously, we'd fall back to the old value if an empty cost model was passed in. Now we're only doing that if the new cost model is `null` or `undefined` (which shouldn't ever happen).