### PR TITLE
Add support for unattestable query responses

### DIFF
--- a/packages/indexer-service/src/queries.ts
+++ b/packages/indexer-service/src/queries.ts
@@ -103,7 +103,10 @@ export class QueryProcessor implements QueryProcessorInterface {
       throw error
     }
 
-    const attestation = await signer.createAttestation(query, response.data)
+    let attestation = null
+    if (response.headers['graph-attestable'] == 'true') {
+      attestation = await signer.createAttestation(query, response.data)
+    }
 
     return {
       status: 200,

--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -288,6 +288,7 @@ export const createApp = async ({
             res
               .status(response.status || 200)
               .contentType('application/json')
+              .header('Graph-Attestable', String(response.result.attestation != null))
               .send(response.result)
           } catch (error) {
             const err = indexerError(IndexerErrorCode.IE032, error)

--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -288,7 +288,6 @@ export const createApp = async ({
             res
               .status(response.status || 200)
               .contentType('application/json')
-              .header('Graph-Attestable', String(response.result.attestation != null))
               .send(response.result)
           } catch (error) {
             const err = indexerError(IndexerErrorCode.IE032, error)

--- a/packages/indexer-service/src/types.ts
+++ b/packages/indexer-service/src/types.ts
@@ -10,7 +10,7 @@ export interface Signature {
 
 export interface QueryResult {
   graphQLResponse: string
-  attestation: Signature
+  attestation: Signature | null
 }
 
 export interface UnattestedQueryResult {


### PR DESCRIPTION
This change sets the Graph-Attestable header on query results based on
that of the graph-node response. By default this header will be set to
false and no attestation will be provided. See [GIP 20](https://hackmd.io/@CGmldHLrTRaYRnAva-HoPQ/S1W2vMjEt)