### PR TITLE
Change check for voucher expiration time

### DIFF
--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -302,7 +302,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
 
     if (BigNumber.from(voucher.amount).lt(this.allocationClaimThreshold)) {
       if (
-        voucher.createdAt.valueOf() / 1000 + this.voucherExpiration * 3600 >=
+        voucher.createdAt.valueOf() / 1000 + this.voucherExpiration * 3600 <=
         Date.now() / 1000
       ) {
         logger.info(


### PR DESCRIPTION
Current check returns true when voucher life time is greater than current date and when deletes voucher. Seems this is not correct. Need to do opposite.
https://discord.com/channels/438038660412342282/791444480628490290/880220214569074688