### PR TITLE
indexer-agent: Add logging for indexing rule fetching and matching

### DIFF
--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -235,7 +235,20 @@ export class Indexer {
       if (result.error) {
         throw result.error
       }
-
+      this.logger.debug(
+        'Fetched indexing rules',
+        {
+          count: result.data.indexingRules.length,
+          rules: result.data.indexingRules.map(
+            (rule: IndexingRuleAttributes) => {
+              return {
+                identifier: rule.deployment,
+                decisionBasis: rule.decisionBasis,
+              }
+            },
+          ),
+        },
+      )
       return result.data.indexingRules
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE025, error)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -488,7 +488,7 @@ export class Network {
     )
 
     while (!queryProgress.exhausted) {
-      this.logger.debug(`Query subgraph deployments`, {
+      this.logger.trace(`Query subgraph deployments`, {
         queryProgress: queryProgress,
       })
       try {
@@ -524,6 +524,7 @@ export class Network {
 
         // In the case of a fresh graph network there will be no published subgraphs, handle gracefully
         if (results.length == 0) {
+          this.logger.warn('No subgraph deployments returned')
           return []
         }
 
@@ -637,6 +638,10 @@ export class Network {
       }
     }
 
+    this.logger.debug(`Fetched subgraph deployments published to network`, {
+      publishedSubgraphs: queryProgress.fetched,
+      worthIndexing: deployments.length,
+    })
     return deployments
   }
 


### PR DESCRIPTION
Improved logging around fetching indexing rules from the Indexer Management endpoint and matching them with subgraph deployments fetched from the subgraph. 

Added to help debug when there are issues with fetching subgraphDeployments published to the network, fetching indexer rules, or matching the deployments to their corresponding rules.

