### PR TITLE
Upgrade node runtime image versions

### DIFF
--- a/Dockerfile.indexer-agent
+++ b/Dockerfile.indexer-agent
@@ -29,7 +29,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:12.16.0-slim
+FROM node:16.13.1-slim
 
 ENV NODE_ENV production
 

--- a/Dockerfile.indexer-cli
+++ b/Dockerfile.indexer-cli
@@ -29,7 +29,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:14.15.4-slim
+FROM node:16.13.1-slim
 
 ENV NODE_ENV production
 

--- a/Dockerfile.indexer-service
+++ b/Dockerfile.indexer-service
@@ -30,7 +30,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:12.16.0-slim
+FROM node:16.13.1-slim
 
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "dependencies": {
     "scrypt": "https://registry.yarnpkg.com/@favware/skip-dependency/-/skip-dependency-1.0.2.tgz"
+  },
+  "engines": {
+    "node": ">=12.22.0"
   }
 }


### PR DESCRIPTION
- Update runtime image versions since `graphql@16.2.0` requires node >= 12.22.0 (recommend ^v16.0.0). 
- Specify engine in package.json to improve handling of node runtime version too low.
