### PR TITLE
indexer-agent: Fix how query fee threshold is passed to claimable allocations

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -426,7 +426,7 @@ export class Network {
           {
             indexer: this.indexerAddress.toLocaleLowerCase(),
             disputableEpoch,
-            minimumQueryFeesCollected: this.queryFeesCollectedClaimThreshold,
+            minimumQueryFeesCollected: this.queryFeesCollectedClaimThreshold.toString(),
           },
         )
         .toPromise()


### PR DESCRIPTION
Because we currently pass the `BigNumber` object to the query for claimable allocations directly, it's serialized as an object and results in a GraphQL query error:

```bash
[2021-01-11 15:38:51.061 +0000] ERROR (IndexerAgent/1 on indexer-agent-56fd576fc6-zqtdq): Failed to query claimable indexer allocations
    component: "Network"
    indexer: "0xd3a3Fa4B73e5007a8adEf6CCdFC8D05C06A76035"
    operator: "0xd159dbA0d6909778C821B81eCF83B6790743A953"
    err: {
      "type": "IndexerError",
      "message": "Failed to query claimable indexer allocations",
      "stack":
          IndexerError: Failed to query claimable indexer allocations
              at Object.indexerError (/opt/indexer/packages/indexer-common/dist/errors.js:97:12)
              at Network.<anonymous> (/opt/indexer/packages/indexer-agent/dist/network.js:336:46)
              at Generator.next (<anonymous>)
              at fulfilled (/opt/indexer/packages/indexer-agent/dist/network.js:24:58)
              at processTicksAndRejections (internal/process/task_queues.js:97:5)
      "code": "IE011",
      "explanation": "https://github.com/graphprotocol/indexer/blob/master/docs/errors.md#ie011",
      "cause": {
        "type": "b",
        "message": "[GraphQL] Invalid value provided for argument `minimumQueryFeesCollected`: Object({\"hex\": String(\"0x00\"), \"type\": String(\"BigNumber\")})",
        "name": "CombinedError",
        "graphQLErrors": [
          {
            "message": "Invalid value provided for argument `minimumQueryFeesCollected`: Object({\"hex\": String(\"0x00\"), \"type\": String(\"BigNumber\")})",
            "extensions": {}
          }
        ],
        "response": {
          "size": 0,
          "timeout": 0
        }
      }
    }
```

What we should do instead is convert the `minimumQueryFeesCollected` argument to a decimal string, which is done with `BigNumber.toString`.