### PR TITLE
Indexer-cli: Formatting improvements to status output

### DIFF
--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -1,0 +1,135 @@
+import { SubgraphDeploymentID, formatGRT } from '@graphprotocol/common-ts'
+import yaml from 'yaml'
+import { GluegunPrint } from 'gluegun'
+import { table, getBorderCharacters } from 'table'
+import { BigNumber, utils } from 'ethers'
+import { pickFields } from './command-helpers'
+
+interface IndexerAllocation {
+  id: number
+  allocatedTokens: BigNumber
+  createdAtEpoch: number
+  closedAtEpoch: number | null
+  subgraphDeployment: string
+  signalAmount: BigNumber
+  stakedTokens: BigNumber
+}
+
+const ALLOCATION_CONVERTERS_FROM_GRAPHQL: Record<
+  keyof IndexerAllocation,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (x: never) => any
+> = {
+  id: x => x,
+  subgraphDeployment: (d: SubgraphDeploymentID) =>
+    typeof d === 'string' ? d : d.ipfsHash,
+  allocatedTokens: nullPassThrough((x: string) => BigNumber.from(x)),
+  createdAtEpoch: nullPassThrough((x: string) => parseInt(x)),
+  closedAtEpoch: nullPassThrough((x: string) => parseInt(x)),
+  signalAmount: nullPassThrough((x: string) => BigNumber.from(x)),
+  stakedTokens: nullPassThrough((x: string) => BigNumber.from(x)),
+}
+
+const ALLOCATION_FORMATTERS: Record<
+  keyof IndexerAllocation,
+  (x: never) => string | null
+> = {
+  id: nullPassThrough(x => x),
+  subgraphDeployment: (d: SubgraphDeploymentID) =>
+    typeof d === 'string' ? d : d.ipfsHash,
+  allocatedTokens: x => utils.commify(formatGRT(x)),
+  createdAtEpoch: x => x,
+  closedAtEpoch: x => x,
+  signalAmount: x => utils.commify(formatGRT(x)),
+  stakedTokens: x => utils.commify(formatGRT(x)),
+}
+
+/**
+ * Formats an indexer allocation for display in the console.
+ */
+export const formatIndexerAllocation = (
+  allocation: Partial<IndexerAllocation>,
+): Partial<IndexerAllocation> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(allocation)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (ALLOCATION_FORMATTERS as any)[key](value)
+  }
+
+  return obj as Partial<IndexerAllocation>
+}
+
+/**
+ * Parses an indexer allocation returned from the indexer management GraphQL
+ * API into normalized form.
+ */
+export const indexerAllocationFromGraphQL = (
+  allocation: Partial<IndexerAllocation>,
+): Partial<IndexerAllocation> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj = {} as any
+  for (const [key, value] of Object.entries(pickFields(allocation, []))) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj[key] = (ALLOCATION_CONVERTERS_FROM_GRAPHQL as any)[key](value)
+  }
+  return obj as Partial<IndexerAllocation>
+}
+
+export const printIndexerAllocations = (
+  print: GluegunPrint,
+  outputFormat: 'table' | 'json' | 'yaml',
+  allocationOrAllocations:
+    | Partial<IndexerAllocation>
+    | Partial<IndexerAllocation>[]
+    | null,
+  keys: (keyof IndexerAllocation)[],
+): void => {
+  if (Array.isArray(allocationOrAllocations)) {
+    const allocations = allocationOrAllocations.map(allocation =>
+      formatIndexerAllocation(pickFields(allocation, keys)),
+    )
+    print.info(displayIndexerAllocations(outputFormat, allocations))
+  } else if (allocationOrAllocations) {
+    const allocation = formatIndexerAllocation(pickFields(allocationOrAllocations, keys))
+    print.info(displayIndexerAllocation(outputFormat, allocation))
+  } else {
+    print.error(`No allocations found`)
+  }
+}
+
+export const displayIndexerAllocations = (
+  outputFormat: 'table' | 'json' | 'yaml',
+  allocations: Partial<IndexerAllocation>[],
+): string =>
+  outputFormat === 'json'
+    ? JSON.stringify(allocations, null, 2)
+    : outputFormat === 'yaml'
+    ? yaml.stringify(allocations).trim()
+    : allocations.length === 0
+    ? 'No data'
+    : table(
+        [
+          Object.keys(allocations[0]),
+          ...allocations.map(allocation => Object.values(allocation)),
+        ],
+        {
+          border: getBorderCharacters('norc'),
+        },
+      ).trim()
+
+export const displayIndexerAllocation = (
+  outputFormat: 'table' | 'json' | 'yaml',
+  allocation: Partial<IndexerAllocation>,
+): string =>
+  outputFormat === 'json'
+    ? JSON.stringify(allocation, null, 2)
+    : outputFormat === 'yaml'
+    ? yaml.stringify(allocation).trim()
+    : table([Object.keys(allocation), Object.values(allocation)], {
+        border: getBorderCharacters('norc'),
+      }).trim()
+
+function nullPassThrough<T, U>(fn: (x: T) => U): (x: T | null) => U | null {
+  return (x: T | null) => (x === null ? null : fn(x))
+}

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -6,6 +6,7 @@ import { loadValidatedConfig } from '../../config'
 import { createIndexerManagementClient } from '../../client'
 import gql from 'graphql-tag'
 import { printIndexingRules, indexingRuleFromGraphQL } from '../../rules'
+import { printIndexerAllocations, indexerAllocationFromGraphQL } from '../../allocations'
 import { formatData, pickFields } from '../../command-helpers'
 
 const HELP = `
@@ -189,7 +190,9 @@ module.exports = {
     }
 
     if (result.data.indexerAllocations) {
-      data.indexerAllocations = result.data.indexerAllocations
+      data.indexerAllocations = result.data.indexerAllocations.map(
+        indexerAllocationFromGraphQL,
+      )
     }
 
     if (result.data.indexingRules) {
@@ -273,22 +276,14 @@ module.exports = {
       print.info('')
       print.info('Indexer Allocations')
       if (data.indexerAllocations) {
-        print.info(
-          formatData(
-            data.indexerAllocations.map((allocation: any) =>
-              pickFields(allocation, [
-                'id',
-                'allocatedTokens',
-                'createdAtEpoch',
-                'closedAtEpoch',
-                'subgraphDeployment',
-                'signalAmount',
-                'stakedTokens',
-              ]),
-            ),
-            outputFormat,
-          ),
-        )
+        printIndexerAllocations(print, outputFormat, data.indexerAllocations, [
+          'id',
+          'subgraphDeployment',
+          'allocatedTokens',
+          'createdAtEpoch',
+          'signalAmount',
+          'stakedTokens',
+        ])
       }
       print.info('')
       print.info('Indexing Rules')

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -8,7 +8,7 @@ import gql from 'graphql-tag'
 import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
-import { BigNumber } from 'ethers'
+import { BigNumber, utils } from 'ethers'
 import { pickFields } from './command-helpers'
 
 export type SubgraphDeploymentIDIsh = SubgraphDeploymentID | 'global' | 'all'
@@ -54,13 +54,13 @@ const INDEXING_RULE_FORMATTERS: Record<
 > = {
   id: nullPassThrough(x => x),
   deployment: (d: SubgraphDeploymentIDIsh) => (typeof d === 'string' ? d : d.ipfsHash),
-  allocationAmount: nullPassThrough(formatGRT),
+  allocationAmount: nullPassThrough(x => utils.commify(formatGRT(x))),
   parallelAllocations: nullPassThrough((x: number) => x.toString()),
-  minSignal: nullPassThrough(formatGRT),
-  maxSignal: nullPassThrough(formatGRT),
-  minStake: nullPassThrough(formatGRT),
+  minSignal: nullPassThrough(x => utils.commify(formatGRT(x))),
+  maxSignal: nullPassThrough(x => utils.commify(formatGRT(x))),
+  minStake: nullPassThrough(x => utils.commify(formatGRT(x))),
   maxAllocationPercentage: nullPassThrough((x: number) => x.toPrecision(2)),
-  minAverageQueryFees: nullPassThrough(formatGRT),
+  minAverageQueryFees: nullPassThrough(x => utils.commify(formatGRT(x))),
   decisionBasis: x => x,
   custom: nullPassThrough(JSON.stringify),
 }


### PR DESCRIPTION
- Create formatting and display functions for indexer allocations. 
- Commify status output numbers.