### PR TITLE
Avoid rechecking allocations for potential disputes

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -489,7 +489,7 @@ class Agent {
               ? 'potential'
               : 'valid',
         } as POIDisputeAttributes
-      }
+      },
     )
 
     const potentialDisputes = disputes.filter(

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -178,7 +178,7 @@ export class Indexer {
           if (result.error) {
             throw result.error
           }
-          this.logger.debug('Reference POI generated', {
+          this.logger.trace('Reference POI generated', {
             indexer: this.indexerAddress,
             subgraph: deployment.ipfsHash,
             block: block,

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -223,7 +223,8 @@ export class Network {
       if (
         error.message.includes(
           'Transaction with the same hash was already imported',
-        )
+        ) ||
+        error.message.includes('nonce has already been used')
       ) {
         txConfig.nonceOffset += 1
         txConfig.nonce =


### PR DESCRIPTION
Previously the POI validator only stored allocations that it identified for potential disputes.  This PR updates the loop to store all allocations that have been checked and on subsequent loops avoids checking allocations that have already been validated. 