### PR TITLE
Add subgraphDeploymentID to POIDisputes

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -20,6 +20,7 @@ import { Indexer } from '../indexer'
 
 const TEST_DISPUTE_1: POIDisputeAttributes = {
   allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
+  subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
   allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
   allocationAmount: '500000000000000000000000',
   allocationProof:
@@ -39,6 +40,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+  subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
   allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
   allocationAmount: '5000000',
   allocationProof:
@@ -62,6 +64,7 @@ const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
   (x: never) => string | BigNumber | number | undefined
 > = {
   allocationID: x => x,
+  subgraphDeploymentID: x => x,
   allocationIndexer: x => x,
   allocationAmount: x => x,
   allocationProof: x => x,
@@ -159,6 +162,7 @@ describe('Indexer tests', () => {
   test('Store POI Disputes rejects invalid indexer address', async () => {
     const badDispute: POIDisputeAttributes = {
       allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+      subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
       allocationIndexer: '0xCOFFEECOFFEECOFFEE',
       allocationAmount: '500000000',
       allocationProof:
@@ -180,7 +184,7 @@ describe('Indexer tests', () => {
     const disputes = [badDispute]
 
     await expect(indexer.storePoiDisputes(disputes)).rejects.toThrow(
-      'Failed to store pending POI disputes',
+      'Failed to store potential POI disputes',
     )
   })
 

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -463,6 +463,7 @@ class Agent {
 
         return {
           allocationID: allocation.id,
+          subgraphDeploymentID: allocation.subgraphDeployment.id.ipfsHash,
           allocationIndexer: allocation.indexer,
           allocationAmount: allocation.allocatedTokens.toString(),
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -20,6 +20,7 @@ const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
   (x: never) => string | BigNumber | number | null
 > = {
   allocationID: x => x,
+  subgraphDeploymentID: x => x,
   allocationIndexer: x => x,
   allocationAmount: x => x,
   allocationProof: x => x,
@@ -323,6 +324,7 @@ export class Indexer {
             mutation storeDisputes($disputes: [POIDisputeInput!]!) {
               storeDisputes(disputes: $disputes) {
                 allocationID
+                subgraphDeploymentID
                 allocationIndexer
                 allocationAmount
                 allocationProof
@@ -371,6 +373,7 @@ export class Indexer {
             query disputes($status: String!, $minClosedEpoch: Int!) {
               disputes(status: $status, minClosedEpoch: $minClosedEpoch) {
                 allocationID
+                subgraphDeploymentID
                 allocationIndexer
                 allocationAmount
                 allocationProof

--- a/packages/indexer-agent/src/migrations/03-poi-disputes-add-subgraph-deployment-id.ts
+++ b/packages/indexer-agent/src/migrations/03-poi-disputes-add-subgraph-deployment-id.ts
@@ -1,0 +1,46 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { QueryInterface, DataTypes } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.info(`Checking if POI disputes table exists`)
+  const tables = await queryInterface.showAllTables()
+  if (!tables.includes('POIDisputes')) {
+    logger.info(`POI disputes table does not exist, migration not necessary`)
+    return
+  }
+
+  logger.info(`Checking if POI disputes table needs to be migrated`)
+  const table = await queryInterface.describeTable('POIDisputes')
+  const subgraphDeploymentIDColumn = table.subgraphDeploymentID
+  if (subgraphDeploymentIDColumn) {
+    logger.info(
+      `Subgraph deployment ID column already exists, migration not necessary`,
+    )
+    return
+  }
+
+  logger.info(`Adding subgraphDeploymentID column to POIDisputes table`)
+  await queryInterface.addColumn('POIDisputes', 'subgraphDeploymentID', {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'notSet',
+  })
+}
+
+export async function down({ context }: Context): Promise<void> {
+  await context.queryInterface.removeColumn(
+    'POIDisputes',
+    'subgraphDeploymentID',
+  )
+}

--- a/packages/indexer-cli/src/disputes.ts
+++ b/packages/indexer-cli/src/disputes.ts
@@ -11,6 +11,7 @@ import { table, getBorderCharacters } from 'table'
 
 const DISPUTE_FORMATTERS: Record<keyof POIDisputeAttributes, (x: never) => string> = {
   allocationID: x => x,
+  subgraphDeploymentID: x => x,
   allocationIndexer: x => x,
   allocationAmount: x => x,
   allocationProof: x => x,
@@ -29,6 +30,7 @@ const DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
   (x: never) => string | number
 > = {
   allocationID: x => x,
+  subgraphDeploymentID: x => x,
   allocationIndexer: x => x,
   allocationAmount: x => +x,
   allocationProof: x => x,

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -29,6 +29,7 @@ const STORE_POI_DISPUTES_MUTATION = gql`
   mutation storeDisputes($disputes: [POIDisputeInput!]!) {
     storeDisputes(disputes: $disputes) {
       allocationID
+      subgraphDeploymentID
       allocationIndexer
       allocationAmount
       allocationProof
@@ -48,6 +49,7 @@ const GET_POI_DISPUTE_QUERY = gql`
   query dispute($allocationID: String!) {
     dispute(allocationID: $allocationID) {
       allocationID
+      subgraphDeploymentID
       allocationIndexer
       allocationAmount
       allocationProof
@@ -67,6 +69,7 @@ const GET_POI_DISPUTES_QUERY = gql`
   query disputes($status: String!, $minClosedEpoch: Int!) {
     disputes(status: $status, minClosedEpoch: $minClosedEpoch) {
       allocationID
+      subgraphDeploymentID
       allocationIndexer
       allocationAmount
       allocationProof
@@ -90,6 +93,7 @@ const DELETE_POI_DISPUTES_QUERY = gql`
 
 const TEST_DISPUTE_1: POIDisputeAttributes = {
   allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
+  subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
   allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
   allocationAmount: '500000000000000000000000',
   allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
@@ -108,6 +112,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
+  subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
   allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
   allocationAmount: '500000000000000000000000',
   allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
@@ -127,6 +132,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
 
 const TEST_DISPUTE_3: POIDisputeAttributes = {
   allocationID: '0x0000000000000000000000000000000000000002',
+  subgraphDeploymentID: 'QmRhYzT8HEZ9LziQhP6JfNfd4co9A7muUYQhPMJsMUojSF',
   allocationIndexer: '0x3C17A4c7cD8929B83e4705e04020fA2B1bca2E55',
   allocationAmount: '500000000000000000000000',
   allocationProof: '0xdb5b142ba36abbd98d41ebe627d96e7fffb8d79a3f2f25c70a9724e6cdc39ad4',
@@ -199,14 +205,7 @@ describe('POI disputes', () => {
 
   test('Store POI disputes', async () => {
     const disputes = TEST_DISPUTES_ARRAY
-    // let expected: Record<string, any>[] = [];
-    // disputes.forEach(dispute => {
-    //   expected.push(Object.assign({}, dispute))
-    // });
-    //
-    // expected = expected.map((dispute) => toGraphQL(dispute))
     const expected = toObjectArray(disputes)
-    // const expected = disputes.map(dispute => toGraphQL(dispute))
 
     const client = await createIndexerManagementClient({
       models,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -45,6 +45,7 @@ const SCHEMA_SDL = gql`
 
   type POIDispute {
     allocationID: String!
+    subgraphDeploymentID: String!
     allocationIndexer: String!
     allocationAmount: BigInt!
     allocationProof: String!
@@ -60,6 +61,7 @@ const SCHEMA_SDL = gql`
 
   input POIDisputeInput {
     allocationID: String!
+    subgraphDeploymentID: String!
     allocationIndexer: String!
     allocationAmount: BigInt!
     allocationProof: String!

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -5,6 +5,7 @@ import { utils } from 'ethers'
 
 export interface POIDisputeAttributes {
   allocationID: string
+  subgraphDeploymentID: string
   allocationIndexer: string
   allocationAmount: string
   allocationProof: string
@@ -22,6 +23,7 @@ export interface POIDisputeCreationAttributes
   extends Optional<
     POIDisputeAttributes,
     | 'allocationID'
+    | 'subgraphDeploymentID'
     | 'allocationIndexer'
     | 'allocationAmount'
     | 'allocationProof'
@@ -39,6 +41,7 @@ export class POIDispute
   extends Model<POIDisputeAttributes, POIDisputeCreationAttributes>
   implements POIDisputeAttributes {
   public allocationID!: string
+  public subgraphDeploymentID!: string
   public allocationIndexer!: string
   public allocationAmount!: string
   public allocationProof!: string
@@ -87,12 +90,26 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
           },
         },
       },
-      allocationIndexer: {
+      subgraphDeploymentID: {
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           isHex: (value: any) => {
+            if (typeof value !== 'string') {
+              throw new Error('Subgraph deployment ID must be a string')
+            }
+
+            return
+          },
+        },
+      },
+      allocationIndexer: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          isValid: (value: any) => {
             if (typeof value !== 'string') {
               throw new Error('Allocation Indexer ID must be a string')
             }


### PR DESCRIPTION
Adds a `subgraphDeployementID` field to the `POIDisputes` model.  

Included changes: 
  - create new database migration to add column to `POIDisputes` table (indexer-common),
  - update tests in indexer-common and indexer-agent,
  - update `POIDisputes` client, models and resolvers (indexer-common), 
  - update `disputes get` command (indexer-cli).