### PR TITLE
Indexer-agent: Bump priority gas fee on gas price too low retry

### DIFF
--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -267,7 +267,7 @@ export class Indexer {
         const defaults = {
           deployment: INDEXING_RULE_GLOBAL,
           allocationAmount: this.defaultAllocationAmount.toString(),
-          parallelAllocations: 2,
+          parallelAllocations: 1,
           decisionBasis: 'rules',
         }
 


### PR DESCRIPTION
This PR includes a few updates to transaction execution management. 
- Upon gas price too low indicators, bump the priority gas fee on retry.
- Improve readability of transaction type logic by introducing a TransactionType enum.