### PR TITLE
indexer-agent: Introduce deployment syncing buffer and fix transaction retry gas price bumping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,10 @@ dist
 
 # Etherlime (added by server wallet)
 .etherlime-store
+
+# Yalc
+yalc.lock
+.yalc/
+
+# IDE
+.idea/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "@octokit/core": "3.2.0",
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "prettier": "^2.4.1"
   },
   "resolutions": {
     "ethers": "5.4.4",

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -102,7 +102,8 @@ class Agent {
 
     const currentEpochStartBlock = currentEpoch.tryMap(
       async () => {
-        const startBlockNumber = await this.network.contracts.epochManager.currentEpochBlock()
+        const startBlockNumber =
+          await this.network.contracts.epochManager.currentEpochBlock()
         const startBlock = await this.network.ethereum.getBlock(
           startBlockNumber.toNumber(),
         )
@@ -423,13 +424,13 @@ class Agent {
           closedEpoch: allocation.closedAtEpoch,
           closedEpochReferenceProof: rewardsPool!.referencePOI,
           closedEpochStartBlockHash: allocation.closedAtEpochStartBlockHash!,
-          closedEpochStartBlockNumber: rewardsPool!
-            .closedAtEpochStartBlockNumber!,
+          closedEpochStartBlockNumber:
+            rewardsPool!.closedAtEpochStartBlockNumber!,
           previousEpochReferenceProof: rewardsPool!.referencePreviousPOI,
-          previousEpochStartBlockHash: rewardsPool!
-            .previousEpochStartBlockHash!,
-          previousEpochStartBlockNumber: rewardsPool!
-            .previousEpochStartBlockNumber!,
+          previousEpochStartBlockHash:
+            rewardsPool!.previousEpochStartBlockHash!,
+          previousEpochStartBlockNumber:
+            rewardsPool!.previousEpochStartBlockNumber!,
           status,
         } as POIDisputeAttributes
       },
@@ -720,9 +721,8 @@ class Agent {
       expiredAllocations,
       async (allocation: Allocation) => {
         try {
-          const onChainAllocation = await this.network.contracts.staking.getAllocation(
-            allocation.id,
-          )
+          const onChainAllocation =
+            await this.network.contracts.staking.getAllocation(allocation.id)
           return onChainAllocation.closedAtEpoch.eq('0')
         } catch (err) {
           this.logger.warn(

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -609,10 +609,7 @@ class Agent {
     const allocationAmount = rule?.allocationAmount
       ? BigNumber.from(rule.allocationAmount)
       : this.indexer.defaultAllocationAmount
-    const desiredNumberOfAllocations = Math.max(
-      1,
-      rule?.parallelAllocations || 1,
-    )
+    const desiredNumberOfAllocations = 1
 
     logger.info(`Reconcile deployment allocations`, {
       allocationAmount: formatGRT(allocationAmount),
@@ -665,8 +662,7 @@ class Agent {
 
     // If there are no allocations at all yet, create a new allocation
     if (activeAllocations.length === 0) {
-      logger.info(`No active allocations for deployment, creating some now`, {
-        desiredNumberOfAllocations,
+      logger.info(`No active allocation for deployment, creating one now`, {
         allocationAmount: formatGRT(allocationAmount),
       })
       const allocationsCreated = await this.network.allocate(

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -577,9 +577,8 @@ export class Indexer {
       // Pick a random index node to assign the deployment too; TODO: Improve
       // this to assign based on load (i.e. always pick the index node with the
       // least amount of deployments assigned)
-      const targetNode = this.indexNodeIDs[
-        Math.floor(Math.random() * this.indexNodeIDs.length)
-      ]
+      const targetNode =
+        this.indexNodeIDs[Math.floor(Math.random() * this.indexNodeIDs.length)]
 
       await this.create(name)
       await this.deploy(name, deployment, targetNode)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -879,15 +879,13 @@ export class Network {
       ])
 
       disputableEpochs = await Promise.all(
-        disputableEpochs.map(
-          async (epoch: Epoch): Promise<Epoch> => {
-            // TODO: May need to retry or skip epochs where obtaining start block fails
-            epoch.startBlockHash = (
-              await this.ethereum.getBlock(epoch?.startBlock)
-            )?.hash
-            return epoch
-          },
-        ),
+        disputableEpochs.map(async (epoch: Epoch): Promise<Epoch> => {
+          // TODO: May need to retry or skip epochs where obtaining start block fails
+          epoch.startBlockHash = (
+            await this.ethereum.getBlock(epoch?.startBlock)
+          )?.hash
+          return epoch
+        }),
       )
 
       return await Promise.all(
@@ -1417,15 +1415,13 @@ export class Network {
       logger.debug('Obtain a unique Allocation ID')
 
       // Obtain a unique allocation ID
-      const {
-        allocationSigner,
-        allocationId: newAllocationId,
-      } = uniqueAllocationID(
-        this.wallet.mnemonic.phrase,
-        currentEpoch.toNumber(),
-        deployment,
-        activeAllocations.map(allocation => allocation.id),
-      )
+      const { allocationSigner, allocationId: newAllocationId } =
+        uniqueAllocationID(
+          this.wallet.mnemonic.phrase,
+          currentEpoch.toNumber(),
+          deployment,
+          activeAllocations.map(allocation => allocation.id),
+        )
 
       // Double-check whether the allocationID already exists on chain, to
       // avoid unnecessary transactions.
@@ -1434,9 +1430,8 @@ export class Network {
       //     enum AllocationState { Null, Active, Closed, Finalized, Claimed }
       //
       // in the contracts.
-      const newAllocationState = await this.contracts.staking.getAllocationState(
-        newAllocationId,
-      )
+      const newAllocationState =
+        await this.contracts.staking.getAllocationState(newAllocationId)
       if (newAllocationState !== 0) {
         logger.warn(`Skipping Allocation as it already exists onchain`, {
           indexer: this.indexerAddress,

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -115,26 +115,27 @@ export class AllocationReceiptCollector implements ReceiptCollector {
 
       const now = new Date()
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const receipts = await this.models.allocationReceipts.sequelize!.transaction(
-        async transaction => {
-          // Update the allocation summary
-          await this.models.allocationSummaries.update(
-            { closedAt: now },
-            {
-              where: { allocation: allocation.id },
-              transaction,
-            },
-          )
+      const receipts =
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        await this.models.allocationReceipts.sequelize!.transaction(
+          async transaction => {
+            // Update the allocation summary
+            await this.models.allocationSummaries.update(
+              { closedAt: now },
+              {
+                where: { allocation: allocation.id },
+                transaction,
+              },
+            )
 
-          // Return all receipts for the just-closed allocation
-          return this.models.allocationReceipts.findAll({
-            where: { allocation: allocation.id },
-            order: ['id'],
-            transaction,
-          })
-        },
-      )
+            // Return all receipts for the just-closed allocation
+            return this.models.allocationReceipts.findAll({
+              where: { allocation: allocation.id },
+              order: ['id'],
+              transaction,
+            })
+          },
+        )
 
       if (receipts.length <= 0) {
         logger.info(`No receipts to collect for allocation`)
@@ -308,8 +309,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(
           `Query fee voucher is below claim threshold and is past the configured expiration time, delete it`,
           {
-            hint:
-              'If you would like to redeem vouchers like this, reduce the allocation claim threshold',
+            hint: 'If you would like to redeem vouchers like this, reduce the allocation claim threshold',
             allocationClaimThreshold: formatGRT(this.allocationClaimThreshold),
           },
         )
@@ -317,8 +317,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(
           `Query fee voucher amount is below claim threshold, skip it for now`,
           {
-            hint:
-              'If you would like to redeem this voucher, reduce the allocation claim threshold',
+            hint: 'If you would like to redeem this voucher, reduce the allocation claim threshold',
             tryingAgainUntil: new Date(
               voucher.createdAt.valueOf() + this.voucherExpiration * 3600,
             ),

--- a/packages/indexer-cli/src/client.ts
+++ b/packages/indexer-cli/src/client.ts
@@ -7,5 +7,5 @@ export const createIndexerManagementClient = async ({
 }: {
   url: string
 }): Promise<IndexerManagementClient> => {
-  return (createClient({ url, fetch }) as unknown) as IndexerManagementClient
+  return createClient({ url, fetch }) as unknown as IndexerManagementClient
 }

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -43,7 +43,6 @@
     "morgan": "1.10.0",
     "ngeohash": "0.6.3",
     "p-retry": "4.4.0",
-    "prettier": "2.1.2",
     "scrypt": "https://registry.yarnpkg.com/@favware/skip-dependency/-/skip-dependency-1.0.2.tgz",
     "sequelize": "6.3.5",
     "ts-custom-error": "^3.2.0",
@@ -61,7 +60,7 @@
     "@typescript-eslint/parser": "4.6.0",
     "eslint": "7.12.1",
     "jest": "26.6.1",
-    "prettier": "2.1.2",
+    "prettier": "^2.4.1",
     "ts-jest": "26.4.3",
     "typescript": "4.0.5"
   },

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -68,6 +68,7 @@ export enum IndexerErrorCode {
   IE055 = 'IE055',
   IE056 = 'IE056',
   IE057 = 'IE057',
+  IE058 = 'IE058',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -128,6 +129,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE055: 'Failed to redeem query fee voucher',
   IE056: 'Failed to remember allocation for collecting receipts later',
   IE057: 'Transaction reverted due to failing assertion in contract',
+  IE058: 'Transaction failed because nonce has already been used',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
@@ -308,9 +308,10 @@ describe('Cost models', () => {
 
     await client.mutation(SET_COST_MODEL_MUTATION, { costModel: input }).toPromise()
 
-    await expect(
-      client.query(GET_COST_MODELS_QUERY).toPromise(),
-    ).resolves.toHaveProperty('data.costModels', [input])
+    await expect(client.query(GET_COST_MODELS_QUERY).toPromise()).resolves.toHaveProperty(
+      'data.costModels',
+      [input],
+    )
   })
 })
 
@@ -333,9 +334,10 @@ describe('Feature: Inject $DAI variable', () => {
     }
     await client.mutation(SET_COST_MODEL_MUTATION, { costModel: update }).toPromise()
 
-    await expect(
-      client.query(GET_COST_MODELS_QUERY).toPromise(),
-    ).resolves.toHaveProperty('data.costModels', [initial])
+    await expect(client.query(GET_COST_MODELS_QUERY).toPromise()).resolves.toHaveProperty(
+      'data.costModels',
+      [initial],
+    )
   })
 
   test('$DAI variable can be overwritten', async () => {
@@ -351,9 +353,10 @@ describe('Feature: Inject $DAI variable', () => {
       variables: JSON.stringify({ DAI: '15.0' }),
     }
     await client.mutation(SET_COST_MODEL_MUTATION, { costModel: update }).toPromise()
-    await expect(
-      client.query(GET_COST_MODELS_QUERY).toPromise(),
-    ).resolves.toHaveProperty('data.costModels', [update])
+    await expect(client.query(GET_COST_MODELS_QUERY).toPromise()).resolves.toHaveProperty(
+      'data.costModels',
+      [update],
+    )
   })
 
   test('$DAI updates are applied to all cost models', async () => {
@@ -482,9 +485,10 @@ describe('Feature: Inject $DAI variable', () => {
       variables: JSON.stringify({}),
     }
     await client.mutation(SET_COST_MODEL_MUTATION, { costModel: update }).toPromise()
-    await expect(
-      client.query(GET_COST_MODELS_QUERY).toPromise(),
-    ).resolves.toHaveProperty('data.costModels', [update])
+    await expect(client.query(GET_COST_MODELS_QUERY).toPromise()).resolves.toHaveProperty(
+      'data.costModels',
+      [update],
+    )
   })
 })
 

--- a/packages/indexer-common/src/indexer-management/models/cost-model.ts
+++ b/packages/indexer-common/src/indexer-management/models/cost-model.ts
@@ -42,7 +42,8 @@ export interface CostModelCreationAttributes
 
 export class CostModel
   extends Model<CostModelAttributes, CostModelCreationAttributes>
-  implements CostModelAttributes {
+  implements CostModelAttributes
+{
   public id!: number
   public deployment!: string
   public model!: string | null

--- a/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
+++ b/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
@@ -42,7 +42,8 @@ export interface IndexingRuleCreationAttributes
 
 export class IndexingRule
   extends Model<IndexingRuleAttributes, IndexingRuleCreationAttributes>
-  implements IndexingRuleAttributes {
+  implements IndexingRuleAttributes
+{
   public id!: number
   public deployment!: string
   public allocationAmount!: string | null

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -39,7 +39,8 @@ export interface POIDisputeCreationAttributes
 
 export class POIDispute
   extends Model<POIDisputeAttributes, POIDisputeCreationAttributes>
-  implements POIDisputeAttributes {
+  implements POIDisputeAttributes
+{
   public allocationID!: string
   public subgraphDeploymentID!: string
   public allocationIndexer!: string

--- a/packages/indexer-common/src/query-fees/models.ts
+++ b/packages/indexer-common/src/query-fees/models.ts
@@ -10,7 +10,8 @@ export interface AllocationReceiptAttributes {
 
 export class AllocationReceipt
   extends Model<AllocationReceiptAttributes>
-  implements AllocationReceiptAttributes {
+  implements AllocationReceiptAttributes
+{
   public id!: string
   public allocation!: Address
   public fees!: string
@@ -50,7 +51,8 @@ export interface TransferReceiptAttributes {
 
 export class TransferReceipt
   extends Model<TransferReceiptAttributes>
-  implements TransferReceiptAttributes {
+  implements TransferReceiptAttributes
+{
   public id!: number
   public signer!: Address
   public fees!: string
@@ -111,7 +113,8 @@ export interface AllocationSummaryAttributes {
 
 export class AllocationSummary
   extends Model<AllocationSummaryAttributes>
-  implements AllocationSummaryAttributes {
+  implements AllocationSummaryAttributes
+{
   public allocation!: Address
   public closedAt!: Date
   public createdTransfers!: number

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -70,7 +70,7 @@
     "jest": "26.6.1",
     "lerna": "3.22.1",
     "nock": "13.0.4",
-    "prettier": "2.1.2",
+    "prettier": "^2.4.1",
     "supertest": "6.0.0",
     "ts-jest": "26.4.3",
     "typescript": "4.0.5"

--- a/packages/indexer-service/src/query-fees/allocations.ts
+++ b/packages/indexer-service/src/query-fees/allocations.ts
@@ -66,9 +66,11 @@ export class AllocationReceiptManager implements ReceiptManager {
     })
   }
 
-  private _parseAllocationReceipt(
-    receiptData: string,
-  ): { id: string; allocation: Address; fees: BigNumber } {
+  private _parseAllocationReceipt(receiptData: string): {
+    id: string
+    allocation: Address
+    fees: BigNumber
+  } {
     return {
       id: receiptData.slice(104, 134), // 15 bytes
       allocation: toAddress('0x' + receiptData.slice(0, 40)), // 20 bytes
@@ -132,19 +134,17 @@ export class AllocationReceiptManager implements ReceiptManager {
               await summary.save()
             }
 
-            const [
-              state,
-              isNew,
-            ] = await this._queryFeeModels.allocationReceipts.findOrBuild({
-              where: { id: receipt.id },
-              defaults: {
-                id: receipt.id,
-                allocation: receipt.allocation,
-                signature: receipt.signature,
-                fees: receipt.fees,
-              },
-              transaction,
-            })
+            const [state, isNew] =
+              await this._queryFeeModels.allocationReceipts.findOrBuild({
+                where: { id: receipt.id },
+                defaults: {
+                  id: receipt.id,
+                  allocation: receipt.allocation,
+                  signature: receipt.signature,
+                  fees: receipt.fees,
+                },
+                transaction,
+              })
 
             // Don't save if we already have a version of the receipt
             // with a higher amount of fees

--- a/packages/indexer-service/src/query-fees/transfers.ts
+++ b/packages/indexer-service/src/query-fees/transfers.ts
@@ -188,19 +188,17 @@ export class TransferReceiptManager implements ReceiptManager {
         await this._sequelize.transaction(
           { isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ },
           async (transaction: Transaction) => {
-            const [
-              state,
-              isNew,
-            ] = await this._queryFeeModels.transferReceipts.findOrBuild({
-              where: { id: receipt.id, signer: receipt.signer },
-              defaults: {
-                id: receipt.id,
-                signature: receipt.signature,
-                signer: receipt.signer,
-                fees: receipt.fees,
-              },
-              transaction,
-            })
+            const [state, isNew] =
+              await this._queryFeeModels.transferReceipts.findOrBuild({
+                where: { id: receipt.id, signer: receipt.signer },
+                defaults: {
+                  id: receipt.id,
+                  signature: receipt.signature,
+                  signer: receipt.signer,
+                  fees: receipt.fees,
+                },
+                transaction,
+              })
 
             // Don't save over receipts that are already advanced
             if (!isNew) {

--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -76,16 +76,14 @@ export const createApp = async ({
 
     queriesWithInvalidReceiptHeader: new metrics.client.Counter({
       name: 'indexer_service_queries_with_invalid_receipt_header',
-      help:
-        'Queries that failed executing because they came with an invalid receipt header',
+      help: 'Queries that failed executing because they came with an invalid receipt header',
       registers: [metrics.registry],
       labelNames: ['deployment'],
     }),
 
     queriesWithInvalidReceiptValue: new metrics.client.Counter({
       name: 'indexer_service_queries_with_invalid_receipt_value',
-      help:
-        'Queries that failed executing because they came with an invalid receipt value',
+      help: 'Queries that failed executing because they came with an invalid receipt value',
       registers: [metrics.registry],
       labelNames: ['deployment'],
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -13256,15 +13256,15 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
-
 prettier@^2.1.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
- Include buffer period for deployments; deployments will now continue to be synced for 1 day after allocation close in case the indexer wants to keep that deployment fresh or the gateway needs to query it. 
- Fix gas price bumping on transaction retry.
- Remove vestiges related to parallel allocations. 
- Wrap register in a retry function.
- Update .gitignore. 
- Apply formatting suggestions.