### PR TITLE
Indexer-agent: Don't remove subgraph deployments with active allocations

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -269,7 +269,11 @@ class Agent {
         }
 
         try {
-          await this.reconcileDeployments(activeDeployments, targetDeployments)
+          await this.reconcileDeployments(
+            activeDeployments,
+            targetDeployments,
+            activeAllocations,
+          )
 
           // Reconcile allocations
           await this.reconcileAllocations(
@@ -437,9 +441,13 @@ class Agent {
   async reconcileDeployments(
     activeDeployments: SubgraphDeploymentID[],
     targetDeployments: SubgraphDeploymentID[],
+    activeAllocations: Allocation[],
   ): Promise<void> {
     activeDeployments = uniqueDeployments(activeDeployments)
     targetDeployments = uniqueDeployments(targetDeployments)
+    const activeAllocationDeployments = uniqueDeployments(
+      activeAllocations.map(allocation => allocation.subgraphDeployment.id),
+    )
 
     // Ensure the network subgraph deployment is _always_ indexed
     if (this.networkSubgraph.deployment) {
@@ -467,7 +475,9 @@ class Agent {
       deployment => !deploymentInList(activeDeployments, deployment),
     )
     const remove = activeDeployments.filter(
-      deployment => !deploymentInList(targetDeployments, deployment),
+      deployment =>
+        !deploymentInList(targetDeployments, deployment) &&
+        !deploymentInList(activeAllocationDeployments, deployment),
     )
 
     this.logger.info('Deployment changes', {

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -1,7 +1,5 @@
 import gql from 'graphql-tag'
 import jayson, { Client as RpcClient } from 'jayson/promise'
-import fetch from 'isomorphic-fetch'
-import { Client, createClient } from '@urql/core'
 import { BigNumber } from 'ethers'
 import { Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
 import {


### PR DESCRIPTION
I've updated this PR to no longer make assumptions about whether to index and allocate towards failed subgraphs. This has significantly reduced the scope of the changes to just one small commit.

Changes: 
- Continue to sync any deployments that are allocated to on the network. Prior to this change subgraph deployments would be removed from the infra immediately upon a rule change leading to a desired deployment removal even though continued syncing may be needed in order to close the allocation. 

----

For posterity: the old notes from the PR that included assumptions around not wanting to allocate to failing subgraphs. Currently only case 1 is handled. 

## Background
The agent eagerly deploys subgraphs and creates allocations based on its indexing rules; however, there are some cases where the agent should be more patient in acting on rules.  Also the indexer should only be allocated towards subgraph deployments which are healthily syncing.  

### Case 1
If an allocation is still active on-chain the agent should not stop syncing the corresponding subgraph deployment because it will need it in order to successfully close the allocation. 

### Case 2 
When a deployment matches an indexing rule the agent begins syncing it and immediately allocates towards it; however, if the subgraph deployment is not healthy the agent should avoid allocating towards it. 

### Case 3 
When an active subgraph deployment that is allocated towards experiences a fatal error, the indexer-agent should close the corresponding allocation immediately. 

## Changes
- Do not allocate on subgraphs that aren't yet healthily syncing on an index-node. 
- Close allocations for failed subgraphs.
- Do not remove subgraph deployments that still have corresponding active allocations.  