### PR TITLE
Various smaller updates

### DIFF
--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
     - main
-    - jannis/*
-    tags: 
+    tags:
     - v*.*.*
 
 jobs:

--- a/.github/workflows/indexer-cli-image.yml
+++ b/.github/workflows/indexer-cli-image.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
     - main
-    - jannis/*
-    tags: 
+    tags:
     - v*.*.*
 
 jobs:

--- a/.github/workflows/indexer-service-image.yml
+++ b/.github/workflows/indexer-service-image.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
     - main
-    - jannis/*
-    tags: 
+    tags:
     - v*.*.*
 
 jobs:

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -114,10 +114,9 @@ to be reported. Make sure that
 - Indexer agent can connect and deploy to the graph/index node or nodes fine.
 - The indexer has sufficient ETH.
 - The indexer has sufficient free stake to create new allocations. If this is
-  the case, reduce the allocation amount and/or parallel allocations on some
-  of the deployments in the indexing rules and wait until some of the existing
-  allocations have been closed and have released the allocated GRT again. In
-  this case, the situation should resolve automatically.
+  the case, reduce the allocation amount until some of the existing 
+  allocations have been closed and have released the allocated GRT again. 
+  In this case, the situation should resolve automatically.
 
 ## IE006
 
@@ -230,10 +229,10 @@ for creating new allocations
 **Solution**
 
 The indexer has sufficient free stake to create new allocations. If this is
-the case, reduce the allocation amount and/or parallel allocations on some of
-the deployments in the indexing rules and wait until some of the existing
-allocations have been closed and have released the allocated GRT again. In
-this case, the situation should resolve automatically.
+the case, reduce the allocation amount on some of the deployments in the 
+indexing rules and wait until some of the existing allocations have been 
+closed and have released the allocated GRT again. In this case, the 
+situation should resolve automatically.
 
 ## IE014
 

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -83,9 +83,10 @@ export default {
         coerce: arg => arg * 10 ** 9,
       })
       .option('transaction-attempts', {
-        description: 'The maximum number of transaction attempts',
+        description:
+          'The maximum number of transaction attempts (Use 0 for unlimited)',
         type: 'number',
-        default: 2,
+        default: 0,
         group: 'Ethereum',
       })
       .option('mnemonic', {

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -126,7 +126,7 @@ export class Indexer {
 
       return result.data.indexingStatuses
         .filter((status: { subgraphDeployment: string; node: string }) => {
-          return status.node !== 'removed'
+          return status.node && status.node !== 'removed'
         })
         .map((status: { subgraphDeployment: string; node: string }) => {
           return new SubgraphDeploymentID(status.subgraphDeployment)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -162,6 +162,7 @@ export class Network {
         logger.warn('Transaction retry limit reached, giving up', {
           txConfig,
         })
+        await delay(30000)
         break
       }
 

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -155,7 +155,10 @@ export class Network {
     logger.info(`Sending transaction`, { tx: tx, attempt: txConfig.attempt })
 
     while (pending) {
-      if (txConfig.attempt >= this.maxTransactionAttempts) {
+      if (
+        this.maxTransactionAttempts !== 0 &&
+        txConfig.attempt > this.maxTransactionAttempts
+      ) {
         logger.warn('Transaction retry limit reached, giving up', {
           txConfig,
         })

--- a/packages/indexer-cli/src/commands/indexer/rules/set.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/set.ts
@@ -74,6 +74,10 @@ module.exports = {
       deployment,
     })
 
+    if (inputRule.parallelAllocations && inputRule.parallelAllocations >= 2) {
+      throw Error ('Parallel allocations are soon to be fully deprecated. Please set parallel allocations to 1 for all your indexing rules')
+    }
+
     // Update the indexing rule according to the key/value pairs
     try {
       const client = await createIndexerManagementClient({ url: config.api })

--- a/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
+++ b/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
@@ -140,6 +140,13 @@ export const defineIndexingRuleModels = (sequelize: Sequelize): IndexingRuleMode
         validate: {
           min: 0,
           max: 20,
+          emitDeprecationWarning: (value: number) => {
+            if (value > 1) {
+              throw new Error(
+                'Parallel allocations are soon to be fully deprecated. Please set parallel allocations to 1 for all your indexing rules',
+              )
+            }
+          },
         },
       },
       maxAllocationPercentage: {

--- a/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
@@ -120,6 +120,7 @@ export default {
     if (result.error) {
       throw new Error(`Falied to query allocations: ${result.error}`)
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return result.data.indexer.allocations.map((allocation: any) => ({
       ...allocation,
       subgraphDeployment: new SubgraphDeploymentID(allocation.subgraphDeployment.id)


### PR DESCRIPTION
- Remove "jannis/*" branches from github workflow triggers. 
- Default to unlimited max transaction attempts in the indexer agent to avoid orphaned transactions. 
- Only allow setting parallel allocations to 1 for indexing rules to prepare for full deprecation of the parallel allocations feature. 
- Treat deployments assigned to node = `null` or `undefined` as `removed`, so they are filtered out of the `actDeployments` array. 