### PR TITLE
Indexer-agent: Monitor submitted proofs of indexing for potential disputes

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -285,7 +285,7 @@ Failed to query indexing status API.
 
 TODO
 
-## IE018
+## IE019
 
 **Summary**
 

--- a/packages/indexer-agent/jest.config.js
+++ b/packages/indexer-agent/jest.config.js
@@ -1,0 +1,25 @@
+const bail = (s) => {
+  throw new Error(s)
+}
+
+module.exports = {
+  collectCoverage: true,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  globals: {
+    __DATABASE__: {
+      host: process.env.POSTGRES_TEST_HOST || bail('POSTGRES_TEST_HOST is not defined'),
+      port: parseInt(process.env.POSTGRES_TEST_PORT || '5432'),
+      username:
+        process.env.POSTGRES_TEST_USERNAME ||
+        bail('POSTGRES_TEST_USERNAME is not defined'),
+      password:
+        process.env.POSTGRES_TEST_PASSWORD ||
+        bail('POSTGRES_TEST_PASSWORD is not defined'),
+      database:
+        process.env.POSTGRES_TEST_DATABASE ||
+        bail('POSTGRES_TEST_DATABASE is not defined'),
+    },
+  },
+}

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write src/*.ts src/**/*.ts src/**/**/*.ts",
     "lint": "eslint . --ext .ts,.tsx",
     "prepare": "yarn format && yarn lint && tsc",
-    "start": "yarn prepare && node ./dist/index.js start"
+    "start": "yarn prepare && node ./dist/index.js start",
+    "test": "jest --runInBand --detectOpenHandles --passWithNoTests --verbose"
   },
   "bin": {
     "graph-indexer-agent": "bin/graph-indexer-agent"
@@ -45,6 +46,8 @@
     "@types/ngeohash": "0.6.2",
     "@types/node": "14.14.6",
     "@types/yargs": "15.0.9",
+    "jest": "26.6.1",
+    "ts-jest": "26.4.3",
     "typechain": "3.0.0"
   },
   "resolutions": {

--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -1,0 +1,219 @@
+import {
+  connectContracts,
+  connectDatabase,
+  createLogger,
+  Logger,
+  NetworkContracts,
+  parseGRT,
+  toAddress,
+} from '@graphprotocol/common-ts'
+import {
+  createIndexerManagementClient,
+  defineIndexerManagementModels,
+  IndexerManagementClient,
+  IndexerManagementModels,
+  POIDisputeAttributes,
+} from '@graphprotocol/indexer-common'
+import { BigNumber, Wallet } from 'ethers'
+import { Sequelize } from 'sequelize/types'
+import { Indexer } from '../indexer'
+
+const TEST_DISPUTE_1: POIDisputeAttributes = {
+  allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
+  allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
+  allocationAmount: '500000000000000000000000',
+  allocationProof:
+    '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+  closedEpoch: 203,
+  closedEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  closedEpochStartBlockNumber: 848484,
+  closedEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  previousEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  previousEpochStartBlockNumber: 848484,
+  previousEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  status: 'potential',
+}
+const TEST_DISPUTE_2: POIDisputeAttributes = {
+  allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+  allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
+  allocationAmount: '5000000',
+  allocationProof:
+    '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+  closedEpoch: 203,
+  closedEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  closedEpochStartBlockNumber: 848484,
+  closedEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  previousEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  previousEpochStartBlockNumber: 848484,
+  previousEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  status: 'potential',
+}
+
+const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
+  keyof POIDisputeAttributes,
+  (x: never) => string | BigNumber | number | undefined
+> = {
+  allocationID: x => x,
+  allocationIndexer: x => x,
+  allocationAmount: x => x,
+  allocationProof: x => x,
+  closedEpoch: x => +x,
+  closedEpochStartBlockHash: x => x,
+  closedEpochStartBlockNumber: x => +x,
+  closedEpochReferenceProof: x => x,
+  previousEpochStartBlockHash: x => x,
+  previousEpochStartBlockNumber: x => +x,
+  previousEpochReferenceProof: x => x,
+  status: x => x,
+}
+
+/**
+ * Parses a POI dispute returned from the indexer management GraphQL
+ * API into normalized form.
+ */
+const disputeFromGraphQL = (
+  dispute: Partial<POIDisputeAttributes>,
+): POIDisputeAttributes => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(dispute)) {
+    if (key === '__typename') {
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (POI_DISPUTES_CONVERTERS_FROM_GRAPHQL as any)[key](value)
+  }
+  return obj as POIDisputeAttributes
+}
+
+declare const __DATABASE__: never
+
+let sequelize: Sequelize
+let models: IndexerManagementModels
+let wallet: Wallet
+let address: string
+let contracts: NetworkContracts
+let logger: Logger
+let indexerManagementClient: IndexerManagementClient
+let indexer: Indexer
+
+const setup = async () => {
+  logger = createLogger({
+    name: 'IndexerAgent',
+    async: false,
+    level: 'trace',
+  })
+
+  sequelize = await connectDatabase(__DATABASE__)
+  models = defineIndexerManagementModels(sequelize)
+  address = '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55'
+  contracts = await connectContracts(wallet, 4)
+  await sequelize.sync({ force: true })
+
+  wallet = Wallet.createRandom()
+
+  indexerManagementClient = await createIndexerManagementClient({
+    models,
+    address: toAddress(address),
+    contracts: contracts,
+    logger,
+    defaults: {
+      globalIndexingRule: {
+        allocationAmount: parseGRT('1000'),
+        parallelAllocations: 2,
+      },
+    },
+    features: {
+      injectDai: false,
+    },
+  })
+
+  indexer = new Indexer(
+    'test',
+    'test',
+    indexerManagementClient,
+    logger,
+    ['test'],
+    parseGRT('1000'),
+    address,
+  )
+}
+
+const teardown = async () => {
+  await sequelize.drop({})
+}
+
+describe('Indexer tests', () => {
+  beforeEach(setup)
+  afterEach(teardown)
+
+  // test('Parse Dispute from GraphQL', async () => {})
+  test('Store POI Disputes rejects invalid indexer address', async () => {
+    const badDispute: POIDisputeAttributes = {
+      allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+      allocationIndexer: '0xCOFFEECOFFEECOFFEE',
+      allocationAmount: '500000000',
+      allocationProof:
+        '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+      closedEpoch: 203,
+      closedEpochStartBlockHash:
+        '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+      closedEpochStartBlockNumber: 848484,
+      closedEpochReferenceProof:
+        '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+      previousEpochStartBlockHash:
+        '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+      previousEpochStartBlockNumber: 848484,
+      previousEpochReferenceProof:
+        '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+      status: 'potential',
+    }
+
+    const disputes = [badDispute]
+
+    await expect(indexer.storePoiDisputes(disputes)).rejects.toThrow(
+      'Failed to store pending POI disputes',
+    )
+  })
+
+  test('Store POI Disputes is idempotent', async () => {
+    const disputes: POIDisputeAttributes[] = [TEST_DISPUTE_1, TEST_DISPUTE_2]
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const expectedResult = disputes.map((dispute: Record<string, any>) => {
+      return disputeFromGraphQL(dispute)
+    })
+    await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
+      expectedResult,
+    )
+    await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
+      expectedResult,
+    )
+    await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
+      expectedResult,
+    )
+  })
+
+  test('Fetch POI Disputes', async () => {
+    const disputes: POIDisputeAttributes[] = [TEST_DISPUTE_1, TEST_DISPUTE_2]
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const expectedResult = disputes.map((dispute: Record<string, any>) => {
+      return disputeFromGraphQL(dispute)
+    })
+    await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
+      expectedResult,
+    )
+    await expect(indexer.fetchPOIDisputes('pending')).resolves.toEqual(
+      expectedResult,
+    )
+  })
+})

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -259,9 +259,12 @@ class Agent {
     )
     this.logger.info(`Waiting for network data before reconciling every 120s`)
 
-    const disputableAllocations = activeDeployments.tryMap(
-      activeDeployments =>
-        this.network.disputableAllocations(activeDeployments, 0),
+    const disputableAllocations = join({
+      currentEpoch,
+      activeDeployments,
+    }).tryMap(
+      ({ currentEpoch, activeDeployments }) =>
+        this.network.disputableAllocations(currentEpoch, activeDeployments, 0),
       {
         onError: () =>
           this.logger.warn(
@@ -269,10 +272,6 @@ class Agent {
           ),
       },
     )
-
-    this.logger.warn('DISPUTABLES', {
-      allocations: disputableAllocations,
-    })
 
     join({
       ticker: timer(120_000),

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -437,7 +437,8 @@ class Agent {
             closedEpoch: allocation.closedAtEpoch,
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             closedEpochReferenceProof: rewardsPool!.referencePOI!,
-            closedEpochStartBlockHash: allocation.closedAtBlockHash,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            closedEpochStartBlockHash: allocation.closedAtEpochStartBlockHash!,
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             closedEpochStartBlockNumber: rewardsPool!
               .closedAtEpochStartBlockNumber!,

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -263,8 +263,10 @@ class Agent {
       activeDeployments =>
         this.network.disputableAllocations(activeDeployments, 0),
       {
-        onError: err =>
-          this.logger.warn(`Failed to fetch disputable allocations`, { err }),
+        onError: () =>
+          this.logger.warn(
+            `Failed to fetch disputable allocations, trying again later`,
+          ),
       },
     )
 

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -652,7 +652,10 @@ class Agent {
       logger.info(
         `Deployment is not (or no longer) worth indexing, close all active allocations that are at least one epoch old`,
         {
-          allocations: activeAllocations.map(allocation => allocation.id),
+          activeAllocations: activeAllocations.map(allocation => allocation.id),
+          eligibleForClose: activeAllocations
+            .filter(allocation => allocation.createdAtEpoch < epoch)
+            .map(allocation => allocation.id),
         },
       )
 
@@ -668,7 +671,7 @@ class Agent {
             const poi = await this.indexer.proofOfIndexing(
               deployment,
               epochStartBlock,
-              this.indexer.indexerAddress
+              this.indexer.indexerAddress,
             )
 
             // Don't proceed if the POI is 0x0 or null

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -431,13 +431,24 @@ class Agent {
           const dispute: POIDisputeAttributes = {
             allocationID: allocation.id,
             allocationIndexer: allocation.indexer,
-            allocationAmount: allocation.allocatedTokens,
+            allocationAmount: allocation.allocatedTokens.toString(),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             allocationProof: allocation.poi!,
-            allocationClosedBlockHash: allocation.closedAtBlockHash,
+            closedEpoch: allocation.closedAtEpoch,
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            indexerProof: rewardsPool!.referencePOI!,
-            status: 'pending',
+            closedEpochReferenceProof: rewardsPool!.referencePOI!,
+            closedEpochStartBlockHash: allocation.closedAtBlockHash,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            closedEpochStartBlockNumber: rewardsPool!
+              .closedAtEpochStartBlockNumber!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            previousEpochReferenceProof: rewardsPool!.referencePreviousPOI!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            previousEpochStartBlockHash: allocation.previousEpochStartBlockHash!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            previousEpochStartBlockNumber: rewardsPool!
+              .previousEpochStartBlockNumber!,
+            status: 'Potential',
           }
           flaggedAllocations.push(dispute)
         }

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -227,6 +227,19 @@ export default {
             [],
           ),
       })
+      .option('poi-disputable-epochs', {
+        description:
+          'The number of epochs in the past to look for potential POI disputes',
+        type: 'number',
+        default: 1,
+        group: 'Disputes',
+      })
+      .option('poi-dispute-monitoring', {
+        description: 'Monitor the network for potential POI disputes',
+        type: 'boolean',
+        default: true,
+        group: 'Disputes',
+      })
       .check(argv => {
         if (
           !argv['network-subgraph-endpoint'] &&
@@ -399,6 +412,8 @@ export default {
       networkSubgraph,
       argv.restakeRewards,
       argv.allocationClaimThreshold,
+      argv.poiDisputeMonitoring,
+      argv.poiDisputableEpochs,
     )
     logger.info('Successfully connected to network', {
       restakeRewards: argv.restakeRewards,

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -10,9 +10,42 @@ import {
   INDEXING_RULE_GLOBAL,
   indexerError,
   IndexerErrorCode,
+  POIDisputeAttributes,
 } from '@graphprotocol/indexer-common'
 import { EthereumBlock, IndexingStatus } from './types'
 import pRetry from 'p-retry'
+
+const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
+  keyof POIDisputeAttributes,
+  (x: never) => string | BigNumber | number | null
+> = {
+  allocationID: x => x,
+  allocationIndexer: x => x,
+  allocationAmount: (x: string) => BigNumber.from(x),
+  allocationProof: x => x,
+  allocationClosedBlockHash: x => x,
+  indexerProof: x => x,
+  status: x => x,
+}
+
+/**
+ * Parses a POI dispute returned from the indexer management GraphQL
+ * API into normalized form.
+ */
+const disputesFromGraphQL = (
+  cost: Partial<POIDisputeAttributes>,
+): POIDisputeAttributes => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(cost)) {
+    if (key === '__typename') {
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (POI_DISPUTES_CONVERTERS_FROM_GRAPHQL as any)[key](value)
+  }
+  return obj as POIDisputeAttributes
+}
 
 export class Indexer {
   statuses: Client
@@ -106,6 +139,7 @@ export class Indexer {
   async proofOfIndexing(
     deployment: SubgraphDeploymentID,
     block: EthereumBlock,
+    indexerAddress: string,
   ): Promise<string | null> {
     try {
       return await pRetry(
@@ -138,7 +172,7 @@ export class Indexer {
                 subgraph: deployment.ipfsHash,
                 blockNumber: block.number,
                 blockHash: block.hash,
-                indexer: this.indexerAddress,
+                indexer: indexerAddress,
               },
             )
             .toPromise()
@@ -268,6 +302,42 @@ export class Indexer {
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE017, error)
       this.logger.error('Failed to ensure default "global" indexing rule', {
+        err,
+      })
+      throw err
+    }
+  }
+
+  async storePoiDisputes(
+    disputes: POIDisputeAttributes[],
+  ): Promise<POIDisputeAttributes> {
+    try {
+      const result = await this.indexerManagement
+        .mutation(
+          gql`
+            mutation storeDisputes($disputes: POIDisputeInput!) {
+              storeDisputes(disputes: $disputes) {
+                allocationId
+                allocationIndexer
+                allocationAmount
+                allocationProof
+                allocationClosedBlockHash
+                indexerProof
+                status
+              }
+            }
+          `,
+          { disputes: disputes },
+        )
+        .toPromise()
+
+      if (result.error) {
+        throw result.error
+      }
+      return disputesFromGraphQL(result.data.storeDisputes)
+    } catch (error) {
+      const err = indexerError(IndexerErrorCode.IE039, error)
+      this.logger.error('Failed to store potential POI disputes', {
         err,
       })
       throw err

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -457,6 +457,7 @@ export class Network {
   }
 
   async disputableAllocations(
+    currentEpoch: BigNumber,
     deployments: SubgraphDeploymentID[],
     minimumAllocation: number,
   ): Promise<Allocation[]> {

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -18,12 +18,6 @@ export interface AgentConfig {
   offchainSubgraphs: SubgraphDeploymentID[]
 }
 
-export interface SubgraphDeployment {
-  id: SubgraphDeploymentID
-  stakedTokens: BigNumber
-  signalAmount: BigNumber
-}
-
 export interface EthereumBlock {
   number: number
   hash: string

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "format": "prettier --write src/**/*.ts src/**/**/*.ts",
     "lint": "eslint . --ext .ts,.tsx",
-    "prepare": "rm -rf dist && yarn format && yarn lint && tsc"
+    "prepare": "rm -rf dist && yarn format && yarn lint && tsc",
+    "disputes": "yarn prepare && ./dist/cli.js indexer disputes get"
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.3.0",

--- a/packages/indexer-cli/src/commands/indexer/disputes.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes.ts
@@ -1,0 +1,15 @@
+import { GluegunToolbox } from 'gluegun'
+
+module.exports = {
+  name: 'disputes',
+  alias: [],
+  description: 'Configure allocation POI monitoring',
+  hidden: false,
+  dashed: false,
+  run: async (toolbox: GluegunToolbox) => {
+    const { print } = toolbox
+    print.info(toolbox.command?.description)
+    print.printCommands(toolbox, ['disputes'])
+    process.exitCode = -1
+  },
+}

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -1,0 +1,60 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import {disputes, printDisputes} from '../../../disputes'
+
+const HELP = `
+${chalk.bold('graph indexer disputes get')} [options] all
+${chalk.bold('graph indexer disputes get')} [options] <status>
+
+${chalk.dim('Options:')}
+
+  -h, --help                    Show usage information
+      --merged                  Shows the deployment rules and global rules merged
+  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
+`
+
+module.exports = {
+  name: 'get',
+  alias: [],
+  description: 'Get one or more indexing rules',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const { h, help, o, output } = parameters.options
+
+
+    const outputFormat = o || output || 'table'
+
+    if (help || h) {
+      print.info(HELP)
+      return
+    }
+
+    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+      print.error(`Invalid output format "${outputFormat}"`)
+      process.exitCode = 1
+      return
+    }
+
+    const config = loadValidatedConfig()
+
+    // Create indexer API client
+    const client = await createIndexerManagementClient({ url: config.api })
+    try {
+      const storedDisputes = await disputes(client)
+
+      console.log('stored dispys', storedDisputes)
+      printDisputes(
+        print,
+        outputFormat,
+        storedDisputes,
+      )
+    } catch (error) {
+      print.error(error.toString())
+      process.exitCode = 1
+    }
+  },
+}

--- a/packages/indexer-cli/src/disputes.ts
+++ b/packages/indexer-cli/src/disputes.ts
@@ -1,0 +1,172 @@
+import {
+  IndexerManagementClient, POIDisputeAttributes, indexerError, IndexerErrorCode,
+} from '@graphprotocol/indexer-common'
+import gql from 'graphql-tag'
+import yaml from 'yaml'
+import { GluegunPrint } from 'gluegun'
+import { table, getBorderCharacters } from 'table'
+
+const DISPUTE_FORMATTERS: Record<
+  keyof POIDisputeAttributes,
+  (x: never) => string
+  > = {
+  allocationID: x => x,
+  allocationIndexer: x => x,
+  allocationAmount: x => x,
+  allocationProof: x => x,
+  closedEpoch: x => x,
+  closedEpochReferenceProof: x => x,
+  closedEpochStartBlockHash: x => x,
+  closedEpochStartBlockNumber: x => x,
+  previousEpochReferenceProof: x => x,
+  previousEpochStartBlockHash: x => x,
+  previousEpochStartBlockNumber: x => x,
+  status: x => x,
+}
+
+const DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
+  keyof POIDisputeAttributes,
+  (x: never) => string | number
+  > = {
+  allocationID: x => x,
+  allocationIndexer: x => x,
+  allocationAmount: x => +x,
+  allocationProof: x => x,
+  closedEpoch: x => +x,
+  closedEpochReferenceProof: x => x,
+  closedEpochStartBlockHash: x => x,
+  closedEpochStartBlockNumber: x => +x,
+  previousEpochReferenceProof: x => x,
+  previousEpochStartBlockHash: x => x,
+  previousEpochStartBlockNumber: x => +x,
+  status: x => x,
+}
+
+
+/**
+ * Formats a dispute for display in the console.
+ */
+export const formatDispute = (
+  rule: Partial<POIDisputeAttributes>,
+): Partial<POIDisputeAttributes> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(rule)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (DISPUTE_FORMATTERS as any)[key](value)
+  }
+  return obj as Partial<POIDisputeAttributes>
+}
+
+
+/**
+ * Parses a POI dispute returned from the indexer management GraphQL
+ * API into normalized form.
+ */
+const disputeFromGraphQL = (
+  dispute: Partial<POIDisputeAttributes>,
+): POIDisputeAttributes => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(dispute)) {
+    if (key === '__typename') {
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (DISPUTES_CONVERTERS_FROM_GRAPHQL as any)[key](value)
+  }
+  return obj as POIDisputeAttributes
+}
+
+
+export const displayDisputes = (
+  outputFormat: 'table' | 'json' | 'yaml',
+  disputes: Partial<POIDisputeAttributes>[],
+): string =>
+  outputFormat === 'json'
+    ? JSON.stringify(disputes, null, 2)
+    : outputFormat === 'yaml'
+    ? yaml.stringify(disputes).trim()
+    : disputes.length === 0
+      ? 'No data'
+      : table([Object.keys(disputes[0]), ...disputes.map(dispute => Object.values(dispute))], {
+        border: getBorderCharacters('norc'),
+      }).trim()
+
+
+export const displayDispute = (
+  outputFormat: 'table' | 'json' | 'yaml',
+  dispute: Partial<POIDisputeAttributes>,
+): string =>
+  outputFormat === 'json'
+    ? JSON.stringify(dispute, null, 2)
+    : outputFormat === 'yaml'
+    ? yaml.stringify(dispute).trim()
+    : table([Object.keys(dispute), Object.values(dispute)], {
+      border: getBorderCharacters('norc'),
+    }).trim()
+
+export const printDisputes = (
+  print: GluegunPrint,
+  outputFormat: 'table' | 'json' | 'yaml',
+  disputes: Partial<POIDisputeAttributes>[] | null,
+): void => {
+  if (Array.isArray(disputes)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formattedDisputes = disputes.map(dispute => formatDispute(dispute))
+    print.info(displayDisputes(outputFormat, formattedDisputes))
+  } else if (disputes) {
+    const dispute = formatDispute(disputes)
+    print.info(displayDispute(outputFormat, dispute))
+  } else {
+    print.error(`No disputes found`)
+  }
+}
+
+export const disputes = async (
+  client: IndexerManagementClient
+): Promise<Partial<POIDisputeAttributes>[]> => {
+    try {
+      console.log('tryinnnggg')
+        const result = await client
+        .query(
+          gql`
+            query disputes {
+              disputes {
+                allocationID
+                allocationIndexer
+                allocationAmount
+                allocationProof
+                closedEpoch
+                closedEpochStartBlockHash
+                closedEpochStartBlockNumber
+                closedEpochReferenceProof
+                previousEpochStartBlockHash
+                previousEpochStartBlockNumber
+                previousEpochReferenceProof
+                status
+              }
+            }
+          `,
+          {},
+        )
+        .toPromise()
+
+      console.log(result)
+      if (result.error) {
+        throw result.error
+      }
+
+      console.log('yeeet')
+
+      return result.data.disputes.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (dispute: Record<string, any>) => {
+          return disputeFromGraphQL(dispute)
+        },
+      )
+    } catch (error) {
+      const err = indexerError(IndexerErrorCode.IE040, error)
+      throw err
+    }
+}

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -13,10 +13,14 @@ export interface SubgraphDeployment {
 export interface Allocation {
   id: Address
   subgraphDeployment: SubgraphDeployment
+  indexer: string
+  allocatedTokens: BigNumber
   createdAtEpoch: number
   createdAtBlockHash: string
   closedAtEpoch: number
-  allocatedTokens: BigNumber
+  closedAtEpochStartBlockHash: string | undefined
+  closedAtBlockHash: string
+  poi: string | undefined
 }
 
 export enum AllocationStatus {
@@ -35,8 +39,56 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
     stakedTokens: BigNumber.from(allocation.subgraphDeployment.stakedTokens),
     signalAmount: BigNumber.from(allocation.subgraphDeployment.signalAmount),
   },
+  indexer: allocation.indexer.id,
   allocatedTokens: BigNumber.from(allocation.allocatedTokens),
   createdAtBlockHash: allocation.createdAtBlockHash,
   createdAtEpoch: allocation.createdAtEpoch,
+  closedAtEpochStartBlockHash: allocation.closedAtEpochStartBlockHash,
   closedAtEpoch: allocation.closedAtEpoch,
+  closedAtBlockHash: allocation.closedAtBlockHash,
+  poi: allocation.poi,
+})
+
+export interface RewardsPool {
+  subgraphDeployment: SubgraphDeploymentID
+  allocationIndexer: string
+  allocationCreatedAtBlockHash: string
+  closedAtEpoch: number
+  closedAtEpochStartBlockHash: string | undefined
+  referencePOI: string | undefined
+}
+
+export const allocationRewardsPool = (allocation: Allocation): RewardsPool => ({
+  subgraphDeployment: allocation.subgraphDeployment.id,
+  allocationIndexer: allocation.indexer,
+  allocationCreatedAtBlockHash: allocation.createdAtBlockHash,
+  closedAtEpoch: allocation.closedAtEpoch,
+  closedAtEpochStartBlockHash: allocation.closedAtEpochStartBlockHash,
+  referencePOI: undefined,
+})
+
+export interface Epoch {
+  id: number
+  startBlock: number
+  startBlockHash: string | undefined
+  endBlock: number
+  signalledTokens: number
+  stakeDeposited: number
+  queryFeeRebates: number
+  totalRewards: number
+  totalIndexerRewards: number
+  totalDelegatorRewards: number
+}
+
+export const parseGraphQLEpochs = (epoch: any): Epoch => ({
+  id: epoch.id,
+  startBlock: epoch.startBlock,
+  startBlockHash: undefined,
+  endBlock: epoch.endBlock,
+  signalledTokens: epoch.signalledTokens,
+  stakeDeposited: epoch.stakeDeposited,
+  queryFeeRebates: epoch.queryFeeRebates,
+  totalRewards: epoch.totalRewards,
+  totalIndexerRewards: epoch.totalIndexerRewards,
+  totalDelegatorRewards: epoch.totalDelegatorRewards,
 })

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -19,6 +19,7 @@ export interface Allocation {
   createdAtBlockHash: string
   closedAtEpoch: number
   closedAtEpochStartBlockHash: string | undefined
+  previousEpochStartBlockHash: string | undefined
   closedAtBlockHash: string
   poi: string | undefined
 }
@@ -43,8 +44,9 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
   allocatedTokens: BigNumber.from(allocation.allocatedTokens),
   createdAtBlockHash: allocation.createdAtBlockHash,
   createdAtEpoch: allocation.createdAtEpoch,
-  closedAtEpochStartBlockHash: allocation.closedAtEpochStartBlockHash,
   closedAtEpoch: allocation.closedAtEpoch,
+  closedAtEpochStartBlockHash: undefined,
+  previousEpochStartBlockHash: undefined,
   closedAtBlockHash: allocation.closedAtBlockHash,
   poi: allocation.poi,
 })
@@ -55,7 +57,11 @@ export interface RewardsPool {
   allocationCreatedAtBlockHash: string
   closedAtEpoch: number
   closedAtEpochStartBlockHash: string | undefined
+  closedAtEpochStartBlockNumber: number | undefined
+  previousEpochStartBlockHash: string | undefined
+  previousEpochStartBlockNumber: number | undefined
   referencePOI: string | undefined
+  referencePreviousPOI: string | undefined
 }
 
 export const allocationRewardsPool = (allocation: Allocation): RewardsPool => ({
@@ -64,7 +70,11 @@ export const allocationRewardsPool = (allocation: Allocation): RewardsPool => ({
   allocationCreatedAtBlockHash: allocation.createdAtBlockHash,
   closedAtEpoch: allocation.closedAtEpoch,
   closedAtEpochStartBlockHash: allocation.closedAtEpochStartBlockHash,
+  closedAtEpochStartBlockNumber: undefined,
+  previousEpochStartBlockHash: allocation.previousEpochStartBlockHash,
+  previousEpochStartBlockNumber: undefined,
   referencePOI: undefined,
+  referencePreviousPOI: undefined,
 })
 
 export interface Epoch {

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import { Address, SubgraphDeploymentID, toAddress } from '@graphprotocol/common-ts'
@@ -32,6 +31,7 @@ export enum AllocationStatus {
   Claimed,
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const parseGraphQLAllocation = (allocation: any): Allocation => ({
   // Ensure the allocation ID (an address) is checksummed
   id: toAddress(allocation.id),
@@ -90,6 +90,7 @@ export interface Epoch {
   totalDelegatorRewards: number
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const parseGraphQLEpochs = (epoch: any): Epoch => ({
   id: epoch.id,
   startBlock: epoch.startBlock,

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -13,7 +13,7 @@ export interface SubgraphDeployment {
 export interface Allocation {
   id: Address
   subgraphDeployment: SubgraphDeployment
-  indexer: string
+  indexer: Address
   allocatedTokens: BigNumber
   createdAtEpoch: number
   createdAtBlockHash: string
@@ -39,7 +39,7 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
     stakedTokens: BigNumber.from(allocation.subgraphDeployment.stakedTokens),
     signalAmount: BigNumber.from(allocation.subgraphDeployment.signalAmount),
   },
-  indexer: allocation.indexer.id,
+  indexer: toAddress(allocation.indexer.id),
   allocatedTokens: BigNumber.from(allocation.allocatedTokens),
   createdAtBlockHash: allocation.createdAtBlockHash,
   createdAtEpoch: allocation.createdAtEpoch,
@@ -51,7 +51,7 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
 
 export interface RewardsPool {
   subgraphDeployment: SubgraphDeploymentID
-  allocationIndexer: string
+  allocationIndexer: Address
   allocationCreatedAtBlockHash: string
   closedAtEpoch: number
   closedAtEpochStartBlockHash: string | undefined

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -47,6 +47,9 @@ export enum IndexerErrorCode {
   IE034 = 'IE034',
   IE035 = 'IE035',
   IE036 = 'IE036',
+  IE037 = 'IE037',
+  IE038 = 'IE038',
+  IE039 = 'IE039',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -86,6 +89,9 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE034: 'Not authorized as an operator for the indexer',
   IE035: 'Unhandled promise rejection',
   IE036: 'Unhandled exception',
+  IE037: 'Failed to query disputable allocations',
+  IE038: 'Failed to query epochs',
+  IE039: 'Failed to store pending POI disputes',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -50,6 +50,7 @@ export enum IndexerErrorCode {
   IE037 = 'IE037',
   IE038 = 'IE038',
   IE039 = 'IE039',
+  IE040 = 'IE040',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -92,6 +93,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE037: 'Failed to query disputable allocations',
   IE038: 'Failed to query epochs',
   IE039: 'Failed to store pending POI disputes',
+  IE040: 'Failed to fetch POI disputes',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -15,7 +15,11 @@ import {
   IndexerManagementDefaults,
   IndexerManagementFeatures,
 } from '../client'
-import { defineIndexerManagementModels, IndexerManagementModels } from '../models'
+import {
+  defineIndexerManagementModels,
+  IndexerManagementModels,
+  POIDisputeAttributes,
+} from '../models'
 
 // Make global Jest variable available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -28,8 +32,13 @@ const STORE_POI_DISPUTES_MUTATION = gql`
       allocationIndexer
       allocationAmount
       allocationProof
-      allocationClosedBlockHash
-      indexerProof
+      closedEpoch
+      closedEpochStartBlockHash
+      closedEpochStartBlockNumber
+      closedEpochReferenceProof
+      previousEpochStartBlockHash
+      previousEpochStartBlockNumber
+      previousEpochReferenceProof
       status
     }
   }
@@ -42,8 +51,13 @@ const GET_POI_DISPUTE_QUERY = gql`
       allocationIndexer
       allocationAmount
       allocationProof
-      allocationClosedBlockHash
-      indexerProof
+      closedEpoch
+      closedEpochStartBlockHash
+      closedEpochStartBlockNumber
+      closedEpochReferenceProof
+      previousEpochStartBlockHash
+      previousEpochStartBlockNumber
+      previousEpochReferenceProof
       status
     }
   }
@@ -56,8 +70,13 @@ const GET_POI_DISPUTES_QUERY = gql`
       allocationIndexer
       allocationAmount
       allocationProof
-      allocationClosedBlockHash
-      indexerProof
+      closedEpoch
+      closedEpochStartBlockHash
+      closedEpochStartBlockNumber
+      closedEpochReferenceProof
+      previousEpochStartBlockHash
+      previousEpochStartBlockNumber
+      previousEpochReferenceProof
       status
     }
   }
@@ -68,6 +87,81 @@ const DELETE_POI_DISPUTES_QUERY = gql`
     deleteDisputes(allocationIDs: $allocationIDs)
   }
 `
+
+const TEST_DISPUTE_1: POIDisputeAttributes = {
+  allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
+  allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
+  allocationAmount: '500000000000000000000000',
+  allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+  closedEpoch: 203,
+  closedEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  closedEpochStartBlockNumber: 848484,
+  closedEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  previousEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  previousEpochStartBlockNumber: 848484,
+  previousEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  status: 'potential',
+}
+const TEST_DISPUTE_2: POIDisputeAttributes = {
+  allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+  allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
+  allocationAmount: '500000000000000000000000',
+  allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+  closedEpoch: 203,
+  closedEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  closedEpochStartBlockNumber: 848484,
+  closedEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  previousEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  previousEpochStartBlockNumber: 848484,
+  previousEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  status: 'potential',
+}
+
+const TEST_DISPUTE_3: POIDisputeAttributes = {
+  allocationID: '0x0000000000000000000000000000000000000002',
+  allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
+  allocationAmount: '500000000000000000000000',
+  allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
+  closedEpoch: 203,
+  closedEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  closedEpochStartBlockNumber: 848484,
+  closedEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  previousEpochStartBlockHash:
+    '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
+  previousEpochStartBlockNumber: 848484,
+  previousEpochReferenceProof:
+    '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
+  status: 'potential',
+}
+
+const TEST_DISPUTES_ARRAY = [TEST_DISPUTE_1, TEST_DISPUTE_2]
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toObject(dispute: POIDisputeAttributes): Record<string, any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const expected: Record<string, any> = Object.assign({}, dispute)
+  expected.allocationAmount = expected.allocationAmount.toString()
+  return expected
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toObjectArray(disputes: POIDisputeAttributes[]): Record<string, any>[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const expected: Record<string, any>[] = []
+  disputes.forEach((dispute) => {
+    expected.push(toObject(dispute))
+  })
+  return expected
+}
 
 let sequelize: Sequelize
 let models: IndexerManagementModels
@@ -92,7 +186,7 @@ const setup = async () => {
   address = '0xtest'
   contracts = await connectContracts(ethers.getDefaultProvider('rinkeby'), 4)
   await sequelize.sync({ force: true })
-  logger = createLogger({ name: 'Indexer API Client', level: 'trace' })
+  logger = createLogger({ name: 'POI dispute tests', level: 'trace' })
 }
 
 const teardown = async () => {
@@ -103,19 +197,16 @@ describe('POI disputes', () => {
   beforeEach(setup)
   afterEach(teardown)
 
-  test('Store POI dispute', async () => {
-    const dispute = {
-      allocationID: '0x0000000000000000000000000000000000000000',
-      allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-      allocationAmount: '100',
-      allocationProof:
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-      allocationClosedBlockHash:
-        '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-      indexerProof: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      status: 'Closed',
-    }
-    const expected = { ...dispute }
+  test('Store POI disputes', async () => {
+    const disputes = TEST_DISPUTES_ARRAY
+    // let expected: Record<string, any>[] = [];
+    // disputes.forEach(dispute => {
+    //   expected.push(Object.assign({}, dispute))
+    // });
+    //
+    // expected = expected.map((dispute) => toGraphQL(dispute))
+    const expected = toObjectArray(disputes)
+    // const expected = disputes.map(dispute => toGraphQL(dispute))
 
     const client = await createIndexerManagementClient({
       models,
@@ -129,10 +220,10 @@ describe('POI disputes', () => {
     await expect(
       client
         .mutation(STORE_POI_DISPUTES_MUTATION, {
-          disputes: [dispute],
+          disputes: disputes,
         })
         .toPromise(),
-    ).resolves.toHaveProperty('data.storeDisputes', [expected])
+    ).resolves.toHaveProperty('data.storeDisputes', expected)
   })
 
   test('Get non-existent dispute', async () => {
@@ -155,32 +246,7 @@ describe('POI disputes', () => {
   })
 
   test('Get one dispute at a time', async () => {
-    const disputes = [
-      {
-        allocationID: '0x0000000000000000000000000000000000000001',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-      {
-        allocationID: '0x0000000000000000000000000000000000000002',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-    ]
+    const disputes = TEST_DISPUTES_ARRAY
 
     const client = await createIndexerManagementClient({
       models,
@@ -203,32 +269,7 @@ describe('POI disputes', () => {
   })
 
   test('Get all disputes', async () => {
-    const disputes = [
-      {
-        allocationID: '0x0000000000000000000000000000000000000000',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-      {
-        allocationID: '0x0000000000000000000000000000000000000001',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-    ]
+    const disputes = TEST_DISPUTES_ARRAY
 
     const client = await createIndexerManagementClient({
       models,
@@ -247,32 +288,7 @@ describe('POI disputes', () => {
   })
 
   test('Remove dispute from store', async () => {
-    const disputes = [
-      {
-        allocationID: '0x0000000000000000000000000000000000000000',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-      {
-        allocationID: '0x0000000000000000000000000000000000000001',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-    ]
+    const disputes = TEST_DISPUTES_ARRAY
 
     const client = await createIndexerManagementClient({
       models,
@@ -288,11 +304,11 @@ describe('POI disputes', () => {
     await expect(
       client
         .mutation(DELETE_POI_DISPUTES_QUERY, {
-          allocationIDs: ['0x0000000000000000000000000000000000000001'],
+          allocationIDs: ['0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C'],
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.deleteDisputes', 1)
-    disputes.splice(1, 1)
+    disputes.splice(0, 1)
 
     await expect(
       client.query(GET_POI_DISPUTES_QUERY).toPromise(),
@@ -300,44 +316,7 @@ describe('POI disputes', () => {
   })
 
   test('Remove multiple disputes from store', async () => {
-    const disputes = [
-      {
-        allocationID: '0x0000000000000000000000000000000000000000',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-      {
-        allocationID: '0x0000000000000000000000000000000000000001',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-      {
-        allocationID: '0x0000000000000000000000000000000000000002',
-        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
-        allocationAmount: '100',
-        allocationProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationClosedBlockHash:
-          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
-        indexerProof:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        status: 'Closed',
-      },
-    ]
+    const disputes = [TEST_DISPUTE_1, TEST_DISPUTE_2, TEST_DISPUTE_3]
 
     const client = await createIndexerManagementClient({
       models,
@@ -354,13 +333,13 @@ describe('POI disputes', () => {
       client
         .mutation(DELETE_POI_DISPUTES_QUERY, {
           allocationIDs: [
-            '0x0000000000000000000000000000000000000001',
-            '0x0000000000000000000000000000000000000002',
+            '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
+            '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
           ],
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.deleteDisputes', 2)
-    disputes.splice(1, 2)
+    disputes.splice(0, 2)
 
     await expect(
       client.query(GET_POI_DISPUTES_QUERY).toPromise(),

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -105,9 +105,8 @@ describe('POI disputes', () => {
 
   test('Store POI dispute', async () => {
     const dispute = {
-      allocationID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      allocationIndexer:
-        '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+      allocationID: '0x0000000000000000000000000000000000000000',
+      allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
       allocationAmount: '100',
       allocationProof:
         '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -149,8 +148,7 @@ describe('POI disputes', () => {
     await expect(
       client
         .query(GET_POI_DISPUTE_QUERY, {
-          allocationID:
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
+          allocationID: '0x0000000000000000000000000000000000000001',
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.dispute', null)
@@ -159,10 +157,8 @@ describe('POI disputes', () => {
   test('Get one dispute at a time', async () => {
     const disputes = [
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000001',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -173,10 +169,8 @@ describe('POI disputes', () => {
         status: 'Closed',
       },
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000002',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -211,10 +205,8 @@ describe('POI disputes', () => {
   test('Get all disputes', async () => {
     const disputes = [
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000000',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -225,10 +217,8 @@ describe('POI disputes', () => {
         status: 'Closed',
       },
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000001',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -259,10 +249,8 @@ describe('POI disputes', () => {
   test('Remove dispute from store', async () => {
     const disputes = [
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000000',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -273,10 +261,8 @@ describe('POI disputes', () => {
         status: 'Closed',
       },
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000001',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -302,9 +288,7 @@ describe('POI disputes', () => {
     await expect(
       client
         .mutation(DELETE_POI_DISPUTES_QUERY, {
-          allocationIDs: [
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
-          ],
+          allocationIDs: ['0x0000000000000000000000000000000000000001'],
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.deleteDisputes', 1)
@@ -318,10 +302,8 @@ describe('POI disputes', () => {
   test('Remove multiple disputes from store', async () => {
     const disputes = [
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000000',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -332,10 +314,8 @@ describe('POI disputes', () => {
         status: 'Closed',
       },
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000001',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -346,10 +326,8 @@ describe('POI disputes', () => {
         status: 'Closed',
       },
       {
-        allocationID:
-          '0x0000000000000000000000000000000000000000000000000000000000000002',
-        allocationIndexer:
-          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationID: '0x0000000000000000000000000000000000000002',
+        allocationIndexer: '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
         allocationAmount: '100',
         allocationProof:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -376,8 +354,8 @@ describe('POI disputes', () => {
       client
         .mutation(DELETE_POI_DISPUTES_QUERY, {
           allocationIDs: [
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
-            '0x0000000000000000000000000000000000000000000000000000000000000002',
+            '0x0000000000000000000000000000000000000001',
+            '0x0000000000000000000000000000000000000002',
           ],
         })
         .toPromise(),

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -1,0 +1,391 @@
+import { Sequelize } from 'sequelize/types'
+import gql from 'graphql-tag'
+import { ethers } from 'ethers'
+import {
+  connectDatabase,
+  connectContracts,
+  createLogger,
+  Logger,
+  NetworkContracts,
+  parseGRT,
+} from '@graphprotocol/common-ts'
+
+import {
+  createIndexerManagementClient,
+  IndexerManagementDefaults,
+  IndexerManagementFeatures,
+} from '../client'
+import { defineIndexerManagementModels, IndexerManagementModels } from '../models'
+
+// Make global Jest variable available
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const __DATABASE__: any
+
+const STORE_POI_DISPUTES_MUTATION = gql`
+  mutation storeDisputes($disputes: [POIDisputeInput!]!) {
+    storeDisputes(disputes: $disputes) {
+      allocationID
+      allocationIndexer
+      allocationAmount
+      allocationProof
+      allocationClosedBlockHash
+      indexerProof
+      status
+    }
+  }
+`
+
+const GET_POI_DISPUTE_QUERY = gql`
+  query dispute($allocationID: String!) {
+    dispute(allocationID: $allocationID) {
+      allocationID
+      allocationIndexer
+      allocationAmount
+      allocationProof
+      allocationClosedBlockHash
+      indexerProof
+      status
+    }
+  }
+`
+
+const GET_POI_DISPUTES_QUERY = gql`
+  query disputes {
+    disputes {
+      allocationID
+      allocationIndexer
+      allocationAmount
+      allocationProof
+      allocationClosedBlockHash
+      indexerProof
+      status
+    }
+  }
+`
+
+const DELETE_POI_DISPUTES_QUERY = gql`
+  mutation deleteDisputes($allocationIDs: [String!]!) {
+    deleteDisputes(allocationIDs: $allocationIDs)
+  }
+`
+
+let sequelize: Sequelize
+let models: IndexerManagementModels
+let address: string
+let contracts: NetworkContracts
+let logger: Logger
+
+const defaults = {
+  globalIndexingRule: {
+    allocationAmount: parseGRT('100'),
+  },
+} as IndexerManagementDefaults
+
+const features: IndexerManagementFeatures = {
+  injectDai: true,
+}
+
+const setup = async () => {
+  // Spin up db
+  sequelize = await connectDatabase(__DATABASE__)
+  models = defineIndexerManagementModels(sequelize)
+  address = '0xtest'
+  contracts = await connectContracts(ethers.getDefaultProvider('rinkeby'), 4)
+  await sequelize.sync({ force: true })
+  logger = createLogger({ name: 'Indexer API Client', level: 'trace' })
+}
+
+const teardown = async () => {
+  await sequelize.drop({})
+}
+
+describe('POI disputes', () => {
+  beforeEach(setup)
+  afterEach(teardown)
+
+  test('Store POI dispute', async () => {
+    const dispute = {
+      allocationID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      allocationIndexer:
+        '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+      allocationAmount: '100',
+      allocationProof:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      allocationClosedBlockHash:
+        '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+      indexerProof: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      status: 'Closed',
+    }
+    const expected = { ...dispute }
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await expect(
+      client
+        .mutation(STORE_POI_DISPUTES_MUTATION, {
+          disputes: [dispute],
+        })
+        .toPromise(),
+    ).resolves.toHaveProperty('data.storeDisputes', [expected])
+  })
+
+  test('Get non-existent dispute', async () => {
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await expect(
+      client
+        .query(GET_POI_DISPUTE_QUERY, {
+          allocationID:
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+        })
+        .toPromise(),
+    ).resolves.toHaveProperty('data.dispute', null)
+  })
+
+  test('Get one dispute at a time', async () => {
+    const disputes = [
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+    ]
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await client.mutation(STORE_POI_DISPUTES_MUTATION, { disputes: disputes }).toPromise()
+
+    for (const dispute of disputes) {
+      await expect(
+        client
+          .query(GET_POI_DISPUTE_QUERY, { allocationID: dispute.allocationID })
+          .toPromise(),
+      ).resolves.toHaveProperty('data.dispute', dispute)
+    }
+  })
+
+  test('Get all disputes', async () => {
+    const disputes = [
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+    ]
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await client.mutation(STORE_POI_DISPUTES_MUTATION, { disputes: disputes }).toPromise()
+
+    await expect(
+      client.query(GET_POI_DISPUTES_QUERY).toPromise(),
+    ).resolves.toHaveProperty('data.disputes', disputes)
+  })
+
+  test('Remove dispute from store', async () => {
+    const disputes = [
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+    ]
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await client.mutation(STORE_POI_DISPUTES_MUTATION, { disputes: disputes }).toPromise()
+
+    await expect(
+      client
+        .mutation(DELETE_POI_DISPUTES_QUERY, {
+          allocationIDs: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+          ],
+        })
+        .toPromise(),
+    ).resolves.toHaveProperty('data.deleteDisputes', 1)
+    disputes.splice(1, 1)
+
+    await expect(
+      client.query(GET_POI_DISPUTES_QUERY).toPromise(),
+    ).resolves.toHaveProperty('data.disputes', disputes)
+  })
+
+  test('Remove multiple disputes from store', async () => {
+    const disputes = [
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+      {
+        allocationID:
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        allocationIndexer:
+          '0xCOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFFEECOFF',
+        allocationAmount: '100',
+        allocationProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        allocationClosedBlockHash:
+          '0xd75c26ba1134debe856894debe64e0aad9f6eb61289af648f07113fd868c23a0',
+        indexerProof:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        status: 'Closed',
+      },
+    ]
+
+    const client = await createIndexerManagementClient({
+      models,
+      address,
+      contracts,
+      logger,
+      defaults,
+      features,
+    })
+
+    await client.mutation(STORE_POI_DISPUTES_MUTATION, { disputes: disputes }).toPromise()
+
+    await expect(
+      client
+        .mutation(DELETE_POI_DISPUTES_QUERY, {
+          allocationIDs: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x0000000000000000000000000000000000000000000000000000000000000002',
+          ],
+        })
+        .toPromise(),
+    ).resolves.toHaveProperty('data.deleteDisputes', 2)
+    disputes.splice(1, 2)
+
+    await expect(
+      client.query(GET_POI_DISPUTES_QUERY).toPromise(),
+    ).resolves.toHaveProperty('data.disputes', disputes)
+  })
+})

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -16,6 +16,7 @@ import { IndexerManagementModels, IndexingRuleCreationAttributes } from './model
 import indexingRuleResolvers from './resolvers/indexing-rules'
 import statusResolvers from './resolvers/indexer-status'
 import costModelResolvers from './resolvers/cost-models'
+import poiDisputeResolvers from './resolvers/poi-disputes'
 import { BigNumber } from 'ethers'
 import { Op, Sequelize } from 'sequelize'
 
@@ -40,6 +41,26 @@ const SCHEMA_SDL = gql`
     rules
     never
     always
+  }
+
+  type POIDispute {
+    allocationID: String!
+    allocationIndexer: String!
+    allocationAmount: BigInt!
+    allocationProof: String!
+    allocationClosedBlockHash: String!
+    indexerProof: String!
+    status: String!
+  }
+
+  input POIDisputeInput {
+    allocationID: String!
+    allocationIndexer: String!
+    allocationAmount: BigInt!
+    allocationProof: String!
+    allocationClosedBlockHash: String!
+    indexerProof: String!
+    status: String!
   }
 
   type IndexingRule {
@@ -118,6 +139,10 @@ const SCHEMA_SDL = gql`
 
     costModels(deployments: [String!]): [CostModel!]!
     costModel(deployment: String!): CostModel
+
+    dispute(allocationID: String!): POIDispute
+    disputes: [POIDispute]!
+    disputesClosedAfter(closedAfterBlock: BigInt!): [POIDispute]!
   }
 
   type Mutation {
@@ -126,6 +151,9 @@ const SCHEMA_SDL = gql`
     deleteIndexingRules(deployments: [String!]!): Boolean!
 
     setCostModel(costModel: CostModelInput!): CostModel!
+
+    storeDisputes(disputes: [POIDisputeInput!]!): [POIDispute!]
+    deleteDisputes(allocationIDs: [String!]!): Int!
   }
 `
 
@@ -198,6 +226,7 @@ export const createIndexerManagementClient = async (
     ...indexingRuleResolvers,
     ...statusResolvers,
     ...costModelResolvers,
+    ...poiDisputeResolvers,
   }
 
   const dai: WritableEventual<string> = mutable()

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -48,8 +48,13 @@ const SCHEMA_SDL = gql`
     allocationIndexer: String!
     allocationAmount: BigInt!
     allocationProof: String!
-    allocationClosedBlockHash: String!
-    indexerProof: String!
+    closedEpoch: Int!
+    closedEpochStartBlockHash: String!
+    closedEpochStartBlockNumber: Int!
+    closedEpochReferenceProof: String!
+    previousEpochStartBlockHash: String!
+    previousEpochStartBlockNumber: Int!
+    previousEpochReferenceProof: String!
     status: String!
   }
 
@@ -58,8 +63,13 @@ const SCHEMA_SDL = gql`
     allocationIndexer: String!
     allocationAmount: BigInt!
     allocationProof: String!
-    allocationClosedBlockHash: String!
-    indexerProof: String!
+    closedEpoch: Int!
+    closedEpochStartBlockHash: String!
+    closedEpochStartBlockNumber: Int!
+    closedEpochReferenceProof: String!
+    previousEpochStartBlockHash: String!
+    previousEpochStartBlockNumber: Int!
+    previousEpochReferenceProof: String!
     status: String!
   }
 

--- a/packages/indexer-common/src/indexer-management/models/index.ts
+++ b/packages/indexer-common/src/indexer-management/models/index.ts
@@ -2,13 +2,22 @@ import { Sequelize } from 'sequelize'
 
 import { IndexingRuleModels, defineIndexingRuleModels } from './indexing-rule'
 import { CostModelModels, defineCostModelModels } from './cost-model'
+import { POIDisputeModels, definePOIDisputeModels } from './poi-dispute'
 
 export * from './indexing-rule'
 export * from './cost-model'
+export * from './poi-dispute'
 
-export type IndexerManagementModels = IndexingRuleModels & CostModelModels
+export type IndexerManagementModels = IndexingRuleModels &
+  CostModelModels &
+  POIDisputeModels
 
 export const defineIndexerManagementModels = (
   sequelize: Sequelize,
 ): IndexerManagementModels =>
-  Object.assign({}, defineCostModelModels(sequelize), defineIndexingRuleModels(sequelize))
+  Object.assign(
+    {},
+    defineCostModelModels(sequelize),
+    defineIndexingRuleModels(sequelize),
+    definePOIDisputeModels(sequelize),
+  )

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -1,0 +1,172 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+import { Optional, Model, DataTypes, Sequelize } from 'sequelize'
+import { BigNumber, utils } from 'ethers'
+
+export interface POIDisputeAttributes {
+  allocationID: string
+  allocationIndexer: string
+  allocationAmount: BigNumber
+  allocationProof: string
+  allocationClosedBlockHash: string
+  indexerProof: string
+  status: string
+}
+
+export interface POIDisputeCreationAttributes
+  extends Optional<
+    POIDisputeAttributes,
+    | 'allocationID'
+    | 'allocationIndexer'
+    | 'allocationAmount'
+    | 'allocationProof'
+    | 'allocationClosedBlockHash'
+    | 'indexerProof'
+    | 'status'
+  > {}
+
+export class POIDispute
+  extends Model<POIDisputeAttributes, POIDisputeCreationAttributes>
+  implements POIDisputeAttributes {
+  public allocationID!: string
+  public allocationIndexer!: string
+  public allocationAmount!: BigNumber
+  public allocationProof!: string
+  public allocationClosedBlockHash!: string
+  public indexerProof!: string
+  public status!: string
+
+  public createdAt!: Date
+  public updatedAt!: Date
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  public toGraphQL(): object {
+    return { ...this.toJSON(), __typename: 'POIDispute' }
+  }
+}
+
+export interface POIDisputeModels {
+  POIDispute: typeof POIDispute
+}
+
+export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels => {
+  POIDispute.init(
+    {
+      allocationID: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        primaryKey: true,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation ID must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation ID must be a valid hex string`)
+          },
+        },
+      },
+      allocationIndexer: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation Indexer ID must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation Indexer ID must be a valid hex string`)
+          },
+        },
+      },
+      allocationAmount: {
+        type: DataTypes.DECIMAL,
+        allowNull: false,
+        validate: {
+          min: 0.0,
+        },
+      },
+      allocationProof: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation POI must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation POI must be a valid hex string`)
+          },
+        },
+      },
+      allocationClosedBlockHash: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation closed block hash must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation closed block hash must be a valid hex string`)
+          },
+        },
+      },
+      indexerProof: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Indexer reference POI must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Indexer reference POI must be a valid hex string`)
+          },
+        },
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+    },
+    {
+      modelName: 'POIDispute',
+      sequelize,
+    },
+  )
+
+  return {
+    ['POIDispute']: POIDispute,
+  }
+}

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -87,6 +87,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
               return
             }
 
+            //TODO: Ensure this error message gets logged when this throws (repeat for each validation function)
             throw new Error(`Allocation Indexer ID must be a valid hex string`)
           },
         },

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -64,7 +64,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
             }
 
             // "0x..." is ok
-            if (utils.isHexString(value, 32)) {
+            if (utils.isHexString(value, 20)) {
               return
             }
 
@@ -83,7 +83,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
             }
 
             // "0x..." is ok
-            if (utils.isHexString(value, 32)) {
+            if (utils.isHexString(value, 20)) {
               return
             }
 

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -1,15 +1,20 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { Optional, Model, DataTypes, Sequelize } from 'sequelize'
-import { BigNumber, utils } from 'ethers'
+import { utils } from 'ethers'
 
 export interface POIDisputeAttributes {
   allocationID: string
   allocationIndexer: string
-  allocationAmount: BigNumber
+  allocationAmount: string
   allocationProof: string
-  allocationClosedBlockHash: string
-  indexerProof: string
+  closedEpoch: number
+  closedEpochReferenceProof: string
+  closedEpochStartBlockHash: string
+  closedEpochStartBlockNumber: number
+  previousEpochReferenceProof: string
+  previousEpochStartBlockHash: string
+  previousEpochStartBlockNumber: number
   status: string
 }
 
@@ -20,8 +25,13 @@ export interface POIDisputeCreationAttributes
     | 'allocationIndexer'
     | 'allocationAmount'
     | 'allocationProof'
-    | 'allocationClosedBlockHash'
-    | 'indexerProof'
+    | 'closedEpoch'
+    | 'closedEpochReferenceProof'
+    | 'closedEpochStartBlockHash'
+    | 'closedEpochStartBlockNumber'
+    | 'previousEpochReferenceProof'
+    | 'previousEpochStartBlockHash'
+    | 'previousEpochStartBlockNumber'
     | 'status'
   > {}
 
@@ -30,10 +40,15 @@ export class POIDispute
   implements POIDisputeAttributes {
   public allocationID!: string
   public allocationIndexer!: string
-  public allocationAmount!: BigNumber
+  public allocationAmount!: string
   public allocationProof!: string
-  public allocationClosedBlockHash!: string
-  public indexerProof!: string
+  public closedEpoch!: number
+  public closedEpochReferenceProof!: string
+  public closedEpochStartBlockHash!: string
+  public closedEpochStartBlockNumber!: number
+  public previousEpochReferenceProof!: string
+  public previousEpochStartBlockHash!: string
+  public previousEpochStartBlockNumber!: number
   public status!: string
 
   public createdAt!: Date
@@ -118,7 +133,30 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
           },
         },
       },
-      allocationClosedBlockHash: {
+      closedEpoch: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      closedEpochReferenceProof: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation POI must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation POI must be a valid hex string`)
+          },
+        },
+      },
+      closedEpochStartBlockHash: {
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
@@ -137,14 +175,18 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
           },
         },
       },
-      indexerProof: {
+      closedEpochStartBlockNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      previousEpochReferenceProof: {
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           isHex: (value: any) => {
             if (typeof value !== 'string') {
-              throw new Error('Indexer reference POI must be a string')
+              throw new Error('Allocation POI must be a string')
             }
 
             // "0x..." is ok
@@ -152,9 +194,32 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
               return
             }
 
-            throw new Error(`Indexer reference POI must be a valid hex string`)
+            throw new Error(`Allocation POI must be a valid hex string`)
           },
         },
+      },
+      previousEpochStartBlockHash: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Allocation closed block hash must be a string')
+            }
+
+            // "0x..." is ok
+            if (utils.isHexString(value, 32)) {
+              return
+            }
+
+            throw new Error(`Allocation closed block hash must be a valid hex string`)
+          },
+        },
+      },
+      previousEpochStartBlockNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
       },
       status: {
         type: DataTypes.STRING,

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { POIDispute, POIDisputeCreationAttributes } from '../models'
+import { IndexerManagementResolverContext } from '../client'
+
+export default {
+  dispute: async (
+    { allocationID }: { allocationID: number },
+    { models }: IndexerManagementResolverContext,
+  ): Promise<object | null> => {
+    const dispute = await models.POIDispute.findOne({
+      where: { allocationID },
+    })
+    return dispute?.toGraphQL() || dispute
+  },
+
+  disputes: async (
+    _: {},
+    { models }: IndexerManagementResolverContext,
+  ): Promise<object | null> => {
+    const disputes = await models.POIDispute.findAll({
+      order: [['allocationAmount', 'DESC']],
+    })
+    return disputes.map((dispute) => dispute.toGraphQL())
+  },
+
+  storeDisputes: async (
+    { disputes }: { disputes: POIDisputeCreationAttributes[] },
+    { models }: IndexerManagementResolverContext,
+  ): Promise<object | null> => {
+    const createdDisputes = await models.POIDispute.bulkCreate(disputes, {
+      returning: true,
+      validate: false,
+    })
+    return createdDisputes.map((dispute: POIDispute) => dispute.toGraphQL())
+  },
+
+  deleteDisputes: async (
+    { allocationIDs }: { allocationIDs: string[] },
+    { models }: IndexerManagementResolverContext,
+  ): Promise<number> => {
+    const numDeleted = await models.POIDispute.destroy({
+      where: {
+        allocationID: allocationIDs,
+      },
+      force: true,
+    })
+    return numDeleted
+  },
+}

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -30,7 +30,8 @@ export default {
   ): Promise<object | null> => {
     const createdDisputes = await models.POIDispute.bulkCreate(disputes, {
       returning: true,
-      validate: false,
+      validate: true,
+      ignoreDuplicates: true,
     })
     return createdDisputes.map((dispute: POIDispute) => dispute.toGraphQL())
   },

--- a/packages/indexer-service/src/allocations.ts
+++ b/packages/indexer-service/src/allocations.ts
@@ -46,6 +46,9 @@ export const monitorActiveAllocations = ({
                   first: 1000
                 ) {
                   id
+                  indexer {
+                    id
+                  }
                   allocatedTokens
                   createdAtBlockHash
                   createdAtEpoch


### PR DESCRIPTION
This PR adds a step to the reconciliation loop of the indexer-agent to check on-chain proofs of indexing against their data to identify potential disputes.  

The agent looks for any closed allocations that are within the dispute period and checks the allocations POI against reference POIs generated from their graph node (if available); if the reference POIs do not match the allocation the allocation is flagged as a potential dispute and saved in the indexer database.  In addition, a `disputes get` command has been added to the indexer-cli for fetching the allocations that have been flagged as potential disputes. 