### PR TITLE
k8s: Use ClusterIP instead of LoadBalancer for internal services

### DIFF
--- a/k8s/base/indexer-agent/service.yaml
+++ b/k8s/base/indexer-agent/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: indexer-agent
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: indexer-agent
   ports:

--- a/k8s/base/indexer-service/service.yaml
+++ b/k8s/base/indexer-service/service.yaml
@@ -6,7 +6,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true, "exposed_ports": {"80":{}}}'
     beta.cloud.google.com/backend-config: '{"ports": {"80":"indexer-service-backend-config"}}'
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: indexer-service
   ports:


### PR DESCRIPTION
This is to avoid exposing both services to the internet directly. We've also made the experience that `LoadBalancer` services add extra latency.