### PR TITLE
Indexer agent: Detect revert reason for failed transactions 

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -83,7 +83,7 @@ export default {
       .option('transaction-attempts', {
         description: 'The maximum number of transaction attempts',
         type: 'number',
-        default: 5,
+        default: 2,
         group: 'Ethereum',
       })
       .option('mnemonic', {

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -67,6 +67,7 @@ export enum IndexerErrorCode {
   IE054 = 'IE054',
   IE055 = 'IE055',
   IE056 = 'IE056',
+  IE057 = 'IE057',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -127,6 +128,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE054: 'Failed to collect receipts in exchange for query fee voucher',
   IE055: 'Failed to redeem query fee voucher',
   IE056: 'Failed to remember allocation for collecting receipts later',
+  IE057: 'Transaction reverted: contract requirement not met',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -121,14 +121,14 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE048: 'Failed to withdraw query fees for allocation',
   IE049: 'Failed to clean up transfers for allocation',
   IE050:
-    'Transaction reverted: gas limit likely hit (cumulative gas used is near the gas limit)',
-  IE051: 'Transaction reverted: reason unknown',
+    'Transaction reverted due to gas limit being hit',
+  IE051: 'Transaction reverted for unknown reason',
   IE052: 'Transaction aborted: maximum configured gas price reached',
   IE053: 'Failed to queue receipts for collecting',
   IE054: 'Failed to collect receipts in exchange for query fee voucher',
   IE055: 'Failed to redeem query fee voucher',
   IE056: 'Failed to remember allocation for collecting receipts later',
-  IE057: 'Transaction reverted: contract requirement not met',
+  IE057: 'Transaction reverted due to failing assertion in contract',
 }
 
 export type IndexerErrorCause = unknown


### PR DESCRIPTION
This PR updates the transaction management mechanism to improve handling of failed transactions. The agent now fetches the revert reason for failed transactions and only retries the transaction with transaction configuration updates if it was an `out of gas` issue. 

I've also updated the default value for `transaction-attempts` from `5` to `2` to prioritize gas conservation in the default configuration.  