### PR TITLE
CLI and Agent properly use new indexer management classes

### DIFF
--- a/packages/indexer-cli/src/client.ts
+++ b/packages/indexer-cli/src/client.ts
@@ -1,10 +1,11 @@
-import { createClient, Client } from '@urql/core'
+import { createClient } from '@urql/core'
 import fetch from 'isomorphic-fetch'
+import {IndexerManagementClient} from "@graphprotocol/indexer-common";
 
 export const createIndexerManagementClient = async ({
   url,
 }: {
   url: string
-}): Promise<Client> => {
-  return createClient({ url, fetch })
+}): Promise<IndexerManagementClient> => {
+  return createClient({ url, fetch }) as IndexerManagementClient
 }

--- a/packages/indexer-cli/src/commands/indexer/cost/set/variables.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/set/variables.ts
@@ -71,7 +71,7 @@ module.exports = {
     let costModel = parseCostModel({
       deployment,
       model: null,
-      variables,
+      variables: parsedVariables,
     })
 
     try {

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -225,6 +225,9 @@ export default {
           allocationAmount: BigNumber.from('0'),
         },
       },
+      features: {
+        injectDai: true,
+      },
     })
 
     // Spin up a basic webserver


### PR DESCRIPTION
Update indexer-cli and indexer-agent to make use of the updated IndexerManagementClient and cost model classes in indexer-common.