### PR TITLE
indexer-agent: Retry low fee query fee vouchers later

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -364,6 +364,16 @@ export default {
         implies: ['allocation-exchange-contract'],
         group: 'Query Fees',
       })
+      .option('voucher-expiration', {
+        description:
+          'Time (in hours) after which a low query fee voucher expires and is deleted (default: 90 days)',
+        type: 'number',
+        default: 2160,
+        required: false,
+        conflicts: ['use-vector'],
+        implies: ['allocation-exchange-contract'],
+        group: 'Query Fees',
+      })
   },
   handler: async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -709,6 +719,7 @@ export default {
         allocationClaimThreshold: parseGRT(
           argv.allocationClaimThreshold.toString(),
         ),
+        voucherExpiration: argv.voucherExpiration,
       })
       await receiptCollector.queuePendingReceiptsFromDatabase()
     }


### PR DESCRIPTION
Add --voucher-expiration to configure the time (in seconds) after which a voucher with too few query fees is permanently deleted. Until then, keep retrying to redeem it to give the indexer a chance to adjust their `--allocation-claim-threshold`.

As requested by Jim on Discord.