### PR TITLE
indexer-agent: implement batch rebate claiming using claimMany

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -316,13 +316,9 @@ class Agent {
         createdAtEpoch: allocation.createdAtEpoch,
       })),
     })
-    await pMap(
-      allocations,
-      async allocation => {
-        await this.network.claim(allocation)
-      },
-      { concurrency: 1 },
-    )
+    if (allocations.length > 0) {
+      await this.network.claimMany(allocations)
+    }
   }
 
   async identifyPotentialDisputes(


### PR DESCRIPTION
This implements these changes:
- Adds a `claimMany` function to `network.ts`, wrapping the contract interactions and performing the relevant safety checks
- Instead of iterating through claims and calling each one, call `claimMany` and pass in a batch
- Adds `--rebate-claim-threshold` and `--rebate-claim-batch-threshold` as options

Thanks @fordN!