### PR TITLE
indexer-agent: implement closeAndAllocate within allocation reconciliation logic

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1082,7 +1082,6 @@ export class Network {
       createdAtBlockHash: existingAllocation.createdAtBlockHash,
     })
     try {
-      logger.info(`closeAndAllocate`)
       // Double-check whether the allocation is still active on chain, to
       // avoid unnecessary transactions.
       // Note: We're checking the allocation state here, which is defined as
@@ -1117,7 +1116,7 @@ export class Network {
 
       const currentEpoch = await this.contracts.epochManager.currentEpoch()
 
-      logger.info(`Close and allocate for subgraph deployment`, {
+      logger.info(`Reallocate to subgraph deployment`, {
         amountGRT: formatGRT(amount),
         epoch: currentEpoch.toString(),
       })
@@ -1245,7 +1244,8 @@ export class Network {
         event.topics,
       )
 
-      logger.info(`Successfully close and allocated to subgraph deployment`, {
+      logger.info(`Successfully reallocated to subgraph deployment`, {
+        deployment: deployment.display,
         amountGRT: formatGRT(eventInputs.tokens),
         allocation: eventInputs.allocationID,
         epoch: eventInputs.epoch.toString(),
@@ -1259,7 +1259,7 @@ export class Network {
           signalAmount: BigNumber.from(0),
         },
         allocatedTokens: BigNumber.from(eventInputs.tokens),
-        createdAtBlockHash: '0x0',
+        createdAtBlockHash: receipt.blockHash,
         createdAtEpoch: eventInputs.epoch,
         closedAtEpoch: 0,
         closedAtBlockHash: '0x0',


### PR DESCRIPTION
This implements three changes:
- Adds a `closeAndAllocate` function to `network.ts`, wrapping the contract interactions and performing the relevant safety checks
- Adds a `reallocate` function to `agent.ts`, which gets the POI, calls `network.closeAndAllocate` and claims receipts for the closed allocation
- Modifies `reconcileDeploymentAllocations` in `agent.ts` to a) use `agent.reallocate` in place of an `agent.closeAllocation` and then `network.allocateMultiple` and b) remove the logic that does a staggered closure of parallel allocations (no longer relevant)

This results in `indexer-agent` using the `closeAndAllocate` function on the Staking contract to renew an expired but still desirable allocation rather than first `closeAllocation` and then `allocateFrom` in two separate transactions.

Sample `closeAndAllocate` transaction from this code running on testnet: https://rinkeby.etherscan.io/tx/0xd6cf7cbcf9d58c06b01c33896e216f8844dd01f6240c88abc49c72e8fa9f17c0

![Screenshot 2021-06-23 at 23 26 05](https://user-images.githubusercontent.com/2657600/123175995-9ec8f200-d47a-11eb-8b7b-035c03d57cc1.png)

Sample `allocateFrom`: https://rinkeby.etherscan.io/tx/0x5acda392d75ef6ce1f43fb2ef345c8845167da4f59d98fd7d2e6379181fc36aa

![Screenshot 2021-06-23 at 23 26 34](https://user-images.githubusercontent.com/2657600/123175966-9375c680-d47a-11eb-9dc8-725b84593ed7.png)

Sample `closeAllocation`: https://rinkeby.etherscan.io/tx/0x53a00129bee095a2f8cdd15dd824cec5511bb81ecf51b87571e9252946d785b1

![Screenshot 2021-06-23 at 23 26 54](https://user-images.githubusercontent.com/2657600/123175949-8d7fe580-d47a-11eb-827f-f0dad2ac2e54.png)

Naturally the gas costs will vary slightly between tx, but the gas cost savings of using `closeAndAllocate` are approximately 122k gas (~23%) over a `closeAllocation` and subsequent `allocateFrom`.
