### PR TITLE
indexer-agent: Submit random POI if cannot create one to allow testing of rewards distribution on testnet

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -467,7 +467,7 @@ class Agent {
               (await this.indexer.proofOfIndexing(
                 deployment,
                 allocation.createdAtBlockHash,
-              )) || utils.hexlify(Array(32).fill(0))
+              )) || utils.hexlify(utils.randomBytes(32))
             await this.network.close(allocation, poi)
           },
           { concurrency: 1 },


### PR DESCRIPTION
Valid POIs are rare on the testnet at the moment since they require that a subgraph is on the same network as the testnet staking contract (most subgraphs are on Mainnet and the testnet network contracts are on Rinkeby.)

In effect: If a POI is not available for the block hash in which the allocation was created a random POI is used to close the allocation.