### PR TITLE
indexer-agent: Update to new `proofOfIndexing` API (#186)

### DIFF
--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -11,7 +11,7 @@ import {
   indexerError,
   IndexerErrorCode,
 } from '@graphprotocol/indexer-common'
-import { IndexingStatus } from './types'
+import { EthereumBlock, IndexingStatus } from './types'
 
 export class Indexer {
   statuses: Client
@@ -104,7 +104,7 @@ export class Indexer {
 
   async proofOfIndexing(
     deployment: SubgraphDeploymentID,
-    block: string,
+    block: EthereumBlock,
   ): Promise<string | undefined> {
     try {
       const result = await this.statuses
@@ -112,11 +112,13 @@ export class Indexer {
           gql`
             query proofOfIndexing(
               $subgraph: String!
+              $blockNumber: Int!
               $blockHash: String!
               $indexer: String!
             ) {
               proofOfIndexing(
                 subgraph: $subgraph
+                blockNumber: $blockNumber
                 blockHash: $blockHash
                 indexer: $indexer
               )
@@ -124,7 +126,8 @@ export class Indexer {
           `,
           {
             subgraph: deployment.ipfsHash,
-            blockHash: block,
+            blockNumber: block.number,
+            blockHash: block.hash,
             indexer: this.indexerAddress,
           },
         )


### PR DESCRIPTION
This adds passing the epoch start block number to the `proofOfIndexing` query, which is being added to graph-node in https://github.com/graphprotocol/graph-node/pull/2100.

This change is necessary so that we can reliably obtain a POI even if the graph-node block store doesn't have the Ethereum block in question. This fixes the main problem in #186. For another improvement (allowing indexers to deal with legitimate 0x0 POIs by closing allocations with manual intervention), we'll create a separate issue.