### PR TITLE
Validate cost models in `setCostModel` to avoid broken cost models

### DIFF
--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.2.0",
+    "@graphprotocol/cost-model": "0.1.5",
     "@types/cors": "2.8.8",
     "@types/express": "4.17.8",
     "@types/jest": "26.0.15",

--- a/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
@@ -89,7 +89,7 @@ describe('Cost models', () => {
   test('Set and get cost model (model and variables)', async () => {
     const input = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
       variables: JSON.stringify({ n: 100 }),
     }
 
@@ -116,7 +116,7 @@ describe('Cost models', () => {
   test('Set and get cost model (model only)', async () => {
     const input = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
     }
 
     const expected = {
@@ -180,22 +180,22 @@ describe('Cost models', () => {
       {
         input: {
           deployment,
-          model: '{ votes} => 10 * $n',
+          model: 'query { votes} => 10 * $n;',
         },
         expected: {
           deployment,
-          model: '{ votes} => 10 * $n',
+          model: 'query { votes} => 10 * $n;',
           variables: null,
         },
       },
       {
         input: {
           deployment,
-          model: '{ votes} => 20 * $n',
+          model: 'query { votes} => 20 * $n;',
         },
         expected: {
           deployment,
-          model: '{ votes} => 20 * $n',
+          model: 'query { votes} => 20 * $n;',
           variables: null,
         },
       },
@@ -206,7 +206,7 @@ describe('Cost models', () => {
         },
         expected: {
           deployment,
-          model: '{ votes} => 20 * $n',
+          model: 'query { votes} => 20 * $n;',
           variables: JSON.stringify({ n: 1 }),
         },
       },
@@ -217,7 +217,7 @@ describe('Cost models', () => {
         },
         expected: {
           deployment,
-          model: '{ votes} => 20 * $n',
+          model: 'query { votes} => 20 * $n;',
           variables: JSON.stringify({ n: 2 }),
         },
       },
@@ -266,12 +266,12 @@ describe('Cost models', () => {
     const inputs = [
       {
         deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        model: '{ votes } => 10 * $n',
+        model: 'query { votes } => 10 * $n;',
         variables: JSON.stringify({ n: 100 }),
       },
       {
         deployment: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        model: '{ proposals } => 30 * $n',
+        model: 'query { proposals } => 30 * $n;',
         variables: JSON.stringify({ n: 10 }),
       },
     ]
@@ -296,16 +296,16 @@ describe('Cost models', () => {
     }
   })
 
-  test('Get all cost model', async () => {
+  test('Get all cost models', async () => {
     const inputs = [
       {
         deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        model: '{ votes } => 10 * $n',
+        model: 'query { votes } => 10 * $n;',
         variables: JSON.stringify({ n: 100 }),
       },
       {
         deployment: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        model: '{ proposals } => 30 * $n',
+        model: 'query { proposals } => 30 * $n;',
         variables: JSON.stringify({ n: 10 }),
       },
     ]
@@ -332,7 +332,7 @@ describe('Cost models', () => {
   test('Clear model by passing in an empty model', async () => {
     let input = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n',
       variables: JSON.stringify({ n: 100 }),
     }
 
@@ -377,7 +377,7 @@ describe('Feature: Inject $DAI variable', () => {
 
     const initial = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
       variables: JSON.stringify({ DAI: '10.0' }),
     }
     await client.mutation(SET_COST_MODEL_MUTATION, { costModel: initial }).toPromise()
@@ -397,7 +397,7 @@ describe('Feature: Inject $DAI variable', () => {
   test('$DAI variable can be overwritten', async () => {
     const initial = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
       variables: JSON.stringify({ DAI: '10.0' }),
     }
     const client = await createIndexerManagementClient({
@@ -424,12 +424,12 @@ describe('Feature: Inject $DAI variable', () => {
     const inputs = [
       {
         deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        model: '{ votes } => 10 * $n',
+        model: 'query { votes } => 10 * $n;',
         variables: JSON.stringify({ n: 100, DAI: '10.0' }),
       },
       {
         deployment: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        model: '{ proposals } => 30 * $n',
+        model: 'query { proposals } => 30 * $n;',
         variables: JSON.stringify({ n: 10 }),
       },
     ]
@@ -472,12 +472,12 @@ describe('Feature: Inject $DAI variable', () => {
     const inputs = [
       {
         deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        model: '{ votes } => 10 * $n',
+        model: 'query { votes } => 10 * $n;',
         variables: JSON.stringify({ n: 100, DAI: '10.0' }),
       },
       {
         deployment: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        model: '{ proposals } => 30 * $n',
+        model: 'query { proposals } => 30 * $n;',
         variables: JSON.stringify({ n: 10 }),
       },
     ]
@@ -521,7 +521,7 @@ describe('Feature: Inject $DAI variable', () => {
   test('$DAI is preserved when cost model is updated', async () => {
     const initial = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
       variables: JSON.stringify({ n: 5, DAI: '10.0' }),
     }
     const client = await createIndexerManagementClient({
@@ -555,7 +555,7 @@ describe('Feature: Inject $DAI variable', () => {
   test('If feature is disabled, $DAI variable is not preserved', async () => {
     const initial = {
       deployment: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      model: '{ votes } => 10 * $n',
+      model: 'query { votes } => 10 * $n;',
       variables: JSON.stringify({ DAI: '10.0' }),
     }
     const client = await createIndexerManagementClient({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,13 @@
     "@ethersproject/contracts" "^5.0.3"
     ethers "^5.0.9"
 
+"@graphprotocol/cost-model@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/@graphprotocol/cost-model/-/cost-model-0.1.5.tgz#c8035238706eac60f8b966b4511cd23048c625a8"
+  integrity sha512-KzhQWc64IyN6e9L9RcDR+G3GhrAvOWi+9JADZfNIlcOJ/lqWLDyHTVNSCMxVeY33RFL6U3LnVaQPJ5EriqnqQg==
+  dependencies:
+    neon-cli "^0.4.0"
+
 "@graphprotocol/pino-sentry-simple@0.7.1":
   version "0.7.1"
   resolved "https://registry.npmjs.org/@graphprotocol/pino-sentry-simple/-/pino-sentry-simple-0.7.1.tgz#ac08b978bfa33178b9e809f53ae0983ff5f724d8"
@@ -3480,6 +3487,16 @@ array-back@^2.0.0:
   dependencies:
     typical "^2.6.1"
 
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz#9b80312935a52062e1a233a9c7abeb5481b30e90"
+  integrity sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==
+
 array-differ@^2.0.3:
   version "2.1.0"
   resolved "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
@@ -3987,7 +4004,7 @@ caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@4.1.0, chalk@^4.0.0:
+chalk@4.1.0, chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -4085,6 +4102,11 @@ cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -4207,6 +4229,33 @@ command-line-args@^4.0.7:
     array-back "^2.0.0"
     find-replace "^1.0.3"
     typical "^2.6.1"
+
+command-line-args@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
+  dependencies:
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-commands@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/command-line-commands/-/command-line-commands-3.0.2.tgz#53872a1181db837f21906b1228e260a4eeb42ee4"
+  integrity sha512-ac6PdCtdR6q7S3HN+JiVLIWGHY30PRYIEl2qPo+FuEuzwAUk0UYyimrngrg7FvF/mCr4Jgoqv5ZnHZgads50rw==
+  dependencies:
+    array-back "^4.0.1"
+
+command-line-usage@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  integrity sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==
+  dependencies:
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@^2.20.3:
   version "2.20.3"
@@ -4611,6 +4660,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-extend@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -5492,6 +5546,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 file-entry-cache@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
@@ -5536,6 +5597,13 @@ find-replace@^1.0.3:
   dependencies:
     array-back "^1.0.4"
     test-value "^2.1.0"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -5867,6 +5935,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+git-config@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/git-config/-/git-config-0.0.7.tgz#a9c8a3ef07a776c3d72261356d8b727b62202b28"
+  integrity sha1-qcij7wendsPXImE1bYtye2IgKyg=
+  dependencies:
+    iniparser "~1.0.5"
 
 git-raw-commits@2.0.0:
   version "2.0.0"
@@ -6441,6 +6516,11 @@ ini@^1.3.2, ini@^1.3.4:
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+iniparser@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
+  integrity sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=
+
 init-package-json@^1.10.3:
   version "1.10.3"
   resolved "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
@@ -6472,6 +6552,25 @@ inquirer@^6.2.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 interpret@^2.2.0:
@@ -7774,6 +7873,11 @@ make-iterator@^1.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+make-promises-safe@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/make-promises-safe/-/make-promises-safe-5.1.0.tgz#dd9d311f555bcaa144f12e225b3d37785f0aa8f2"
+  integrity sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -8185,6 +8289,26 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+neon-cli@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/neon-cli/-/neon-cli-0.4.2.tgz#e5dfda11a918922ca24cc87abb1f7b1e89adcdb0"
+  integrity sha512-C7yRKV9ZRg3YCc4pcDDGMRxtpJWGuhFYnpK/6xbOIMhwvxmvTdXcS1N7IlVqedJmveVblJDWOzXk48h7JSPgzQ==
+  dependencies:
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-commands "^3.0.1"
+    command-line-usage "^6.1.0"
+    git-config "0.0.7"
+    handlebars "^4.7.6"
+    inquirer "^7.3.3"
+    make-promises-safe "^5.1.0"
+    rimraf "^3.0.2"
+    semver "^7.3.2"
+    toml "^3.0.0"
+    ts-typed-json "^0.3.2"
+    validate-npm-package-license "^3.0.4"
+    validate-npm-package-name "^3.0.0"
 
 ngeohash@0.6.3:
   version "0.6.3"
@@ -9526,6 +9650,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
+
 regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
@@ -9725,7 +9854,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -9737,7 +9866,7 @@ rsvp@^4.8.4:
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.2.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -9761,7 +9890,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6.6.3, rxjs@^6.4.0:
+rxjs@6.6.3, rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.3"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
@@ -10437,6 +10566,16 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+table-layout@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz#8411181ee951278ad0638aea2f779a9ce42894f9"
+  integrity sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 table@6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/table/-/table-6.0.3.tgz#e5b8a834e37e27ad06de2e0fda42b55cfd8a0123"
@@ -10660,6 +10799,11 @@ toidentifier@1.0.0:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 toposort-class@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
@@ -10770,6 +10914,11 @@ ts-jest@26.4.3:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-typed-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/ts-typed-json/-/ts-typed-json-0.3.2.tgz#f4f20f45950bae0a383857f7b0a94187eca1b56a"
+  integrity sha512-Tdu3BWzaer7R5RvBIJcg9r8HrTZgpJmsX+1meXMJzYypbkj8NK2oJN0yvm4Dp/Iv6tzFa/L5jKRmEVTga6K3nA==
 
 tslib@2.0.1:
   version "2.0.1"
@@ -10886,6 +11035,16 @@ typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
   integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.0.0, typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4:
   version "3.12.4"
@@ -11049,7 +11208,7 @@ v8flags@^3.2.0:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
@@ -11220,6 +11379,14 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wordwrapjs@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz#9aa9394155993476e831ba8e59fb5795ebde6800"
+  integrity sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.0.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
This fixes https://github.com/graphprotocol/indexer/issues/182.

I tried baking this right into the sequelize model so that we could be certain a model is valid before it hits the db, but I always got errors that `CostModel` was not set on `undefined`, so something with the `addon` inside the cost model library wasn't right. Either way, this does what we want it to do.