### PR TITLE
Pass undefined as auth data if there's empty user and password

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -487,11 +487,22 @@ export default {
       )
     }
 
+    // Prevent passing empty basicAuth info
+    let username;
+    let password;
+    if (providerUrl.username == "" && providerUrl.password == "") {
+      username = undefined;
+      password = undefined;
+    } else {
+      username = providerUrl.username;
+      password = providerUrl.password;
+    }
+
     const ethereum = new providers.StaticJsonRpcProvider(
       {
         url: providerUrl.toString(),
-        user: providerUrl.username,
-        password: providerUrl.password,
+        user: username,
+        password: password,
         allowInsecureAuthentication: true,
       },
       argv.ethereumNetwork,


### PR DESCRIPTION
URL parse function provide empty username and password fields if auth data wasn't supplied in auth URL.
But ether.js considers empty username and password as a valid auth data and forms basic auth header with that.
I have faced that some ethereum node operators (without auth) fails to handle such requests.

ether.js maintainers reported that it's not a bug and they are not going to fix this in their lib. So fix for this case should be implemented on graphprotocol/indexer side - https://github.com/ethers-io/ethers.js/pull/1697#issuecomment-869036939

This PR adds checking if username and password fields both empty, then `undefined` would be supplied to ether.js which would disable adding empty auth header to requests.

/fix https://github.com/graphprotocol/indexer/issues/256 