### PR TITLE
deploy(indexer-service): remove old state channels environment variables

### DIFF
--- a/k8s/base/indexer-service/deployment.yaml
+++ b/k8s/base/indexer-service/deployment.yaml
@@ -63,24 +63,5 @@ spec:
                   key: password
             - name: INDEXER_SERVICE_POSTGRES_DATABASE
               value: indexer-service
-            - name: SERVER_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: host
-            - name: SERVER_PORT
-              value: "5432"
-            - name: SERVER_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: user
-            - name: SERVER_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: password
-            - name: SERVER_DB_NAME
-              value: indexer-service
             - name: INDEXER_SERVICE_WALLET_SKIP_EVM_VALIDATION
               value: "true"


### PR DESCRIPTION
These are now configured by reusing the other postgresql environment variables.
