### PR TITLE
indexer-agent: Format start.ts

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -499,14 +499,14 @@ export default {
     }
 
     // Prevent passing empty basicAuth info
-    let username;
-    let password;
-    if (providerUrl.username == "" && providerUrl.password == "") {
-      username = undefined;
-      password = undefined;
+    let username
+    let password
+    if (providerUrl.username == '' && providerUrl.password == '') {
+      username = undefined
+      password = undefined
     } else {
-      username = providerUrl.username;
-      password = providerUrl.password;
+      username = providerUrl.username
+      password = providerUrl.password
     }
 
     const ethereum = new providers.StaticJsonRpcProvider(


### PR DESCRIPTION
This formatting error was introduced prior to the formatting Ci check.
This change fixes the formatting so that future PRs will not have CI
failures for unrelated formatting issues.