### PR TITLE
indexer-agent: Fix race between registering and pause/operator detection (#167)

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix race condition between registering and pause/operator detection (#167)
 
 ## [0.9.0-alpha.3] - 2020-12-19
 ### Fixed


### PR DESCRIPTION
Before, there was a delay in detecting whether the network is paused or whether the operator is authorized for the indexer. This caused registration to be skipped on startup for a lot of indexers.

Now, the agent is properly detecting the network pause and operator status _first_ and then continues checking if it needs to register etc.