### PR TITLE
offchain subgraphs parameter fix

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -268,7 +268,7 @@ export default {
           arg.reduce(
             (acc: string[], value: string) => [...acc, ...value.split(',')],
             [],
-          ),
+          )).map((id: string) => id.trim()).filter((id: string) => id.length > 0),
       })
       .option('poi-disputable-epochs', {
         description:


### PR DESCRIPTION
this fixes the agent from crashing when the --offchain-subgraphs command line parameter contains the empty string. 