### PR TITLE
Indexer Agent, Indexer Service: Ethereum provider connection stability

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -37,6 +37,13 @@ export default {
         required: true,
         group: 'Ethereum',
       })
+      .option('ethereum-network', {
+        description: 'Ethereum network ',
+        type: 'string',
+        required: false,
+        default: 'rinkeby',
+        group: 'Ethereum',
+      })
       .option('ethereum-polling-interval', {
         description: 'Polling interval for the Ethereum provider (ms)',
         type: 'number',
@@ -288,11 +295,21 @@ export default {
       }),
     }
 
-    const ethereum = new providers.StaticJsonRpcProvider({
-      url: providerUrl.toString(),
-      user: providerUrl.username,
-      password: providerUrl.password,
-    })
+    if (providerUrl.password && providerUrl.protocol == 'http:') {
+      logger.warn(
+        'Ethereum endpoint does not use HTTPS, your authentication credentials may not be secure',
+      )
+    }
+
+    const ethereum = new providers.StaticJsonRpcProvider(
+      {
+        url: providerUrl.toString(),
+        user: providerUrl.username,
+        password: providerUrl.password,
+        allowInsecureAuthentication: true,
+      },
+      argv.ethereumNetwork,
+    )
     ethereum.pollingInterval = argv.ethereumPollingInterval
 
     ethereum.on('debug', info => {
@@ -307,6 +324,13 @@ export default {
           response: info.response,
         })
       }
+    })
+
+    ethereum.on('network', (newNetwork, oldNetwork) => {
+      logger.trace('Ethereum network change', {
+        oldNetwork: oldNetwork,
+        newNetwork: newNetwork,
+      })
     })
 
     logger.info(`Connected to Ethereum`, {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -239,7 +239,18 @@ export class Network {
     logger = logger.child({ operator: wallet.address })
 
     logger.info(`Connecting to contracts`)
-    const contracts = await connectContracts(wallet, network.chainId)
+    let contracts = undefined
+    try {
+      contracts = await connectContracts(wallet, network.chainId)
+    } catch (error) {
+      logger.error(
+        `Failed to connect to contracts, please ensure you are using the intended Ethereum Network`,
+        {
+          error,
+        },
+      )
+      throw error
+    }
 
     logger.info(`Successfully connected to contracts`, {
       curation: contracts.curation.address,

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -37,6 +37,13 @@ export default {
         required: true,
         group: 'Ethereum',
       })
+      .option('ethereum-network', {
+        description: 'Ethereum network ',
+        type: 'string',
+        required: false,
+        default: 'rinkeby',
+        group: 'Ethereum',
+      })
       .option('ethereum-polling-interval', {
         description: 'Polling interval for the Ethereum provider (ms)',
         type: 'number',
@@ -225,11 +232,22 @@ export default {
         labelNames: ['method'],
       }),
     }
-    const web3 = new providers.StaticJsonRpcProvider({
-      url: ethereum.toString(),
-      user: ethereum.username,
-      password: ethereum.password,
-    })
+
+    if (ethereum.password && ethereum.protocol == 'http:') {
+      logger.warn(
+        'Ethereum endpoint does not use HTTPS, your authentication credentials may not be secure',
+      )
+    }
+
+    const web3 = new providers.StaticJsonRpcProvider(
+      {
+        url: ethereum.toString(),
+        user: ethereum.username,
+        password: ethereum.password,
+        allowInsecureAuthentication: true,
+      },
+      'any',
+    )
     web3.pollingInterval = argv.ethereumPollingInterval
 
     web3.on('debug', info => {
@@ -246,6 +264,13 @@ export default {
       }
     })
 
+    web3.on('network', (newNetwork, oldNetwork) => {
+      logger.trace('Ethereum network change', {
+        oldNetwork: oldNetwork,
+        newNetwork: newNetwork,
+      })
+    })
+
     const network = await web3.getNetwork()
     logger.info('Successfully connected to Ethereum', {
       provider: web3.connection.url,
@@ -257,8 +282,21 @@ export default {
       network: network.name,
       chainId: network.chainId,
     })
-    const contracts = await connectContracts(web3, network.chainId)
-    logger.info('Successfully to contracts')
+
+    let contracts = undefined
+    try {
+      contracts = await connectContracts(web3, network.chainId)
+    } catch (error) {
+      logger.error(
+        `Failed to connect to contracts, please ensure you are using the intended Ethereum Network`,
+        {
+          error,
+        },
+      )
+      throw error
+    }
+
+    logger.info('Successfully connected to contracts')
 
     // Create receipt manager
     const receiptManager = new ReceiptManager(


### PR DESCRIPTION
Update the Ethereum provider configuration to reduce issues detecting network and authenticating. Resolves [Mission Control Indexer #186](https://github.com/graphprotocol/mission-control-indexer/issues/186) and [Mission Control Indexer #103](https://github.com/graphprotocol/mission-control-indexer/issues/103)

Changes:
 - Default to using Ethereum providers hardcoded for the Rinkeby network
 - Allow insecure connection and emit security warning if http auth
 password is used in conjunction with the http protocol