### PR TITLE
indexer-service: Fix how queries are declined

### DIFF
--- a/packages/indexer-service/src/queries.ts
+++ b/packages/indexer-service/src/queries.ts
@@ -108,7 +108,13 @@ export class QueryProcessor implements QueryProcessorInterface {
 
     // Fail query outright if we have no signer for this attestation
     if (signer === undefined) {
-      throw new Error(`Unable to sign the query response attestation`)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const error = Error(`Unable to sign the query response attestation`) as any
+      error.envelopedResponse = JSON.stringify(
+        await this.receiptManager.declineQuery(stateChannelMessage),
+      )
+      error.status = 500
+      throw error
     }
 
     // FIXME: Checking the validity of the state channel message before executing
@@ -131,9 +137,10 @@ export class QueryProcessor implements QueryProcessorInterface {
         query.query,
       )
     } catch (error) {
-      error.envelopedResponse = await this.receiptManager.declineQuery(
-        stateChannelMessage,
+      error.envelopedResponse = JSON.stringify(
+        await this.receiptManager.declineQuery(stateChannelMessage),
       )
+      error.status = 500
       throw error
     }
 

--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -264,10 +264,11 @@ export const createApp = async ({
           } catch (err) {
             logger.error(`Failed to handle paid query`, { err })
             serverMetrics.failedQueries.inc({ deployment: subgraphDeploymentID.ipfsHash })
-            res
-              .status(err.status || 500)
-              .contentType('application/json')
-              .send({ error: `${err.message}` })
+            res = res.status(err.status || 500).contentType('application/json')
+            if (err.envelopedResponse) {
+              res = res.header('x-graph-payment', err.envelopedResponse)
+            }
+            res.send({ error: `${err.message}` })
           }
         } else {
           logger.info(`Received free query`, { deployment: subgraphDeploymentID.display })


### PR DESCRIPTION
We need to return a 200 status code so that the gateway can distinguish declined queries from other server errors.

We also need to include the enveloped response in the `X-Graph-Payment` header so that the gateway can read it and update the channel accordingly, without stalling the channel.

The corresponding gateway logic is here: https://github.com/graphprotocol/gateway/blob/master/packages/query-engine/src/query-engine.ts#L445-L523