### PR TITLE
indexer-agent: Close parallel allocations (instead of renewing)

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -39,9 +39,7 @@ import {
 import { strict as assert } from 'assert'
 import gql from 'graphql-tag'
 import geohash from 'ngeohash'
-import pReduce from 'p-reduce'
 import delay from 'delay'
-import * as ti from '@thi.ng/iterators'
 
 const allocationIdProof = (
   signer: Signer,
@@ -942,30 +940,7 @@ export class Network {
     }
   }
 
-  async allocateMultiple(
-    deployment: SubgraphDeploymentID,
-    amount: BigNumber,
-    activeAllocations: Allocation[],
-    numAllocations: number,
-  ): Promise<Allocation[]> {
-    return await pReduce(
-      ti.repeat(amount, numAllocations),
-      async (allocations, allocationAmount) => {
-        const newAllocation = await this.allocate(
-          deployment,
-          allocationAmount,
-          allocations,
-        )
-        if (newAllocation) {
-          allocations.push(newAllocation)
-        }
-        return allocations
-      },
-      activeAllocations,
-    )
-  }
-
-  private async allocate(
+  async allocate(
     deployment: SubgraphDeploymentID,
     amount: BigNumber,
     activeAllocations: Allocation[],

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -256,7 +256,9 @@ module.exports = {
                 deployment: deployment.subgraphDeployment,
                 synced: deployment.synced,
                 health: deployment.health,
-                fatalError: deployment.fatalError ? deployment.fatalError.message : '-',
+                fatalError: deployment.fatalError
+                  ? JSON.stringify(deployment.fatalError.message)
+                  : '-',
                 node: deployment.node,
                 network: chain.network,
                 latestBlockNumber: chain.latestBlock.number,


### PR DESCRIPTION
Part of the epic to deprecate parallel allocations this PR adds logic to reconcileDeploymentAllocations() to close any parallel allocations as they become old enough. 