### PR TITLE
indexer-agent: Add references_unavailable state to potential disputes

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -12,6 +12,8 @@ import {
   defineIndexerManagementModels,
   IndexerManagementClient,
   IndexerManagementModels,
+  IndexingStatusResolver,
+  NetworkSubgraph,
   POIDisputeAttributes,
 } from '@graphprotocol/indexer-common'
 import { BigNumber, Wallet } from 'ethers'
@@ -123,15 +125,28 @@ const setup = async () => {
 
   wallet = Wallet.createRandom()
 
+  const indexingStatusResolver = new IndexingStatusResolver({
+    logger: logger,
+    statusEndpoint: 'http://localhost:8030/graphql',
+  })
+
+  const networkSubgraph = await NetworkSubgraph.create({
+    logger,
+    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    deployment: undefined,
+  })
+
   indexerManagementClient = await createIndexerManagementClient({
     models,
     address: toAddress(address),
     contracts: contracts,
+    indexingStatusResolver,
+    networkSubgraph,
     logger,
     defaults: {
       globalIndexingRule: {
         allocationAmount: parseGRT('1000'),
-        parallelAllocations: 2,
+        parallelAllocations: 1,
       },
     },
     features: {
@@ -142,7 +157,7 @@ const setup = async () => {
   indexer = new Indexer(
     logger,
     'test',
-    'test',
+    indexingStatusResolver,
     indexerManagementClient,
     ['test'],
     parseGRT('1000'),

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -287,13 +287,13 @@ export default {
       })
       .option('poi-disputable-epochs', {
         description:
-          'The number of epochs in the past to look for potential POI disputes',
+          'The number of epochs in the past to look for potential PoI disputes',
         type: 'number',
         default: 1,
         group: 'Disputes',
       })
       .option('poi-dispute-monitoring', {
-        description: 'Monitor the network for potential POI disputes',
+        description: 'Monitor the network for potential PoI disputes',
         type: 'boolean',
         default: false,
         group: 'Disputes',

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -175,7 +175,7 @@ export class Indexer {
           if (result.error) {
             throw result.error
           }
-          this.logger.trace('Reference POI generated', {
+          this.logger.trace('Reference PoI generated', {
             indexer: this.indexerAddress,
             subgraph: deployment.ipfsHash,
             block: block,
@@ -351,7 +351,7 @@ export class Indexer {
       )
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE039, error)
-      this.logger.error('Failed to store potential POI disputes', {
+      this.logger.error('Failed to store potential PoI disputes', {
         err,
       })
       throw err

--- a/packages/indexer-agent/src/migrations/03-poi-disputes-add-subgraph-deployment-id.ts
+++ b/packages/indexer-agent/src/migrations/03-poi-disputes-add-subgraph-deployment-id.ts
@@ -13,14 +13,14 @@ interface Context {
 export async function up({ context }: Context): Promise<void> {
   const { queryInterface, logger } = context
 
-  logger.info(`Checking if POI disputes table exists`)
+  logger.info(`Checking if PoI disputes table exists`)
   const tables = await queryInterface.showAllTables()
   if (!tables.includes('POIDisputes')) {
-    logger.info(`POI disputes table does not exist, migration not necessary`)
+    logger.info(`PoI disputes table does not exist, migration not necessary`)
     return
   }
 
-  logger.info(`Checking if POI disputes table needs to be migrated`)
+  logger.info(`Checking if PoI disputes table needs to be migrated`)
   const table = await queryInterface.describeTable('POIDisputes')
   const subgraphDeploymentIDColumn = table.subgraphDeploymentID
   if (subgraphDeploymentIDColumn) {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -702,10 +702,15 @@ export class Network {
     deployments: SubgraphDeploymentID[],
     minimumAllocation: number,
   ): Promise<Allocation[]> {
+    const logger = this.logger.child({ component: 'PoI Monitor' })
     if (!this.poiDisputeMonitoring) {
-      this.logger.info('POI monitoring disabled, skipping')
+      logger.debug('PoI monitoring disabled, skipping')
       return Promise.resolve([])
     }
+
+    logger.debug(
+      'Query network for any newly closed allocations for deployment this indexer is syncing (available reference PoIs',
+    )
 
     let dataRemaining = true
     let allocations: Allocation[] = []
@@ -817,7 +822,7 @@ export class Network {
       )
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE037, error)
-      this.logger.error(INDEXER_ERROR_MESSAGES.IE037, {
+      logger.error(INDEXER_ERROR_MESSAGES.IE037, {
         err,
       })
       throw err

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -10,10 +10,10 @@ export interface POIDisputeAttributes {
   allocationAmount: string
   allocationProof: string
   closedEpoch: number
-  closedEpochReferenceProof: string
+  closedEpochReferenceProof: string | null
   closedEpochStartBlockHash: string
   closedEpochStartBlockNumber: number
-  previousEpochReferenceProof: string
+  previousEpochReferenceProof: string | null
   previousEpochStartBlockHash: string
   previousEpochStartBlockNumber: number
   status: string
@@ -46,10 +46,10 @@ export class POIDispute
   public allocationAmount!: string
   public allocationProof!: string
   public closedEpoch!: number
-  public closedEpochReferenceProof!: string
+  public closedEpochReferenceProof!: string | null
   public closedEpochStartBlockHash!: string
   public closedEpochStartBlockNumber!: number
-  public previousEpochReferenceProof!: string
+  public previousEpochReferenceProof!: string | null
   public previousEpochStartBlockHash!: string
   public previousEpochStartBlockNumber!: number
   public status!: string
@@ -74,6 +74,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
         type: DataTypes.STRING,
         allowNull: false,
         primaryKey: true,
+        unique: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           isHex: (value: any) => {
@@ -156,7 +157,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
       },
       closedEpochReferenceProof: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           isHex: (value: any) => {
@@ -198,7 +199,7 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
       },
       previousEpochReferenceProof: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           isHex: (value: any) => {

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -42,7 +42,11 @@ export default {
     const createdDisputes = await models.POIDispute.bulkCreate(disputes, {
       returning: true,
       validate: true,
-      ignoreDuplicates: true,
+      updateOnDuplicate: [
+        'closedEpochReferenceProof',
+        'previousEpochReferenceProof',
+        'status',
+      ],
     })
     return createdDisputes.map((dispute: POIDispute) => dispute.toGraphQL())
   },


### PR DESCRIPTION
- Relax the non-null restrictions on reference PoIs in the PotentialDisputes model.
- Use references_unavailable state to describe the case where at least one reference poi is unavailable and the allocation PoI has not been validated.