### PR TITLE
indexer-cli: Remove styling characters from non-table output

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -136,15 +136,16 @@ module.exports = {
       const keys = Object.keys(pickFields(result.data.indexerEndpoints, []))
       keys.sort()
 
+      const statusUp = outputFormat == 'table' ? chalk.green('up') : 'up'
+      const statusDown = outputFormat == 'table' ? chalk.red('down') : 'down'
+
       data.endpoints = keys.reduce(
         (out, key) => [
           ...out,
           {
             name: key,
             url: result.data.indexerEndpoints[key].url,
-            status: result.data.indexerEndpoints[key].healthy
-              ? chalk.green('up')
-              : chalk.red('down'),
+            status: result.data.indexerEndpoints[key].healthy ? statusUp : statusDown,
             tests: result.data.indexerEndpoints[key].tests,
           },
         ],


### PR DESCRIPTION
The `indexer status` output would include styling characters in the yaml
and json output formats. This would result in fields such as
`"status": "\u001b[32mup\u001b[39m",` instead of `"status": "up",`. This
PR only applies the styling characters when the table output format is
selected.