### PR TITLE
indexer-agent: Allow to index subgraphs that are not on chain

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -65,6 +65,7 @@ class Agent {
   logger: Logger
   networkSubgraph: Client | SubgraphDeploymentID
   registerIndexer: boolean
+  offchainSubgraphs: SubgraphDeploymentID[]
 
   constructor(
     logger: Logger,
@@ -72,12 +73,14 @@ class Agent {
     network: Network,
     networkSubgraph: Client | SubgraphDeploymentID,
     registerIndexer: boolean,
+    offchainSubgraphs: SubgraphDeploymentID[],
   ) {
     this.logger = logger
     this.indexer = indexer
     this.network = network
     this.networkSubgraph = networkSubgraph
     this.registerIndexer = registerIndexer
+    this.offchainSubgraphs = offchainSubgraphs
   }
 
   async start(): Promise<void> {
@@ -355,6 +358,13 @@ class Agent {
     if (this.networkSubgraph instanceof SubgraphDeploymentID) {
       if (!deploymentInList(targetDeployments, this.networkSubgraph)) {
         targetDeployments.push(this.networkSubgraph)
+      }
+    }
+
+    // Ensure all offchain subgraphs are _always_ indexed
+    for (const offchainSubgraph of this.offchainSubgraphs) {
+      if (!deploymentInList(targetDeployments, offchainSubgraph)) {
+        targetDeployments.push(offchainSubgraph)
       }
     }
 
@@ -743,6 +753,7 @@ export const startAgent = async (config: AgentConfig): Promise<Agent> => {
     config.network,
     config.networkSubgraph,
     config.registerIndexer,
+    config.offchainSubgraphs,
   )
   await agent.start()
   return agent

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -215,6 +215,18 @@ export default {
         default: true,
         group: 'Protocol',
       })
+      .option('offchain-subgraphs', {
+        description:
+          'Subgraphs to index that are not on chain (comma-separated)',
+        type: 'string',
+        array: true,
+        default: [],
+        coerce: arg =>
+          arg.reduce(
+            (acc: string[], value: string) => [...acc, ...value.split(',')],
+            [],
+          ),
+      })
       .check(argv => {
         if (
           !argv['network-subgraph-endpoint'] &&
@@ -436,6 +448,9 @@ export default {
       indexerManagement: indexerManagementClient,
       defaultAllocationAmount: parseGRT(argv.defaultAllocationAmount),
       registerIndexer: argv.register,
+      offchainSubgraphs: argv.offchainSubgraphs.map(
+        (s: string) => new SubgraphDeploymentID(s),
+      ),
     })
   },
 }

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -15,6 +15,7 @@ export interface AgentConfig {
   networkSubgraph: Client | SubgraphDeploymentID
   indexNodeIDs: string[]
   registerIndexer: boolean
+  offchainSubgraphs: SubgraphDeploymentID[]
 }
 
 export interface SubgraphDeployment {


### PR DESCRIPTION
This feature allows indexers to index e.g. their own subgraphs or other subgraphs they deem interesting that are not published on chain (yet). They won't be able to claim rewards (neither indexing nor querying) for these but indexing and querying on its own may be worth it in some cases.

Usage:
```sh
graph-indexer-agent ... --offchain-subgraphs QmA...,QmB...,QmC...
```