### PR TITLE
indexer-agent: fix out of bounds lookup in for loop

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -703,7 +703,7 @@ class Agent {
       // We do a synchronous for-loop and await each iteration so that we can patch the contents
       // of activeAllocations with new allocations as they are made. This is important so that each
       // iteration gets an up to date copy of activeAllocations
-      for (let i = 0; i <= activeAllocations.length; i++) {
+      for (let i = 0; i <= activeAllocations.length - 1; i++) {
         const oldAllocation = activeAllocations[i]
         if (allocationInList(expiredAllocations, oldAllocation)) {
           const { newAllocation, reallocated } = await this.reallocate(


### PR DESCRIPTION
@fordN reported the agent throwing the following error when reallocating (`closeAndAllocate`) on testnet:

```Failed to reconcile indexer and network
    component: "Agent"
    err: {
      "type": "IndexerError",
      "message": "Failed to reconcile indexer and network",
      "stack":
          IndexerError: Failed to reconcile indexer and network
              at Object.indexerError (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-common/src/errors.ts:156:10)
              at Agent.<anonymous> (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:296:18)
              at Generator.throw (<anonymous>)
              at rejected (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:6:65)
              at runMicrotasks (<anonymous>)
              at processTicksAndRejections (internal/process/task_queues.js:93:5)
      "code": "IE005",
      "explanation": "https://github.com/graphprotocol/indexer/blob/master/docs/errors.md#ie005",
      "cause": {
        "type": "TypeError",
        "message": "Cannot read property 'id' of undefined",
        "stack":
            TypeError: Cannot read property 'id' of undefined
                at /Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:34:56
                at Array.find (<anonymous>)
                at allocationInList (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:34:20)
                at Agent.<anonymous> (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:711:13)
                at Generator.next (<anonymous>)
                at fulfilled (/Users/ford/thegraph/workspaces/temp/indexer/packages/indexer-agent/src/agent.ts:5:58)
                at runMicrotasks (<anonymous>)
                at processTicksAndRejections (internal/process/task_queues.js:93:5)
      }
    }
```

This is due to an out of bounds array lookup within a synchronous for loop over an array. The loop declaration doesn't `-1` from the array length, leading to the out of bounds lookup on the zero indexed array. This tiny PR fixes that.