### PR TITLE
indexer-agent: Properly generate previous epoch reference POI for flagging potential disputes

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -589,7 +589,7 @@ class Agent {
       ...activeAllocations.map(allocation => allocation.subgraphDeployment.id),
     ])
 
-    // Ensure the network subgraph is never allocaated towards
+    // Ensure the network subgraph is never allocated towards
     if (this.networkSubgraph instanceof SubgraphDeploymentID) {
       const networkSubgraphDeployment = this.networkSubgraph
       targetDeployments = targetDeployments.filter(


### PR DESCRIPTION
The previous epoch was being calculated by a relative index and in some edge cases this could lead to incorrect value for previous epoch.