### PR TITLE
indexer-service: docker entrypoint instead of cmd

### DIFF
--- a/Dockerfile.indexer-service
+++ b/Dockerfile.indexer-service
@@ -64,4 +64,4 @@ ENV ETHEREUM ""
 
 # Run the indexer-service
 WORKDIR /opt/indexer/packages/indexer-service
-CMD ["node", "dist/index.js", "start"]
+ENTRYPOINT ["node", "dist/index.js", "start"]


### PR DESCRIPTION
Like indexer-agent's Dockerfile, we should specify an `ENTRYPOINT` in indexer-service's Dockerfile instead of a `CMD`. This is because the `CMD` is overwritten when you specify command line arguments in the `docker run indexer-service ...` form. Currently the image falls back to the ENTRYPOINT defined in the base image, which is `node`, which means that arguments get passed to node instead of the `indexer-service` process.

This PR fixes that, making the default `docker run` behaviour intuitive/run as expected.