### PR TITLE
indexer-agent:  Fix subgraph deployments batch query processing

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -597,7 +597,7 @@ class Agent {
               allocation.subgraphDeployment.id.bytes32 === deployment.bytes32,
           ),
 
-          // Whether the deployment is worth indexing
+          // Whether the deployment is worth allocating towards
           targetDeployments.find(
             target => target.bytes32 === deployment.bytes32,
           ) !== undefined,
@@ -618,7 +618,7 @@ class Agent {
   async reconcileDeploymentAllocations(
     deployment: SubgraphDeploymentID,
     activeAllocations: Allocation[],
-    worthIndexing: boolean,
+    worthAllocating: boolean,
     rule: IndexingRuleAttributes | undefined,
     epoch: number,
     epochStartBlock: BlockPointer,
@@ -652,12 +652,14 @@ class Agent {
         createdAtEpoch: allocation.createdAtEpoch,
         amount: formatGRT(allocation.allocatedTokens),
       })),
+
+      worthAllocating,
     })
 
-    // Return early if the deployment is not (or no longer) worth indexing
-    if (!worthIndexing) {
+    // Return early if the deployment is not (or no longer) worth allocating towards
+    if (!worthAllocating) {
       logger.info(
-        `Deployment is not (or no longer) worth indexing, close all active allocations that are at least one epoch old`,
+        `Deployment is not (or no longer) worth allocating towards, close all active allocations that are at least one epoch old`,
         {
           activeAllocations: activeAllocations.map(allocation => allocation.id),
           eligibleForClose: activeAllocations

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -235,20 +235,15 @@ export class Indexer {
       if (result.error) {
         throw result.error
       }
-      this.logger.debug(
-        'Fetched indexing rules',
-        {
-          count: result.data.indexingRules.length,
-          rules: result.data.indexingRules.map(
-            (rule: IndexingRuleAttributes) => {
-              return {
-                identifier: rule.deployment,
-                decisionBasis: rule.decisionBasis,
-              }
-            },
-          ),
-        },
-      )
+      this.logger.debug('Fetched indexing rules', {
+        count: result.data.indexingRules.length,
+        rules: result.data.indexingRules.map((rule: IndexingRuleAttributes) => {
+          return {
+            identifier: rule.deployment,
+            decisionBasis: rule.decisionBasis,
+          }
+        }),
+      })
       return result.data.indexingRules
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE025, error)


### PR DESCRIPTION
Important updates to `network.subgraphDeploymentsWorthIndexing()`:
- Fix bug that led to false empty result returned from `subgraphsWorthIndexing()`.
- If subgraph deployments query returns empty array throw error instead of gracefully returning an empty array.
- Pass error message to IndexerError.cause.

Small improvements to `reconcileDeploymentAllocations()`:
- Update naming  to be more clear: `worthIndexing` --> `worthAllocating`.