### PR TITLE
indexer-agent: Allocation only claimed if it has collected query fees

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -151,6 +151,12 @@ export default {
         default: true,
         group: 'Indexer Infrastructure',
       })
+      .option('allocation-claim-threshold', {
+        description: `Minimum query fees collected (GRT) on an allocation for it to be claimed`,
+        type: 'number',
+        default: 0,
+        group: 'Indexer Infrastructure',
+      })
       .option('inject-dai', {
         description:
           'Inject the GRT to DAI/USDC conversion rate into cost model variables',
@@ -380,6 +386,7 @@ export default {
       argv.indexerGeoCoordinates,
       networkSubgraph,
       argv.restakeRewards,
+      argv.allocationClaimThreshold,
     )
     logger.info('Successfully connected to network', {
       restakeRewards: argv.restakeRewards,


### PR DESCRIPTION
This PR introduces a minimum query fees collected threshold for claimable allocations. The configurable threshold, defaulting to 0, will serve to avoid sending unnecessary claim transactions for allocations that haven't collected any query fees.  