### PR TITLE
indexer-agent: Fix Indexer agent tests setup

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -140,10 +140,10 @@ const setup = async () => {
   })
 
   indexer = new Indexer(
+    logger,
     'test',
     'test',
     indexerManagementClient,
-    logger,
     ['test'],
     parseGRT('1000'),
     address,


### PR DESCRIPTION
The order of params in the Indexer class constructor had been changed in https://github.com/graphprotocol/indexer/commit/5786d0551b05ee4307fc197c81a354e3f0add2ba, but the test was not updated to reflect the new signature.