### PR TITLE
indexer-agent: add existing allocation GRT to freeStake check when reallocating

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1149,11 +1149,6 @@ export class Network {
 
       const currentEpoch = await this.contracts.epochManager.currentEpoch()
 
-      logger.info(`Reallocate to subgraph deployment`, {
-        amountGRT: formatGRT(amount),
-        epoch: currentEpoch.toString(),
-      })
-
       // Identify how many GRT the indexer has staked
       const freeStake = await this.contracts.staking.getIndexerCapacity(
         this.indexerAddress,
@@ -1165,6 +1160,12 @@ export class Network {
       // Fetch the existing allocation amount and add it to the freeStake for comparison
       const { tokens: existingAllocationStake } = await this.contracts.staking.getAllocation(existingAllocation.id)
       const postCloseFreeStake = freeStake.add(existingAllocationStake)
+
+      logger.info(`Reallocate to subgraph deployment`, {
+        existingAllocationAmount: formatGRT(existingAllocationStake),
+        newAllocationAmount: formatGRT(amount),
+        epoch: currentEpoch.toString(),
+      })
 
       // If there isn't enough left for allocating, abort
       if (postCloseFreeStake.lt(amount)) {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1149,6 +1149,12 @@ export class Network {
 
       const currentEpoch = await this.contracts.epochManager.currentEpoch()
 
+      logger.info(`Reallocate to subgraph deployment`, {
+        existingAllocationAmount: formatGRT(existingAllocation.allocatedTokens),
+        newAllocationAmount: formatGRT(amount),
+        epoch: currentEpoch.toString(),
+      })
+
       // Identify how many GRT the indexer has staked
       const freeStake = await this.contracts.staking.getIndexerCapacity(
         this.indexerAddress,
@@ -1156,14 +1162,7 @@ export class Network {
 
       // When reallocating, we will first close the old allocation and free up the GRT in that allocation
       // This GRT will be available in addition to freeStake for the new allocation
-
       const postCloseFreeStake = freeStake.add(existingAllocation.allocatedTokens)
-
-      logger.info(`Reallocate to subgraph deployment`, {
-        existingAllocationAmount: formatGRT(existingAllocation.allocatedTokens),
-        newAllocationAmount: formatGRT(amount),
-        epoch: currentEpoch.toString(),
-      })
 
       // If there isn't enough left for allocating, abort
       if (postCloseFreeStake.lt(amount)) {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1157,12 +1157,10 @@ export class Network {
       // When reallocating, we will first close the old allocation and free up the GRT in that allocation
       // This GRT will be available in addition to freeStake for the new allocation
 
-      // Fetch the existing allocation amount and add it to the freeStake for comparison
-      const { tokens: existingAllocationStake } = await this.contracts.staking.getAllocation(existingAllocation.id)
-      const postCloseFreeStake = freeStake.add(existingAllocationStake)
+      const postCloseFreeStake = freeStake.add(existingAllocation.allocatedTokens)
 
       logger.info(`Reallocate to subgraph deployment`, {
-        existingAllocationAmount: formatGRT(existingAllocationStake),
+        existingAllocationAmount: formatGRT(existingAllocation.allocatedTokens),
         newAllocationAmount: formatGRT(amount),
         epoch: currentEpoch.toString(),
       })
@@ -1177,7 +1175,7 @@ export class Network {
             )} GRT: indexer only has a free stake amount of ${formatGRT(
               freeStake,
             )} GRT, plus ${formatGRT(
-              amount,
+              existingAllocation.allocatedTokens,
             )} GRT from the existing allocation`,
           ),
         )


### PR DESCRIPTION
When reallocating (`closeAndAllocate`), the GRT that we free up when closing the existing allocation becomes immediately available for the new allocation within the batched call.

This PR updates the agent to add the GRT amount of the existing allocation to the check against the Indexer's available tokens.

Without this fix, an indexer would need to have a buffer of free tokens equal to or in excess of the existing allocation or else the agent won't submit the reallocation transaction.