### PR TITLE
deploy(indexer-service): rename environment variable to skip EVM validation

### DIFF
--- a/k8s/base/indexer-service/deployment.yaml
+++ b/k8s/base/indexer-service/deployment.yaml
@@ -82,5 +82,5 @@ spec:
                   key: password
             - name: SERVER_DB_NAME
               value: indexer-service
-            - name: SKIP_EVM_VALIDATION
+            - name: INDEXER_SERVICE_WALLET_SKIP_EVM_VALIDATION
               value: "true"


### PR DESCRIPTION
Since `argv.walletSkipEvmValidation` is now used in the `start.ts` script.
