### PR TITLE
indexer-agent: Fix syntax error in offchain-subgraphs option

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -265,10 +265,13 @@ export default {
         array: true,
         default: [],
         coerce: arg =>
-          arg.reduce(
-            (acc: string[], value: string) => [...acc, ...value.split(',')],
-            [],
-          )).map((id: string) => id.trim()).filter((id: string) => id.length > 0),
+          arg
+            .reduce(
+              (acc: string[], value: string) => [...acc, ...value.split(',')],
+              [],
+            )
+            .map((id: string) => id.trim())
+            .filter((id: string) => id.length > 0),
       })
       .option('poi-disputable-epochs', {
         description:


### PR DESCRIPTION
Error introduced in 5febd002ec4668d9f1679f6d116f53fa836188a0