### PR TITLE
Indexer agent logger improvement 

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -564,7 +564,7 @@ export default {
     wallet = wallet.connect(ethereum)
     logger.info(`Connected wallet`)
 
-    logger.info(`Connecting to contracts`)
+    logger.info(`Connect to contracts`)
     let contracts = undefined
     try {
       contracts = await connectContracts(wallet, ethereum.network.chainId)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -533,7 +533,6 @@ export class Network {
         queryProgress.exhausted = results.length < queryProgress.first
         queryProgress.fetched += results.length
         queryProgress.lastId = results[results.length - 1].id
-
         deployments.push(
           ...results
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1362,13 +1361,13 @@ export class Network {
             allocation.id,
           )
           if (state === 4) {
-            logger.info(
+            logger.trace(
               `Allocation rebate rewards already claimed, ignoring ${allocation.id}.`,
             )
             return false
           }
           if (state === 1) {
-            logger.info(`Allocation still active, ignoring ${allocation.id}.`)
+            logger.trace(`Allocation still active, ignoring ${allocation.id}.`)
             return false
           }
           return true
@@ -1643,7 +1642,11 @@ export class Network {
       restakeRewards: this.restakeRewards,
     })
     try {
-      logger.info(`Claim tokens from the rebate pool for allocation`)
+      logger.info(`Claim tokens from the rebate pool for allocation`, {
+        deployment: allocation.subgraphDeployment.id.display,
+        allocation: allocation.id,
+        claimAmount: this.restakeRewards,
+      })
 
       // Double-check whether the allocation is claimed to
       // avoid unnecessary transactions.
@@ -1656,7 +1659,7 @@ export class Network {
         allocation.id,
       )
       if (state === 4) {
-        logger.info(`Allocation rebate rewards already claimed`)
+        logger.trace(`Allocation rebate rewards already claimed`)
         return true
       }
       if (state === 1) {
@@ -1680,7 +1683,9 @@ export class Network {
       if (receipt === 'paused' || receipt === 'unauthorized') {
         return false
       }
-      logger.info(`Successfully claimed allocation`)
+      logger.info(`Successfully claimed allocation`, {
+        logs: receipt.logs,
+      })
       return true
     } catch (err) {
       logger.warn(`Failed to claim allocation`, {

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -20,6 +20,7 @@ import { ReceiptCollector } from '.'
 import { BigNumber, Contract } from 'ethers'
 import { Op } from 'sequelize'
 import { Network } from '../network'
+import pRetry from 'p-retry'
 
 // Receipts are collected with a delay of 20 minutes after
 // the corresponding allocation was closed

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -21,6 +21,7 @@ export interface Allocation {
   previousEpochStartBlockHash: string | undefined
   closedAtBlockHash: string
   poi: string | undefined
+  queryFeeRebates: BigNumber | undefined
 }
 
 export enum AllocationStatus {
@@ -49,6 +50,7 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
   previousEpochStartBlockHash: undefined,
   closedAtBlockHash: allocation.closedAtBlockHash,
   poi: allocation.poi,
+  queryFeeRebates: allocation.queryFeeRebates,
 })
 
 export interface RewardsPool {


### PR DESCRIPTION
Adding extra info to the logs
- IPFS hash to `Reconcile deployment allocations`
- Rebate claim amount to `Claim tokens from the rebate pool for allocation`
- Latest block or fatal errors to `Received a null or zero POI for deployment`
- Added attempts to `redeem query fee voucher`

Reduce logs 
- lowered levels for `Allocation rebate rewards`
- added conditions for other logs such as `Reconcile`

Plan for next steps
- more logger stuff
-- ask indexers how they'd change the logs
-- quantify and analyze log messages
- Investigate IE055 in `redeem query fee voucher`