### PR TITLE
*: Ensure allocation summaries for pre-existing allocations

### DIFF
--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
     - main
-    - jannis/release-prep
-    - jannis/allocation-receipts
+    - jannis/*
     tags: 
     - v*.*.*
 

--- a/.github/workflows/indexer-service-image.yml
+++ b/.github/workflows/indexer-service-image.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
     - main
-    - jannis/release-prep
-    - jannis/allocation-receipts
+    - jannis/*
     tags: 
     - v*.*.*
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.15.1-alpha.0"
+  "version": "0.15.1-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.15.0"
+  "version": "0.15.1-alpha.0"
 }

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-agent",
-  "version": "0.15.0",
+  "version": "0.15.1-alpha.0",
   "description": "Indexer agent",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
     "@thi.ng/heaps": "^1.2.36",
     "@thi.ng/iterators": "5.1.40",
     "@uniswap/sdk": "3.0.3",

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-agent",
-  "version": "0.15.1-alpha.0",
+  "version": "0.15.1-alpha.1",
   "description": "Indexer agent",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.1",
     "@thi.ng/heaps": "^1.2.36",
     "@thi.ng/iterators": "5.1.40",
     "@uniswap/sdk": "3.0.3",

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -75,7 +75,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
       await this.models.allocationSummaries.sequelize!.transaction(
         async transaction => {
           for (const allocation of allocations) {
-            const summary = await ensureAllocationSummary(
+            const [summary] = await ensureAllocationSummary(
               this.models,
               allocation.id,
               transaction,
@@ -255,7 +255,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         )
 
         // Update the query fees tracked against the allocation
-        const summary = await ensureAllocationSummary(
+        const [summary] = await ensureAllocationSummary(
           this.models,
           toAddress(voucher.allocation),
           transaction,
@@ -333,7 +333,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await this.models.allocationSummaries.sequelize!.transaction(
         async transaction => {
-          const summary = await ensureAllocationSummary(
+          const [summary] = await ensureAllocationSummary(
             this.models,
             toAddress(voucher.allocation),
             transaction,

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-cli",
-  "version": "0.15.0",
+  "version": "0.15.1-alpha.0",
   "description": "Indexer CLI for The Graph Network",
   "main": "dist/index.js",
   "repository": "https://github.com/graphprotocol/cli",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.40",
     "@urql/core": "1.13.1",

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-cli",
-  "version": "0.15.1-alpha.0",
+  "version": "0.15.1-alpha.1",
   "description": "Indexer CLI for The Graph Network",
   "main": "dist/index.js",
   "repository": "https://github.com/graphprotocol/cli",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.1",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.40",
     "@urql/core": "1.13.1",

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-common",
-  "version": "0.15.0",
+  "version": "0.15.1-alpha.0",
   "description": "Common library for Graph Protocol indexer components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-common",
-  "version": "0.15.1-alpha.0",
+  "version": "0.15.1-alpha.1",
   "description": "Common library for Graph Protocol indexer components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/indexer-common/src/query-fees/allocation-utils.ts
+++ b/packages/indexer-common/src/query-fees/allocation-utils.ts
@@ -6,8 +6,8 @@ export const ensureAllocationSummary = async (
   models: QueryFeeModels,
   allocation: Address,
   transaction: Transaction,
-): Promise<AllocationSummary> => {
-  const [summary] = await models.allocationSummaries.findOrBuild({
+): Promise<[AllocationSummary, boolean]> => {
+  const [summary, isNew] = await models.allocationSummaries.findOrBuild({
     where: { allocation },
     defaults: {
       allocation,
@@ -21,5 +21,5 @@ export const ensureAllocationSummary = async (
     },
     transaction,
   })
-  return summary
+  return [summary, isNew]
 }

--- a/packages/indexer-common/src/query-fees/allocation-utils.ts
+++ b/packages/indexer-common/src/query-fees/allocation-utils.ts
@@ -1,0 +1,25 @@
+import { Address } from '@graphprotocol/common-ts'
+import { Transaction } from 'sequelize'
+import { AllocationSummary, QueryFeeModels } from './models'
+
+export const ensureAllocationSummary = async (
+  models: QueryFeeModels,
+  allocation: Address,
+  transaction: Transaction,
+): Promise<AllocationSummary> => {
+  const [summary] = await models.allocationSummaries.findOrBuild({
+    where: { allocation },
+    defaults: {
+      allocation,
+      closedAt: null,
+      createdTransfers: 0,
+      resolvedTransfers: 0,
+      failedTransfers: 0,
+      openTransfers: 0,
+      collectedFees: '0',
+      withdrawnFees: '0',
+    },
+    transaction,
+  })
+  return summary
+}

--- a/packages/indexer-common/src/query-fees/index.ts
+++ b/packages/indexer-common/src/query-fees/index.ts
@@ -1,2 +1,3 @@
 export * from './vector-client'
 export * from './models'
+export * from './allocation-utils'

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-service",
-  "version": "0.15.0",
+  "version": "0.15.1-alpha.0",
   "description": "Indexer service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,7 @@
     "@connext/vector-utils": "0.2.1",
     "@google-cloud/profiler": "4.1.1",
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
     "@graphprotocol/indexer-native": "^0.15.0",
     "@thi.ng/cache": "1.0.59",
     "@urql/core": "1.13.1",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-service",
-  "version": "0.15.1-alpha.0",
+  "version": "0.15.1-alpha.1",
   "description": "Indexer service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,7 @@
     "@connext/vector-utils": "0.2.1",
     "@google-cloud/profiler": "4.1.1",
     "@graphprotocol/common-ts": "1.5.1",
-    "@graphprotocol/indexer-common": "^0.15.1-alpha.0",
+    "@graphprotocol/indexer-common": "^0.15.1-alpha.1",
     "@graphprotocol/indexer-native": "^0.15.0",
     "@thi.ng/cache": "1.0.59",
     "@urql/core": "1.13.1",

--- a/packages/indexer-service/src/query-fees/allocations.ts
+++ b/packages/indexer-service/src/query-fees/allocations.ts
@@ -123,11 +123,14 @@ export class AllocationReceiptManager implements ReceiptManager {
         await this._sequelize.transaction(
           { isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ },
           async (transaction: Transaction) => {
-            await ensureAllocationSummary(
+            const [summary, isNewSummary] = await ensureAllocationSummary(
               this._queryFeeModels,
               receipt.allocation,
               transaction,
             )
+            if (isNewSummary) {
+              await summary.save()
+            }
 
             const [
               state,


### PR DESCRIPTION
To track allocations and associated receipts, the agent creates allocation summaries in the db for every allocation it opens. It then links incoming receipts to these based on the allocation ID. The problem is, these allocation summaries are only created when allocations are created. Most, if not all indexers, however, already have allocations from before 0.15.0 and there's no summaries for these.

This commit ensures allocation summaries are created when flushing receipts, to make sure receipts that were created before 0.15.0 (or manually without the agent running) can be flushed to the database.