### PR TITLE
Improvements to Indexer-Agent allocation process

### DIFF
--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -32,6 +32,7 @@
     "p-filter": "^2.1.0",
     "p-map": "^4.0.0",
     "p-queue": "^6.4.0",
+    "p-reduce": "^2.1.0",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -483,12 +483,11 @@ class Agent {
         desiredNumberOfAllocations,
         allocationAmount: formatGRT(allocationAmount),
       })
-
-      await pMap(
-        ti.repeat(allocationAmount, desiredNumberOfAllocations),
-        async amount =>
-          await this.network.allocate(deployment, amount, activeAllocations),
-        { concurrency: 1 },
+      await this.network.allocateMultiple(
+        deployment,
+        allocationAmount,
+        activeAllocations,
+        desiredNumberOfAllocations,
       )
 
       return
@@ -627,12 +626,12 @@ class Agent {
           allocationAmount: formatGRT(allocationAmount),
         },
       )
-      await pMap(
-        ti.repeat(allocationAmount, allocationsToCreate),
-        async amount => {
-          await this.network.allocate(deployment, amount, activeAllocations)
-        },
-        { concurrency: 1 },
+
+      await this.network.allocateMultiple(
+        deployment,
+        allocationAmount,
+        activeAllocations,
+        allocationsToCreate,
       )
     }
   }

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -31,6 +31,8 @@ import { Client, createClient } from '@urql/core'
 import gql from 'graphql-tag'
 import fetch from 'isomorphic-fetch'
 import geohash from 'ngeohash'
+import pReduce from 'p-reduce'
+import * as ti from '@thi.ng/iterators'
 
 const txOverrides = {
   gasLimit: 1000000,
@@ -540,11 +542,34 @@ export class Network {
     }
   }
 
-  async allocate(
+  async allocateMultiple(
     deployment: SubgraphDeploymentID,
     amount: BigNumber,
     activeAllocations: Allocation[],
-  ): Promise<void> {
+    numAllocations: number,
+  ): Promise<Allocation[]> {
+    return await pReduce(
+      ti.repeat(amount, numAllocations),
+      async (allocations, allocationAmount) => {
+        const newAllocation = await this.allocate(
+          deployment,
+          allocationAmount,
+          allocations,
+        )
+        if (newAllocation) {
+          allocations.push(newAllocation)
+        }
+        return allocations
+      },
+      activeAllocations,
+    )
+  }
+
+  private async allocate(
+    deployment: SubgraphDeploymentID,
+    amount: BigNumber,
+    activeAllocations: Allocation[],
+  ): Promise<Allocation | undefined> {
     const price = parseGRT('0.01')
 
     const logger = this.logger.child({ deployment: deployment.display })
@@ -628,6 +653,19 @@ export class Network {
       allocation: eventInputs.allocationID,
       epoch: eventInputs.epoch.toString(),
     })
+
+    return {
+      id: id,
+      subgraphDeployment: {
+        id: deployment,
+        stakedTokens: BigNumber.from(0),
+        signalAmount: BigNumber.from(0),
+      },
+      allocatedTokens: BigNumber.from(eventInputs.tokens),
+      createdAtBlockHash: '0x0',
+      createdAtEpoch: eventInputs.epoch,
+      closedAtEpoch: 0,
+    } as Allocation
   }
 
   async close(allocation: Allocation, poi: string): Promise<boolean> {


### PR DESCRIPTION

This PR aims to resolve several known issues with allocation from the indexer-agent:
- Resolves #89  - Use `first: 1000` in `Allocation` queries to increase the query return size limitation from 100 -> 1000.
- Towards resolving #88 - Add an allocateMultiple function to the Network class which uses pReduce to keep an updated state of activeAllocations and provide collision resistance.