### PR TITLE
Avoid Network Error from some Ethereum endpoints by specifying the network

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -242,11 +242,14 @@ export default {
     } catch (e) {
       throw new Error(`Invalid Ethereum URL '${argv.ethereum}': ${e}`)
     }
-    const ethereum = new providers.JsonRpcProvider({
-      url: providerUrl.toString(),
-      user: providerUrl.username,
-      password: providerUrl.password,
-    })
+    const ethereum = new providers.JsonRpcProvider(
+      {
+        url: providerUrl.toString(),
+        user: providerUrl.username,
+        password: providerUrl.password,
+      },
+      'rinkeby',
+    )
     logger.info(`Connected to Ethereum`)
 
     logger.info('Connect to network')

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -151,11 +151,14 @@ export default {
     } catch (e) {
       throw new Error(`Invalid Ethereum URL '${argv.ethereum}': ${e}`)
     }
-    const web3 = new providers.JsonRpcProvider({
-      url: ethereum.toString(),
-      user: ethereum.username,
-      password: ethereum.password,
-    })
+    const web3 = new providers.JsonRpcProvider(
+      {
+        url: ethereum.toString(),
+        user: ethereum.username,
+        password: ethereum.password,
+      },
+      'rinkeby',
+    )
     const network = await web3.getNetwork()
     logger.info('Successfully connected to Ethereum', { provider: web3.connection.url })
 


### PR DESCRIPTION
Resolves [Mission Control Indexer #186](https://github.com/graphprotocol/mission-control-indexer/issues/186)

Specify the network in the JsonRPCProvider connection, so it doesn'thave to detect the network automatically which can cause issues on geth nodes.
Check out the related [Ethers issue](https://github.com/ethers-io/ethers.js/issues/866) for more details. 