### PR TITLE
Indexer-agent, indexer-cli: Improve allocation POI monitoring efficiency, allow filtering of disputes from cli

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -35,7 +35,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'Potential',
+  status: 'potential',
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
@@ -54,7 +54,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'Potential',
+  status: 'potential',
 }
 
 const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
@@ -213,7 +213,7 @@ describe('Indexer tests', () => {
     await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
       expectedResult,
     )
-    await expect(indexer.fetchPOIDisputes('Potential', 205)).resolves.toEqual(
+    await expect(indexer.fetchPOIDisputes('potential', 205)).resolves.toEqual(
       expectedFilteredResult,
     )
   })

--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -35,7 +35,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'potential',
+  status: 'Potential',
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
@@ -43,7 +43,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationAmount: '5000000',
   allocationProof:
     '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
-  closedEpoch: 203,
+  closedEpoch: 210,
   closedEpochStartBlockHash:
     '0x675e9411241c431570d07b920321b2ff6aed2359aa8e26109905d34bffd8932a',
   closedEpochStartBlockNumber: 848484,
@@ -54,7 +54,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'potential',
+  status: 'Potential',
 }
 
 const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
@@ -209,11 +209,12 @@ describe('Indexer tests', () => {
     const expectedResult = disputes.map((dispute: Record<string, any>) => {
       return disputeFromGraphQL(dispute)
     })
+    const expectedFilteredResult = [disputeFromGraphQL(TEST_DISPUTE_2)]
     await expect(indexer.storePoiDisputes(disputes)).resolves.toEqual(
       expectedResult,
     )
-    await expect(indexer.fetchPOIDisputes('pending')).resolves.toEqual(
-      expectedResult,
+    await expect(indexer.fetchPOIDisputes('Potential', 205)).resolves.toEqual(
+      expectedFilteredResult,
     )
   })
 })

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -391,7 +391,7 @@ class Agent {
     disputableEpoch: number,
   ): Promise<void> {
     const storedDisputes = await this.indexer.fetchPOIDisputes(
-      'Potential',
+      'potential',
       disputableEpoch,
     )
     const newDisputableAllocations = disputableAllocations.filter(
@@ -477,7 +477,7 @@ class Agent {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             previousEpochStartBlockNumber: rewardsPool!
               .previousEpochStartBlockNumber!,
-            status: 'Potential',
+            status: 'potential',
           }
           flaggedAllocations.push(dispute)
         }

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -178,7 +178,7 @@ export class Indexer {
           if (result.error) {
             throw result.error
           }
-          this.logger.debug('Reference Proof of indexing generated', {
+          this.logger.debug('Reference POI generated', {
             indexer: this.indexerAddress,
             subgraph: deployment.ipfsHash,
             block: block,
@@ -386,8 +386,8 @@ export class Indexer {
             }
           `,
           {
-            status: status,
-            minClosedEpoch: minClosedEpoch,
+            status,
+            minClosedEpoch,
           },
         )
         .toPromise()

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -23,12 +23,6 @@ export interface AgentConfig {
   payments: PaymentsConfig
 }
 
-export interface SubgraphDeployment {
-  id: SubgraphDeploymentID
-  stakedTokens: BigNumber
-  signalAmount: BigNumber
-}
-
 export interface EthereumBlock {
   number: number
   hash: string

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -46,7 +46,6 @@ module.exports = {
     try {
       const storedDisputes = await disputes(client)
 
-      console.log('stored dispys', storedDisputes)
       printDisputes(
         print,
         outputFormat,

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -8,6 +8,8 @@ import {disputes, printDisputes} from '../../../disputes'
 const HELP = `
 ${chalk.bold('graph indexer disputes get')} [options] <status> <minimumAllocationClosedEpoch>
 
+  <status>  potential|pending|valid
+  
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -6,8 +6,7 @@ import { createIndexerManagementClient } from '../../../client'
 import {disputes, printDisputes} from '../../../disputes'
 
 const HELP = `
-${chalk.bold('graph indexer disputes get')} [options] all
-${chalk.bold('graph indexer disputes get')} [options] <status>
+${chalk.bold('graph indexer disputes get')} [options] <status> <minimumAllocationClosedEpoch>
 
 ${chalk.dim('Options:')}
 
@@ -24,8 +23,7 @@ module.exports = {
     const { print, parameters } = toolbox
 
     const { h, help, o, output } = parameters.options
-
-
+    const [status, minAllocationClosedEpoch] = parameters.array || []
     const outputFormat = o || output || 'table'
 
     if (help || h) {
@@ -44,7 +42,7 @@ module.exports = {
     // Create indexer API client
     const client = await createIndexerManagementClient({ url: config.api })
     try {
-      const storedDisputes = await disputes(client)
+      const storedDisputes = await disputes(client, status, +minAllocationClosedEpoch)
 
       printDisputes(
         print,

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -11,7 +11,6 @@ ${chalk.bold('graph indexer disputes get')} [options] <status> <minimumAllocatio
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-      --merged                  Shows the deployment rules and global rules merged
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/disputes.ts
+++ b/packages/indexer-cli/src/disputes.ts
@@ -124,15 +124,16 @@ export const printDisputes = (
 }
 
 export const disputes = async (
-  client: IndexerManagementClient
+  client: IndexerManagementClient,
+  status: string,
+  minClosedEpoch: number,
 ): Promise<Partial<POIDisputeAttributes>[]> => {
     try {
-      console.log('tryinnnggg')
-        const result = await client
+      const result = await client
         .query(
           gql`
-            query disputes {
-              disputes {
+            query disputes($status: String!, $minClosedEpoch: Int!) {
+              disputes(status: $status, minClosedEpoch: $minClosedEpoch) {
                 allocationID
                 allocationIndexer
                 allocationAmount
@@ -148,7 +149,10 @@ export const disputes = async (
               }
             }
           `,
-          {},
+          {
+            status,
+            minClosedEpoch
+          },
         )
         .toPromise()
 
@@ -156,8 +160,6 @@ export const disputes = async (
       if (result.error) {
         throw result.error
       }
-
-      console.log('yeeet')
 
       return result.data.disputes.map(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -104,7 +104,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'Potential',
+  status: 'potential',
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
@@ -122,7 +122,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'Potential',
+  status: 'potential',
 }
 
 const TEST_DISPUTE_3: POIDisputeAttributes = {
@@ -141,7 +141,7 @@ const TEST_DISPUTE_3: POIDisputeAttributes = {
   previousEpochStartBlockNumber: 848484,
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
-  status: 'Potential',
+  status: 'potential',
 }
 
 const TEST_DISPUTES_ARRAY = [TEST_DISPUTE_1, TEST_DISPUTE_2]
@@ -284,7 +284,7 @@ describe('POI disputes', () => {
 
     await expect(
       client
-        .query(GET_POI_DISPUTES_QUERY, { status: 'Potential', minClosedEpoch: 0 })
+        .query(GET_POI_DISPUTES_QUERY, { status: 'potential', minClosedEpoch: 0 })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', disputes)
   })
@@ -305,7 +305,7 @@ describe('POI disputes', () => {
 
     await expect(
       client
-        .query(GET_POI_DISPUTES_QUERY, { status: 'Potential', minClosedEpoch: 205 })
+        .query(GET_POI_DISPUTES_QUERY, { status: 'potential', minClosedEpoch: 205 })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', [TEST_DISPUTE_2])
   })
@@ -335,7 +335,7 @@ describe('POI disputes', () => {
 
     await expect(
       client
-        .query(GET_POI_DISPUTES_QUERY, { status: 'Potential', minClosedEpoch: 0 })
+        .query(GET_POI_DISPUTES_QUERY, { status: 'potential', minClosedEpoch: 0 })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', disputes)
   })
@@ -368,7 +368,7 @@ describe('POI disputes', () => {
 
     await expect(
       client
-        .query(GET_POI_DISPUTES_QUERY, { status: 'Potential', minClosedEpoch: 0 })
+        .query(GET_POI_DISPUTES_QUERY, { status: 'potential', minClosedEpoch: 0 })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', disputes)
   })

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -151,7 +151,7 @@ const SCHEMA_SDL = gql`
     costModel(deployment: String!): CostModel
 
     dispute(allocationID: String!): POIDispute
-    disputes: [POIDispute]!
+    disputes(status: String!, minClosedEpoch: Int!): [POIDispute]!
     disputesClosedAfter(closedAfterBlock: BigInt!): [POIDispute]!
   }
 

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -2,6 +2,7 @@
 
 import { POIDispute, POIDisputeCreationAttributes } from '../models'
 import { IndexerManagementResolverContext } from '../client'
+import { Op } from 'sequelize'
 
 export default {
   dispute: async (
@@ -15,10 +16,20 @@ export default {
   },
 
   disputes: async (
-    _: {},
+    { status, minClosedEpoch }: { status: string; minClosedEpoch: number },
     { models }: IndexerManagementResolverContext,
   ): Promise<object | null> => {
     const disputes = await models.POIDispute.findAll({
+      where: {
+        [Op.and]: [
+          { status: status },
+          {
+            closedEpoch: {
+              [Op.gte]: minClosedEpoch,
+            },
+          },
+        ],
+      },
       order: [['allocationAmount', 'DESC']],
     })
     return disputes.map((dispute) => dispute.toGraphQL())

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -22,7 +22,7 @@ export default {
     const disputes = await models.POIDispute.findAll({
       where: {
         [Op.and]: [
-          { status: status },
+          { status },
           {
             closedEpoch: {
               [Op.gte]: minClosedEpoch,


### PR DESCRIPTION
This PR updates the allocation POI monitoring algorithm to avoid checking allocation POIs that have already been identified as potential disputes and stored in the indexer db (`POIDisputes` table).  In addition the indexer-cli has been updated, so disputes can be filtered when fetching them, new structure `indexer disputes get <status> <minimumAllocationClosedEpoch>`. 