### PR TITLE
Make POI monitoring an experimental feature

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -266,7 +266,7 @@ export default {
       .option('poi-dispute-monitoring', {
         description: 'Monitor the network for potential POI disputes',
         type: 'boolean',
-        default: true,
+        default: false,
         group: 'Disputes',
       })
       .check(argv => {

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -8,9 +8,7 @@ import { disputes, printDisputes } from '../../../disputes'
 const HELP = `
 ${chalk.bold(
   'graph indexer disputes get',
-)} [options] <status> <minimumAllocationClosedEpoch>
-
-  <status>  potential|pending|valid
+)} [options] potential <minimumAllocationClosedEpoch>
   
 ${chalk.dim('Options:')}
 
@@ -40,8 +38,8 @@ module.exports = {
       return
     }
 
-    if (!status) {
-      print.error(`No dispute status (potential, pending or valid) provided`)
+    if (!status || status !== 'potential') {
+      print.error(`Must provide a dispute status filter, options: 'potential'`)
       process.exitCode = 1
       return
     }

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -104,7 +104,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE036: 'Unhandled exception',
   IE037: 'Failed to query disputable allocations',
   IE038: 'Failed to query epochs',
-  IE039: 'Failed to store pending POI disputes',
+  IE039: 'Failed to store potential POI disputes',
   IE040: 'Failed to fetch POI disputes',
   IE041: 'Failed to query transfers to resolve',
   IE042: 'Failed to add transfer to the database',


### PR DESCRIPTION
This PR updates POI Monitoring default config, so that it is now turned off by default.  There are also several minor updates for consistency of error messaging and simplicity of indexer-cli use. 