### PR TITLE
Add option to allocate on network subgraph

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -59,6 +59,7 @@ class Agent {
   indexer: Indexer
   network: Network
   networkSubgraph: NetworkSubgraph
+  allocateOnNetworkSubgraph: boolean
   registerIndexer: boolean
   offchainSubgraphs: SubgraphDeploymentID[]
   receiptCollector: ReceiptCollector
@@ -69,6 +70,7 @@ class Agent {
     indexer: Indexer,
     network: Network,
     networkSubgraph: NetworkSubgraph,
+    allocateOnNetworkSubgraph: boolean,
     registerIndexer: boolean,
     offchainSubgraphs: SubgraphDeploymentID[],
     receiptCollector: ReceiptCollector,
@@ -78,6 +80,7 @@ class Agent {
     this.indexer = indexer
     this.network = network
     this.networkSubgraph = networkSubgraph
+    this.allocateOnNetworkSubgraph = allocateOnNetworkSubgraph
     this.registerIndexer = registerIndexer
     this.offchainSubgraphs = offchainSubgraphs
     this.receiptCollector = receiptCollector
@@ -580,8 +583,11 @@ class Agent {
       ...activeAllocations.map(allocation => allocation.subgraphDeployment.id),
     ])
 
-    // Ensure the network subgraph is never allocated towards
-    if (this.networkSubgraph.deployment?.id.bytes32) {
+    // Ensure the network subgraph is never allocated towards unless explicitly allowed
+    if (
+      !this.allocateOnNetworkSubgraph &&
+      this.networkSubgraph.deployment?.id.bytes32
+    ) {
       const networkSubgraphDeploymentId = this.networkSubgraph.deployment.id
       targetDeployments = targetDeployments.filter(
         deployment =>
@@ -919,6 +925,7 @@ export const startAgent = async (config: AgentConfig): Promise<Agent> => {
     config.indexer,
     config.network,
     config.networkSubgraph,
+    config.allocateOnNetworkSubgraph,
     config.registerIndexer,
     config.offchainSubgraphs,
     config.receiptCollector,

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -154,6 +154,12 @@ export default {
         type: 'string',
         group: 'Network Subgraph',
       })
+      .option('allocate-on-network-subgraph', {
+        description: 'Whether to allocate to the network subgraph',
+        type: 'boolean',
+        default: false,
+        group: 'Network Subgraph',
+      })
       .option('index-node-ids', {
         description:
           'Node IDs of Graph nodes to use for indexing (separated by commas)',
@@ -729,6 +735,7 @@ export default {
       indexer,
       network,
       networkSubgraph,
+      allocateOnNetworkSubgraph: argv.allocateOnNetworkSubgraph,
       registerIndexer: argv.register,
       offchainSubgraphs: argv.offchainSubgraphs.map(
         (s: string) => new SubgraphDeploymentID(s),

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -10,6 +10,7 @@ export interface AgentConfig {
   indexer: Indexer
   network: Network
   networkSubgraph: NetworkSubgraph
+  allocateOnNetworkSubgraph: boolean
   registerIndexer: boolean
   offchainSubgraphs: SubgraphDeploymentID[]
   receiptCollector: ReceiptCollector


### PR DESCRIPTION
Adds an override to allow allocations to the network subgraph. This is useful for the local testing environment.