### PR TITLE
indexer-agent: add max batch size, tweak claim defaults

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -102,8 +102,7 @@ class Agent {
 
     const currentEpochStartBlock = currentEpoch.tryMap(
       async () => {
-        const startBlockNumber =
-          await this.network.contracts.epochManager.currentEpochBlock()
+        const startBlockNumber = await this.network.contracts.epochManager.currentEpochBlock()
         const startBlock = await this.network.ethereum.getBlock(
           startBlockNumber.toNumber(),
         )
@@ -444,13 +443,13 @@ class Agent {
           closedEpoch: allocation.closedAtEpoch,
           closedEpochReferenceProof: rewardsPool!.referencePOI,
           closedEpochStartBlockHash: allocation.closedAtEpochStartBlockHash!,
-          closedEpochStartBlockNumber:
-            rewardsPool!.closedAtEpochStartBlockNumber!,
+          closedEpochStartBlockNumber: rewardsPool!
+            .closedAtEpochStartBlockNumber!,
           previousEpochReferenceProof: rewardsPool!.referencePreviousPOI,
-          previousEpochStartBlockHash:
-            rewardsPool!.previousEpochStartBlockHash!,
-          previousEpochStartBlockNumber:
-            rewardsPool!.previousEpochStartBlockNumber!,
+          previousEpochStartBlockHash: rewardsPool!
+            .previousEpochStartBlockHash!,
+          previousEpochStartBlockNumber: rewardsPool!
+            .previousEpochStartBlockNumber!,
           status,
         } as POIDisputeAttributes
       },
@@ -739,8 +738,9 @@ class Agent {
       expiredAllocations,
       async (allocation: Allocation) => {
         try {
-          const onChainAllocation =
-            await this.network.contracts.staking.getAllocation(allocation.id)
+          const onChainAllocation = await this.network.contracts.staking.getAllocation(
+            allocation.id,
+          )
           return onChainAllocation.closedAtEpoch.eq('0')
         } catch (err) {
           this.logger.warn(

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -207,15 +207,15 @@ export default {
         group: 'Indexer Infrastructure',
       })
       .option('rebate-claim-threshold', {
-        description: `Minimum value of query fees for a single allocation (in GRT) in order for it to be included in a batch rebate claim on-chain`,
+        description: `Minimum value of rebate for a single allocation (in GRT) in order for it to be included in a batch rebate claim on-chain`,
         type: 'string',
-        default: '0',
+        default: '200', // This value (the marginal gain of a claim in GRT), should always exceed the marginal cost of a claim (in ETH gas)
         group: 'Indexer Infrastructure',
       })
       .option('rebate-claim-batch-threshold', {
-        description: `Minimum total value of query fees in an allocation batch (in GRT) before rebates are claimed on-chain`,
+        description: `Minimum total value of all rebates in an batch (in GRT) before the batch is claimed on-chain`,
         type: 'string',
-        default: '0',
+        default: '2000',
         group: 'Indexer Infrastructure',
       })
       .option('inject-dai', {

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -577,8 +577,9 @@ export class Indexer {
       // Pick a random index node to assign the deployment too; TODO: Improve
       // this to assign based on load (i.e. always pick the index node with the
       // least amount of deployments assigned)
-      const targetNode =
-        this.indexNodeIDs[Math.floor(Math.random() * this.indexNodeIDs.length)]
+      const targetNode = this.indexNodeIDs[
+        Math.floor(Math.random() * this.indexNodeIDs.length)
+      ]
 
       await this.create(name)
       await this.deploy(name, deployment, targetNode)

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -309,7 +309,8 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(
           `Query fee voucher is below claim threshold and is past the configured expiration time, delete it`,
           {
-            hint: 'If you would like to redeem vouchers like this, reduce the allocation claim threshold',
+            hint:
+              'If you would like to redeem vouchers like this, reduce the allocation claim threshold',
             allocationClaimThreshold: formatGRT(this.allocationClaimThreshold),
           },
         )
@@ -317,7 +318,8 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(
           `Query fee voucher amount is below claim threshold, skip it for now`,
           {
-            hint: 'If you would like to redeem this voucher, reduce the allocation claim threshold',
+            hint:
+              'If you would like to redeem this voucher, reduce the allocation claim threshold',
             tryingAgainUntil: new Date(
               voucher.createdAt.valueOf() + this.voucherExpiration * 3600,
             ),


### PR DESCRIPTION
- Updates defaults for batch rebate claiming to set the individual rebate threshold to `200` GRT, and the batch claim threshold to `2000` GRT. This should prevent claiming unprofitable rebates, and also increases claim efficiency by leveraging batching.
- This sets a maximum batch size of 100 claims, preventing constructing transactions that are larger than the block gas limit

Should fix #330 