### PR TITLE
indexer-agent: Startup arg for optional 'restake-rewards' setting 

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -128,6 +128,12 @@ export default {
         required: false,
         group: 'Indexer Infrastructure',
       })
+      .option('restake-rewards', {
+        description: `Restake claimed indexer rewards, if set to 'false' rewards will be returned to the wallet`,
+        type: 'boolean',
+        default: true,
+        group: 'Indexer Infrastructure',
+      })
       .option('inject-dai', {
         description:
           'Inject the GRT per DAI conversion rate into cost model variables',
@@ -264,8 +270,11 @@ export default {
       argv.graphNodeQueryEndpoint,
       argv.indexerGeoCoordinates,
       networkSubgraph,
+      argv.restakeRewards,
     )
-    logger.info('Successfully connected to network')
+    logger.info('Successfully connected to network', {
+      restakeRewards: argv.restakeRewards,
+    })
 
     logger.info('Launch indexer management API server')
     const indexerManagementClient = await createIndexerManagementClient({


### PR DESCRIPTION
Use an optional startup argument to define behavior when claiming indexing rewards.  
True (default) --> Indexing rewards will be released to the indexer's stake.
False --> Indexing rewards will be released directly to the indexer wallet. 