### PR TITLE
indexer-cli: Show indexer deployment status

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -21,6 +21,7 @@ import {
   registerIndexerErrorMetrics,
   defineQueryFeeModels,
   NetworkSubgraph,
+  IndexingStatusResolver,
 } from '@graphprotocol/indexer-common'
 
 import { startAgent } from '../agent'
@@ -580,11 +581,17 @@ export default {
 
     const indexerAddress = toAddress(argv.indexerAddress)
 
+    const indexingStatusResolver = new IndexingStatusResolver({
+      logger: logger,
+      statusEndpoint: argv.graphNodeStatusEndpoint,
+    })
+
     logger.info('Launch indexer management API server')
     const indexerManagementClient = await createIndexerManagementClient({
       models: managementModels,
       address: indexerAddress,
       contracts,
+      indexingStatusResolver,
       logger,
       defaults: {
         globalIndexingRule: {
@@ -607,7 +614,7 @@ export default {
     const indexer = new Indexer(
       logger,
       argv.graphNodeAdminEndpoint,
-      argv.graphNodeStatusEndpoint,
+      indexingStatusResolver,
       indexerManagementClient,
       argv.indexNodeIds,
       parseGRT(argv.defaultAllocationAmount),
@@ -631,7 +638,7 @@ export default {
       endpoint: argv.networkSubgraphEndpoint,
       deployment: argv.networkSubgraphDeployment
         ? {
-            indexingStatusResolver: indexer,
+            indexingStatusResolver: indexingStatusResolver,
             deployment: new SubgraphDeploymentID(
               argv.networkSubgraphDeployment,
             ),

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -60,15 +60,26 @@ module.exports = {
               }
 
               indexerDeployments {
-                deployment
+                subgraphDeployment
                 synced
                 health
-                fatalError
+                fatalError {
+                  handler
+                  message
+                }
                 node
-                network
-                latestBlockNumber
-                chainHeadBlockNumber
-                earliestBlockNumber
+                chains {
+                  network
+                  latestBlock {
+                    number
+                  }
+                  chainHeadBlock {
+                    number
+                  }
+                  earliestBlock {
+                    number
+                  }
+                }
               }
 
               indexerEndpoints {

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -59,6 +59,18 @@ module.exports = {
                 }
               }
 
+              indexerDeployments {
+                deployment
+                synced
+                health
+                fatalError
+                node
+                network
+                latestBlockNumber
+                chainHeadBlockNumber
+                earliestBlockNumber
+              }
+
               indexerEndpoints {
                 service {
                   url
@@ -148,6 +160,8 @@ module.exports = {
           'Indexer endpoints unknown. Make sure to run `indexer-agent` and register on chain',
       }
     }
+
+    print.debug(result.data.indexerDeployments)
 
     if (result.data.indexingRules) {
       if (result.data.indexingRules.length === 0) {

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -133,6 +133,7 @@ module.exports = {
     const data: any = {
       registration: null,
       endpoints: null,
+      indexerDeployments: null,
       indexingRules: null,
     }
 
@@ -172,7 +173,9 @@ module.exports = {
       }
     }
 
-    print.debug(result.data.indexerDeployments)
+    if (result.data.indexerDeployments) {
+      data.indexerDeployments = result.data.indexerDeployments
+    }
 
     if (result.data.indexingRules) {
       if (result.data.indexingRules.length === 0) {
@@ -227,6 +230,28 @@ module.exports = {
             }
           }
         }
+      }
+      print.info('')
+      print.info('Indexer Deployments')
+      if (data.indexerDeployments) {
+        print.info(
+          formatData(
+            data.indexerDeployments.flatMap((deployment: any) =>
+              deployment.chains.map((chain: any) => ({
+                deployment: deployment.subgraphDeployment,
+                synced: deployment.synced,
+                health: deployment.health,
+                fatalError: deployment.fatalError ? deployment.fatalError : '-',
+                node: deployment.node,
+                network: chain.network,
+                latestBlockNumber: chain.latestBlock.number,
+                chainHeadBlockNumber: chain.chainHeadBlock.number,
+                earliestBlockNumber: chain.earliestBlock.number,
+              })),
+            ),
+            outputFormat,
+          ),
+        )
       }
       print.info('')
       print.info('Indexing Rules')

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -116,7 +116,7 @@ const SCHEMA_SDL = gql`
   }
 
   type IndexingError {
-    handler: String!
+    handler: String
     message: String!
   }
 

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -19,6 +19,7 @@ import costModelResolvers from './resolvers/cost-models'
 import poiDisputeResolvers from './resolvers/poi-disputes'
 import { BigNumber } from 'ethers'
 import { Op, Sequelize } from 'sequelize'
+import { IndexingStatusResolver } from '../indexing-status'
 
 export interface IndexerManagementFeatures {
   injectDai: boolean
@@ -179,6 +180,7 @@ export interface IndexerManagementClientOptions {
   models: IndexerManagementModels
   address: string
   contracts: NetworkContracts
+  indexingStatusResolver: IndexingStatusResolver
   logger?: Logger
   defaults: IndexerManagementDefaults
   features: IndexerManagementFeatures
@@ -231,7 +233,15 @@ export class IndexerManagementClient extends Client {
 export const createIndexerManagementClient = async (
   options: IndexerManagementClientOptions,
 ): Promise<IndexerManagementClient> => {
-  const { models, address, contracts, logger, defaults, features } = options
+  const {
+    models,
+    address,
+    contracts,
+    indexingStatusResolver,
+    logger,
+    defaults,
+    features,
+  } = options
   const schema = buildSchema(print(SCHEMA_SDL))
   const resolvers = {
     ...indexingRuleResolvers,
@@ -249,6 +259,7 @@ export const createIndexerManagementClient = async (
       models,
       address,
       contracts,
+      indexingStatusResolver,
       logger: logger ? logger.child({ component: 'IndexerManagementClient' }) : undefined,
       defaults,
       features,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -115,16 +115,30 @@ const SCHEMA_SDL = gql`
     location: GeoLocation
   }
 
+  type IndexingError {
+    handler: String!
+    message: String!
+  }
+
+  type BlockPointer {
+    number: Int!
+    hash: String!
+  }
+
+  type ChainIndexingStatus {
+    network: String!
+    latestBlock: BlockPointer!
+    chainHeadBlock: BlockPointer!
+    earliestBlock: BlockPointer!
+  }
+
   type IndexerDeployment {
-    deployment: String!
+    subgraphDeployment: String!
     synced: Boolean!
     health: String!
-    fatalError: [String]
-    node: String
-    network: String
-    latestBlockNumber: Int
-    chainHeadBlockNumber: Int
-    earliestBlockNumber: Int
+    fatalError: IndexingError
+    node: String!
+    chains: [ChainIndexingStatus]
   }
 
   type IndexerEndpointTest {

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -29,6 +29,7 @@ export interface IndexerManagementResolverContext {
   models: IndexerManagementModels
   address: string
   contracts: NetworkContracts
+  indexingStatusResolver: IndexingStatusResolver
   logger?: Logger
   defaults: IndexerManagementDefaults
   features: IndexerManagementFeatures
@@ -114,6 +115,18 @@ const SCHEMA_SDL = gql`
     location: GeoLocation
   }
 
+  type IndexerDeployment {
+    deployment: String!
+    synced: Boolean!
+    health: String!
+    fatalError: [String]
+    node: String
+    network: String
+    latestBlockNumber: Int
+    chainHeadBlockNumber: Int
+    earliestBlockNumber: Int
+  }
+
   type IndexerEndpointTest {
     test: String!
     error: String
@@ -147,6 +160,7 @@ const SCHEMA_SDL = gql`
     indexingRule(deployment: String!, merged: Boolean! = false): IndexingRule
     indexingRules(merged: Boolean! = false): [IndexingRule!]!
     indexerRegistration: IndexerRegistration!
+    indexerDeployments: [IndexerDeployment]!
     indexerEndpoints: IndexerEndpoints!
 
     costModels(deployments: [String!]): [CostModel!]!

--- a/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import geohash from 'ngeohash'
-import gql from 'graphql-tag'
 import { IndexerManagementResolverContext } from '../client'
 
 interface Test {
@@ -84,63 +83,11 @@ export default {
     _: {},
     { indexingStatusResolver }: IndexerManagementResolverContext,
   ): Promise<object | null> => {
-    // TOOD: indexingStatusResolver.indexingStatus([]) to query all
-    const result = await indexingStatusResolver.statuses
-      .query(
-        gql`
-          {
-            indexingStatuses {
-              subgraphDeployment: subgraph
-              node
-              synced
-              health
-              fatalError {
-                handler
-                message
-              }
-              chains {
-                network
-                ... on EthereumIndexingStatus {
-                  latestBlock {
-                    number
-                    hash
-                  }
-                  chainHeadBlock {
-                    number
-                    hash
-                  }
-                  earliestBlock {
-                    number
-                    hash
-                  }
-                }
-              }
-            }
-          }
-        `,
-      )
-      .toPromise()
-
-    if (result.error) {
-      throw result.error
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return result.data.indexingStatuses.map((stat: any) => {
-      return {
-        deployment: stat.subgraphDeployment,
-        synced: stat.synced,
-        health: stat.health,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fatalError: stat.fatalError?.map((e: any) => e.message),
-        node: stat.node,
-        network: stat.chains[0]?.network,
-        latestBlockNumber: stat.chains[0]?.latestBlock.number,
-        chainHeadBlockNumber: stat.chains[0]?.chainHeadBlock.number,
-        earliestBlockNumber: stat.chains[0]?.earliestBlock.number,
-        __typename: 'IndexerDeployment',
-      }
-    })
+    const result = await indexingStatusResolver.indexingStatus([])
+    return result.map((status) => ({
+      ...status,
+      subgraphDeployment: status.subgraphDeployment.ipfsHash,
+    }))
   },
 
   indexerEndpoints: async (

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -2,7 +2,7 @@ import fetch from 'isomorphic-fetch'
 import gql from 'graphql-tag'
 import { Client, createClient } from '@urql/core'
 import { Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
-import { IndexingStatus, IndexingStatusResolver } from './types'
+import { IndexingStatus } from './types'
 import { indexerError, IndexerErrorCode } from './errors'
 
 export interface IndexingStatusFetcherOptions {
@@ -10,7 +10,7 @@ export interface IndexingStatusFetcherOptions {
   statusEndpoint: string
 }
 
-export class IndexingStatusFetcher implements IndexingStatusResolver {
+export class IndexingStatusResolver {
   logger: Logger
   statuses: Client
 

--- a/packages/indexer-common/src/network-subgraph.ts
+++ b/packages/indexer-common/src/network-subgraph.ts
@@ -213,7 +213,11 @@ const monitorDeployment = async ({
     try {
       logger.trace(`Checking the network subgraph deployment status`)
 
-      const indexingStatus = await indexingStatusResolver.indexingStatus(deployment)
+      const indexingStatuses = await indexingStatusResolver.indexingStatus([deployment])
+      const indexingStatus = indexingStatuses.pop()
+      if (!indexingStatus) {
+        throw `No indexing status found`
+      }
 
       const status = {
         health: indexingStatus.health,

--- a/packages/indexer-common/src/network-subgraph.ts
+++ b/packages/indexer-common/src/network-subgraph.ts
@@ -2,7 +2,8 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import { Eventual, Logger, SubgraphDeploymentID, timer } from '@graphprotocol/common-ts'
 import { DocumentNode, print } from 'graphql'
 import { OperationResult, CombinedError } from '@urql/core'
-import { IndexingStatusResolver, BlockPointer, IndexingError } from './types'
+import { BlockPointer, IndexingError } from './types'
+import { IndexingStatusResolver } from './indexing-status'
 
 export interface NetworkSubgraphCreateOptions {
   logger: Logger

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -25,7 +25,3 @@ export interface IndexingError {
   handler: string
   message: string
 }
-
-export interface IndexingStatusResolver {
-  indexingStatus(deployment: SubgraphDeploymentID): Promise<IndexingStatus>
-}

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -9,6 +9,7 @@ export interface EthereumIndexingStatus {
   network: string
   latestBlock: BlockPointer
   chainHeadBlock: BlockPointer
+  earliestBlock: BlockPointer
 }
 
 export type ChainIndexingStatus = EthereumIndexingStatus
@@ -18,6 +19,7 @@ export interface IndexingStatus {
   health: string
   synced: boolean
   fatalError: IndexingError
+  node: string
   chains: ChainIndexingStatus[]
 }
 

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -21,7 +21,7 @@ import {
   createVectorClient,
   defineQueryFeeModels,
   NetworkSubgraph,
-  IndexingStatusFetcher,
+  IndexingStatusResolver,
 } from '@graphprotocol/indexer-common'
 
 import { createServer } from '../server'
@@ -277,7 +277,7 @@ export default {
     logger.info('Successfully connected to database')
 
     logger.info(`Connect to network`)
-    const indexingStatusResolver = new IndexingStatusFetcher({
+    const indexingStatusResolver = new IndexingStatusResolver({
       logger,
       statusEndpoint: argv.graphNodeStatusEndpoint,
     })
@@ -459,6 +459,7 @@ export default {
       models,
       address,
       contracts,
+      indexingStatusResolver,
       logger,
       defaults: {
         // This is just a dummy, since we're never writing to the management


### PR DESCRIPTION
This change adds an Indexer Deployments section to the `indexer status` command. Example output:
```
Indexer Deployments
┌────────────────────────────────────────────────┬────────┬─────────┬────────────┬─────────┬─────────┬───────────────────┬──────────────────────┬─────────────────────┐
│ deployment                                     │ synced │ health  │ fatalError │ node    │ network │ latestBlockNumber │ chainHeadBlockNumber │ earliestBlockNumber │
├────────────────────────────────────────────────┼────────┼─────────┼────────────┼─────────┼─────────┼───────────────────┼──────────────────────┼─────────────────────┤
│ QmVqMeQUwvQ3XjzCYiMhRvQjRiQLGpVt8C3oHgvDi3agJ2 │ false  │ healthy │ -          │ default │ mainnet │ 12421076          │ 12864751             │ 11101016            │
├────────────────────────────────────────────────┼────────┼─────────┼────────────┼─────────┼─────────┼───────────────────┼──────────────────────┼─────────────────────┤
│ QmVEV7RA2U6BJT9Ssjxcfyrk4YQUnVqSRNX4TvYagjzh9h │ false  │ healthy │ -          │ default │ mainnet │ 12594851          │ 12864751             │ 9371102             │
└────────────────────────────────────────────────┴────────┴─────────┴────────────┴─────────┴─────────┴───────────────────┴──────────────────────┴─────────────────────┘
```

Closes #231