### PR TITLE
indexer-agent: Batched voucher redemptions

### DIFF
--- a/Dockerfile.indexer-agent
+++ b/Dockerfile.indexer-agent
@@ -32,6 +32,11 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 FROM node:16.13.1-slim
 
 ENV NODE_ENV production
+# When simulating large transactions, sometimes indexer-agent runs out of memory.
+# This flag seems force node into GC earlier, preventing the crash
+# 1536mb is 1.5GB, which is appropriate for an environment with 2GB RAM
+ENV NODE_OPTIONS="--max-old-space-size=1536"
+
 
 RUN apt-get update && apt-get install -y python build-essential git curl
 

--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added automatic batching of query voucher redemptions
+- Added `--voucher-redemption-threshold`, `--voucher-redemption-batch-threshold` and `--voucher-redemption-max-batch-size` for controlling voucher batching behaviour
+
+### Fixed
+- Added `--rebate-claim-max-batch-size` to make max batch size configurable. For users in low-RAM environments, the primary constraint is not block space but the RAM required to construct large transactions.
+- Improved validation of rebate batch claim parameters
+
+
 ## [0.18.6] - 2021-12-23
 ### Fixed
 - Fix subgraphDeploymentsWorthIndexing batch query mangagement

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -457,7 +457,7 @@ export default {
       )
     }
 
-    if (argv.voucherClaimThreshold.eq(0)) {
+    if (argv.voucherRedemptionThreshold.eq(0)) {
       logger.warn(
         `Minimum voucher redemption value is 0 GRT, which may lead to redeeming unprofitable vouchers`,
       )

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -228,7 +228,7 @@ export default {
       .option('rebate-claim-max-batch-size', {
         description: `Maximum number of rebates inside a batch. Upper bound is constrained by available system memory, and by the block gas limit.`,
         type: 'number',
-        default: 80, // TODO justify reduction in docs
+        default: 100,
         group: 'Indexer Infrastructure',
       })
       .option('voucher-redemption-threshold', {
@@ -248,7 +248,7 @@ export default {
       .option('voucher-redemption-max-batch-size', {
         description: `Maximum number of rebates inside a batch. Upper bound is constrained by available system memory, and by the block gas limit.`,
         type: 'number',
-        default: 80, // TODO what is the right number here?
+        default: 100,
         group: 'Indexer Infrastructure',
       })
       .option('inject-dai', {
@@ -460,7 +460,6 @@ export default {
       )
     }
 
-    // TODO add batch size checks for voucher redemptions
     if (argv.voucherRedemptionMaxBatchSize > 200) {
       logger.warn(
         `Setting the max batch size for voucher redemptions to more than 200 may result in batches that are too large to fit into a block`,

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -181,7 +181,7 @@ export default {
         default: '0.01',
         required: false,
         group: 'Protocol',
-        coerce: (arg) => parseGRT(arg),
+        coerce: arg => parseGRT(arg),
       })
       .option('indexer-management-port', {
         description: 'Port to serve the indexer management API at',
@@ -216,14 +216,14 @@ export default {
         type: 'string',
         default: '200', // This value (the marginal gain of a claim in GRT), should always exceed the marginal cost of a claim (in ETH gas)
         group: 'Indexer Infrastructure',
-        coerce: (arg) => parseGRT(arg),
+        coerce: arg => parseGRT(arg),
       })
       .option('rebate-claim-batch-threshold', {
         description: `Minimum total value of all rebates in an batch (in GRT) before the batch is claimed on-chain`,
         type: 'string',
         default: '2000',
         group: 'Indexer Infrastructure',
-        coerce: (arg) => parseGRT(arg),
+        coerce: arg => parseGRT(arg),
       })
       .option('rebate-claim-max-batch-size', {
         description: `Maximum number of rebates inside a batch. Upper bound is constrained by available system memory, and by the block gas limit.`,
@@ -236,14 +236,14 @@ export default {
         type: 'string',
         default: '200', // This value (the marginal gain of a claim in GRT), should always exceed the marginal cost of a claim (in ETH gas)
         group: 'Indexer Infrastructure',
-        coerce: (arg) => parseGRT(arg),
+        coerce: arg => parseGRT(arg),
       })
       .option('voucher-redemption-batch-threshold', {
         description: `Minimum total value of all rebates in an batch (in GRT) before the batch is claimed on-chain`,
         type: 'string',
         default: '2000',
         group: 'Indexer Infrastructure',
-        coerce: (arg) => parseGRT(arg),
+        coerce: arg => parseGRT(arg),
       })
       .option('voucher-redemption-max-batch-size', {
         description: `Maximum number of rebates inside a batch. Upper bound is constrained by available system memory, and by the block gas limit.`,
@@ -358,7 +358,10 @@ export default {
         if (argv['gas-increase-factor'] <= 1.0) {
           return 'Invalid --gas-increase-factor provided. Must be > 1.0'
         }
-        if (!Number.isInteger(argv['rebate-claim-max-batch-size']) || argv['rebate-claim-max-batch-size'] <= 0) {
+        if (
+          !Number.isInteger(argv['rebate-claim-max-batch-size']) ||
+          argv['rebate-claim-max-batch-size'] <= 0
+        ) {
           return 'Invalid --rebate-claim-max-batch-size provided. Must be > 0 and an integer.'
         }
         return true

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -222,6 +222,12 @@ export default {
         default: '2000',
         group: 'Indexer Infrastructure',
       })
+      .option('rebate-claim-max-batch-size', {
+        description: `Maximum number of rebates inside a batch. Upper bound is constrained by available system memory, and by the block gas limit.`,
+        type: 'number',
+        default: 80,
+        group: 'Indexer Infrastructure',
+      })
       .option('inject-dai', {
         description:
           'Inject the GRT to DAI/USDC conversion rate into cost model variables',
@@ -328,6 +334,9 @@ export default {
         }
         if (argv['gas-increase-factor'] <= 1.0) {
           return 'Invalid --gas-increase-factor provided. Must be > 1.0'
+        }
+        if (!Number.isInteger(argv['rebate-claim-max-batch-size']) || argv['rebate-claim-max-batch-size'] <= 0) {
+          return 'Invalid --rebate-claim-max-batch-size provided. Must be > 0 and an integer.'
         }
         return true
       })
@@ -688,6 +697,7 @@ export default {
       argv.restakeRewards,
       parseGRT(argv.rebateClaimThreshold),
       parseGRT(argv.rebateClaimBatchThreshold),
+      argv.rebateClaimMaxBatchSize,
       argv.poiDisputeMonitoring,
       argv.poiDisputableEpochs,
       argv.gasIncreaseTimeout,

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -80,8 +80,8 @@ export class Network {
   paused: Eventual<boolean>
   isOperator: Eventual<boolean>
   restakeRewards: boolean
-  rebateClaimMinSingleValue: BigNumber
-  rebateClaimMinBatchValue: BigNumber
+  rebateClaimThreshold: BigNumber
+  rebateClaimBatchThreshold: BigNumber
   rebateClaimMaxBatchSize: number
   poiDisputeMonitoring: boolean
   poiDisputableEpochs: number
@@ -102,8 +102,8 @@ export class Network {
     paused: Eventual<boolean>,
     isOperator: Eventual<boolean>,
     restakeRewards: boolean,
-    rebateClaimMinSingleValue: BigNumber,
-    rebateClaimMinBatchValue: BigNumber,
+    rebateClaimThreshold: BigNumber,
+    rebateClaimBatchThreshold: BigNumber,
     rebateClaimMaxBatchSize: number,
     poiDisputeMonitoring: boolean,
     poiDisputableEpochs: number,
@@ -123,8 +123,8 @@ export class Network {
     this.paused = paused
     this.isOperator = isOperator
     this.restakeRewards = restakeRewards
-    this.rebateClaimMinSingleValue = rebateClaimMinSingleValue
-    this.rebateClaimMinBatchValue = rebateClaimMinBatchValue
+    this.rebateClaimThreshold = rebateClaimThreshold
+    this.rebateClaimBatchThreshold = rebateClaimBatchThreshold
     this.rebateClaimMaxBatchSize = rebateClaimMaxBatchSize
     this.poiDisputeMonitoring = poiDisputeMonitoring
     this.poiDisputableEpochs = poiDisputableEpochs
@@ -424,8 +424,8 @@ export class Network {
     geoCoordinates: [string, string],
     networkSubgraph: NetworkSubgraph,
     restakeRewards: boolean,
-    rebateClaimMinSingleValue: BigNumber,
-    rebateClaimMinBatchValue: BigNumber,
+    rebateClaimThreshold: BigNumber,
+    rebateClaimBatchThreshold: BigNumber,
     rebateClaimMaxBatchSize: number,
     poiDisputeMonitoring: boolean,
     poiDisputableEpochs: number,
@@ -464,8 +464,8 @@ export class Network {
       paused,
       isOperator,
       restakeRewards,
-      rebateClaimMinSingleValue,
-      rebateClaimMinBatchValue,
+      rebateClaimThreshold,
+      rebateClaimBatchThreshold,
       rebateClaimMaxBatchSize,
       poiDisputeMonitoring,
       poiDisputableEpochs,
@@ -926,7 +926,7 @@ export class Network {
         {
           indexer: this.indexerAddress.toLocaleLowerCase(),
           disputableEpoch,
-          minimumQueryFeesCollected: this.rebateClaimMinSingleValue.toString(),
+          minimumQueryFeesCollected: this.rebateClaimThreshold.toString(),
         },
       )
 
@@ -948,13 +948,15 @@ export class Network {
       // If the total fees claimable do not meet the minimum required for batching, return an empty array
       if (
         parsedAllocs.length > 0 &&
-        totalFees.lt(this.rebateClaimMinBatchValue)
+        totalFees.lt(this.rebateClaimBatchThreshold)
       ) {
         this.logger.info(
           `Allocation rebate batch value does not meet minimum for claiming`,
           {
-            totalBatchFees: formatGRT(totalFees),
-            minBatchFees: formatGRT(this.rebateClaimMinBatchValue),
+            batchValueGRT: formatGRT(totalFees),
+            rebateClaimBatchThreshold: formatGRT(this.rebateClaimBatchThreshold),
+            rebateClaimMaxBatchSize: this.rebateClaimMaxBatchSize,
+            batchSize: parsedAllocs.length,
             allocations: parsedAllocs.map(allocation => {
               return {
                 allocation: allocation.id,

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -82,6 +82,7 @@ export class Network {
   restakeRewards: boolean
   rebateClaimMinSingleValue: BigNumber
   rebateClaimMinBatchValue: BigNumber
+  rebateClaimMaxBatchSize: number
   poiDisputeMonitoring: boolean
   poiDisputableEpochs: number
   gasIncreaseTimeout: number
@@ -103,6 +104,7 @@ export class Network {
     restakeRewards: boolean,
     rebateClaimMinSingleValue: BigNumber,
     rebateClaimMinBatchValue: BigNumber,
+    rebateClaimMaxBatchSize: number,
     poiDisputeMonitoring: boolean,
     poiDisputableEpochs: number,
     gasIncreaseTimeout: number,
@@ -123,6 +125,7 @@ export class Network {
     this.restakeRewards = restakeRewards
     this.rebateClaimMinSingleValue = rebateClaimMinSingleValue
     this.rebateClaimMinBatchValue = rebateClaimMinBatchValue
+    this.rebateClaimMaxBatchSize = rebateClaimMaxBatchSize
     this.poiDisputeMonitoring = poiDisputeMonitoring
     this.poiDisputableEpochs = poiDisputableEpochs
     this.gasIncreaseTimeout = gasIncreaseTimeout
@@ -423,6 +426,7 @@ export class Network {
     restakeRewards: boolean,
     rebateClaimMinSingleValue: BigNumber,
     rebateClaimMinBatchValue: BigNumber,
+    rebateClaimMaxBatchSize: number,
     poiDisputeMonitoring: boolean,
     poiDisputableEpochs: number,
     gasIncreaseTimeout: number,
@@ -462,6 +466,7 @@ export class Network {
       restakeRewards,
       rebateClaimMinSingleValue,
       rebateClaimMinBatchValue,
+      rebateClaimMaxBatchSize,
       poiDisputeMonitoring,
       poiDisputableEpochs,
       gasIncreaseTimeout,
@@ -1501,12 +1506,13 @@ export class Network {
 
       // Max claims per batch should roughly be equal to average gas per claim / block gas limit
       // On-chain data shows an average of 120k gas per claim and the block gas limit is 15M
-      // If we add a 30k gas buffer (for 150k estimated gas per claim)
-      // Then we could fit a maximum of a 100 claim batch in a block
-      const MAX_CLAIMS_PER_BATCH = 100
+      // We get at least 21k gas savings per inclusion of a claim in a batch
+      // A reasonable upper bound for this value is 200 assuming the system has the memory
+      // requirements to construct the transaction
+      const maxClaimsPerBatch = this.rebateClaimMaxBatchSize
       const allocationIds = allocations
         .map(allocation => allocation.id)
-        .slice(0, MAX_CLAIMS_PER_BATCH)
+        .slice(0, maxClaimsPerBatch)
 
       if (allocationIds.length === 0) {
         logger.info(`No allocation rebates to claim`)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1511,7 +1511,8 @@ export class Network {
       // requirements to construct the transaction
       const maxClaimsPerBatch = this.rebateClaimMaxBatchSize
       const allocationIds = allocations
-        .map(allocation => allocation.id) // TODO add sorting by allocation value
+        .sort((x, y) => y.queryFeesCollected.sub(x.queryFeesCollected)) // sort desc by query fee development
+        .map(allocation => allocation.id)
         .slice(0, maxClaimsPerBatch)
 
       if (allocationIds.length === 0) {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1511,7 +1511,7 @@ export class Network {
       // requirements to construct the transaction
       const maxClaimsPerBatch = this.rebateClaimMaxBatchSize
       const allocationIds = allocations
-        .sort((x, y) => y.queryFeesCollected.sub(x.queryFeesCollected)) // sort desc by query fee development
+        .sort((x, y) => (y.queryFeesCollected?.gt(x.queryFeesCollected || 0)? 0 : -1)) // sort desc by query fee development
         .map(allocation => allocation.id)
         .slice(0, maxClaimsPerBatch)
 

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1520,7 +1520,7 @@ export class Network {
       // more query fees collected should mean higher value rebates
       const allocationIds = allocations
         .sort((x, y) =>
-          y.queryFeesCollected?.gt(x.queryFeesCollected || 0) ? 0 : -1,
+          y.queryFeesCollected?.gt(x.queryFeesCollected || 0) ? 1 : -1,
         )
         .map(allocation => allocation.id)
         .slice(0, maxClaimsPerBatch)

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -954,7 +954,9 @@ export class Network {
           `Allocation rebate batch value does not meet minimum for claiming`,
           {
             batchValueGRT: formatGRT(totalFees),
-            rebateClaimBatchThreshold: formatGRT(this.rebateClaimBatchThreshold),
+            rebateClaimBatchThreshold: formatGRT(
+              this.rebateClaimBatchThreshold,
+            ),
             rebateClaimMaxBatchSize: this.rebateClaimMaxBatchSize,
             batchSize: parsedAllocs.length,
             allocations: parsedAllocs.map(allocation => {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1515,7 +1515,9 @@ export class Network {
       // in order to maximise the value of the truncated batch
       // more query fees collected should mean higher value rebates
       const allocationIds = allocations
-        .sort((x, y) => (y.queryFeesCollected?.gt(x.queryFeesCollected || 0)? 0 : -1))
+        .sort((x, y) =>
+          y.queryFeesCollected?.gt(x.queryFeesCollected || 0) ? 0 : -1,
+        )
         .map(allocation => allocation.id)
         .slice(0, maxClaimsPerBatch)
 

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1511,7 +1511,7 @@ export class Network {
       // requirements to construct the transaction
       const maxClaimsPerBatch = this.rebateClaimMaxBatchSize
       const allocationIds = allocations
-        .map(allocation => allocation.id)
+        .map(allocation => allocation.id) // TODO add sorting by allocation value
         .slice(0, maxClaimsPerBatch)
 
       if (allocationIds.length === 0) {

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1510,8 +1510,12 @@ export class Network {
       // A reasonable upper bound for this value is 200 assuming the system has the memory
       // requirements to construct the transaction
       const maxClaimsPerBatch = this.rebateClaimMaxBatchSize
+
+      // When we construct the batch, we sort desc by query fees collected
+      // in order to maximise the value of the truncated batch
+      // more query fees collected should mean higher value rebates
       const allocationIds = allocations
-        .sort((x, y) => (y.queryFeesCollected?.gt(x.queryFeesCollected || 0)? 0 : -1)) // sort desc by query fee development
+        .sort((x, y) => (y.queryFeesCollected?.gt(x.queryFeesCollected || 0)? 0 : -1))
         .map(allocation => allocation.id)
         .slice(0, maxClaimsPerBatch)
 

--- a/packages/indexer-agent/src/query-fees/allocation-exchange.ts
+++ b/packages/indexer-agent/src/query-fees/allocation-exchange.ts
@@ -1,57 +1,7 @@
 import { Address } from '@graphprotocol/common-ts'
 import { Contract, Signer } from 'ethers'
 
-const ABI = [
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address',
-      },
-    ],
-    name: 'allocationsRedeemed',
-    outputs: [
-      {
-        internalType: 'bool',
-        name: '',
-        type: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [
-      {
-        components: [
-          {
-            internalType: 'address',
-            name: 'allocationID',
-            type: 'address',
-          },
-          {
-            internalType: 'uint256',
-            name: 'amount',
-            type: 'uint256',
-          },
-          {
-            internalType: 'bytes',
-            name: 'signature',
-            type: 'bytes',
-          },
-        ],
-        internalType: 'struct AllocationExchange.AllocationVoucher',
-        name: '_voucher',
-        type: 'tuple',
-      },
-    ],
-    name: 'redeem',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-]
+const ABI = [{"inputs":[{"internalType":"contract IGraphToken","name":"_graphToken","type":"address"},{"internalType":"contract IStaking","name":"_staking","type":"address"},{"internalType":"address","name":"_governor","type":"address"},{"internalType":"address","name":"_authority","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"allocationID","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"AllocationRedeemed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"account","type":"address"}],"name":"AuthoritySet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"NewOwnership","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"NewPendingOwnership","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"to","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"TokensWithdrawn","type":"event"},{"inputs":[],"name":"acceptOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"allocationsRedeemed","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"approveAll","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"authority","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"governor","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pendingGovernor","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"allocationID","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"struct AllocationExchange.AllocationVoucher","name":"_voucher","type":"tuple"}],"name":"redeem","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"allocationID","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"struct AllocationExchange.AllocationVoucher[]","name":"_vouchers","type":"tuple[]"}],"name":"redeemMany","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_authority","type":"address"}],"name":"setAuthority","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_newGovernor","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_to","type":"address"},{"internalType":"uint256","name":"_amount","type":"uint256"}],"name":"withdraw","outputs":[],"stateMutability":"nonpayable","type":"function"}]
 
 export const bindAllocationExchangeContract = (
   signer: Signer,

--- a/packages/indexer-agent/src/query-fees/allocation-exchange.ts
+++ b/packages/indexer-agent/src/query-fees/allocation-exchange.ts
@@ -1,7 +1,190 @@
 import { Address } from '@graphprotocol/common-ts'
 import { Contract, Signer } from 'ethers'
 
-const ABI = [{"inputs":[{"internalType":"contract IGraphToken","name":"_graphToken","type":"address"},{"internalType":"contract IStaking","name":"_staking","type":"address"},{"internalType":"address","name":"_governor","type":"address"},{"internalType":"address","name":"_authority","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"allocationID","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"AllocationRedeemed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"account","type":"address"}],"name":"AuthoritySet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"NewOwnership","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"NewPendingOwnership","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"to","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"TokensWithdrawn","type":"event"},{"inputs":[],"name":"acceptOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"allocationsRedeemed","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"approveAll","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"authority","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"governor","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pendingGovernor","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"allocationID","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"struct AllocationExchange.AllocationVoucher","name":"_voucher","type":"tuple"}],"name":"redeem","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"allocationID","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"signature","type":"bytes"}],"internalType":"struct AllocationExchange.AllocationVoucher[]","name":"_vouchers","type":"tuple[]"}],"name":"redeemMany","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_authority","type":"address"}],"name":"setAuthority","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_newGovernor","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_to","type":"address"},{"internalType":"uint256","name":"_amount","type":"uint256"}],"name":"withdraw","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+const ABI = [
+  {
+    inputs: [
+      {
+        internalType: 'contract IGraphToken',
+        name: '_graphToken',
+        type: 'address',
+      },
+      { internalType: 'contract IStaking', name: '_staking', type: 'address' },
+      { internalType: 'address', name: '_governor', type: 'address' },
+      { internalType: 'address', name: '_authority', type: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'allocationID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'AllocationRedeemed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'AuthoritySet',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'from', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'to', type: 'address' },
+    ],
+    name: 'NewOwnership',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'from', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'to', type: 'address' },
+    ],
+    name: 'NewPendingOwnership',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'to', type: 'address' },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'TokensWithdrawn',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'acceptOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'allocationsRedeemed',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'approveAll',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'authority',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'governor',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pendingGovernor',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'allocationID', type: 'address' },
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct AllocationExchange.AllocationVoucher',
+        name: '_voucher',
+        type: 'tuple',
+      },
+    ],
+    name: 'redeem',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'allocationID', type: 'address' },
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct AllocationExchange.AllocationVoucher[]',
+        name: '_vouchers',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'redeemMany',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: '_authority', type: 'address' }],
+    name: 'setAuthority',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: '_newGovernor', type: 'address' },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: '_to', type: 'address' },
+      { internalType: 'uint256', name: '_amount', type: 'uint256' },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]
 
 export const bindAllocationExchangeContract = (
   signer: Signer,

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -274,7 +274,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(`Query voucher batch is ready for redemption`, {
           batchSize: voucherBatch.length,
           voucherRedemptionMaxBatchSize: this.voucherRedemptionMaxBatchSize,
-          voucherRedemptionBatchThreshold: this.voucherRedemptionBatchThreshold,
+          voucherRedemptionBatchThreshold: formatGRT(this.voucherRedemptionBatchThreshold),
           batchValueGRT: formatGRT(batchValueGRT),
         })
         await this.submitVouchers(voucherBatch)
@@ -282,7 +282,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(`Query voucher batch value too low for redemption`, {
           batchSize: voucherBatch.length,
           voucherRedemptionMaxBatchSize: this.voucherRedemptionMaxBatchSize,
-          voucherRedemptionBatchThreshold: this.voucherRedemptionBatchThreshold,
+          voucherRedemptionBatchThreshold: formatGRT(this.voucherRedemptionBatchThreshold),
           batchValueGRT: formatGRT(batchValueGRT),
         })
       }

--- a/packages/indexer-agent/src/query-fees/allocations.ts
+++ b/packages/indexer-agent/src/query-fees/allocations.ts
@@ -261,6 +261,9 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         })
       }
 
+      // If there are no eligible vouchers then bail
+      if (vouchers.eligible.length === 0) return
+
       const voucherBatch = vouchers.eligible.slice(
           0,
           this.voucherRedemptionMaxBatchSize,
@@ -274,7 +277,9 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(`Query voucher batch is ready for redemption`, {
           batchSize: voucherBatch.length,
           voucherRedemptionMaxBatchSize: this.voucherRedemptionMaxBatchSize,
-          voucherRedemptionBatchThreshold: formatGRT(this.voucherRedemptionBatchThreshold),
+          voucherRedemptionBatchThreshold: formatGRT(
+            this.voucherRedemptionBatchThreshold,
+          ),
           batchValueGRT: formatGRT(batchValueGRT),
         })
         await this.submitVouchers(voucherBatch)
@@ -282,7 +287,9 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         logger.info(`Query voucher batch value too low for redemption`, {
           batchSize: voucherBatch.length,
           voucherRedemptionMaxBatchSize: this.voucherRedemptionMaxBatchSize,
-          voucherRedemptionBatchThreshold: formatGRT(this.voucherRedemptionBatchThreshold),
+          voucherRedemptionBatchThreshold: formatGRT(
+            this.voucherRedemptionBatchThreshold,
+          ),
           batchValueGRT: formatGRT(batchValueGRT),
         })
       }

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -22,6 +22,7 @@ export interface Allocation {
   closedAtBlockHash: string
   poi: string | undefined
   queryFeeRebates: BigNumber | undefined
+  queryFeesCollected: BigNumber | undefined
 }
 
 export enum AllocationStatus {
@@ -51,6 +52,7 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
   closedAtBlockHash: allocation.closedAtBlockHash,
   poi: allocation.poi,
   queryFeeRebates: allocation.queryFeeRebates,
+  queryFeesCollected: allocation.queryFeesCollected,
 })
 
 export interface RewardsPool {


### PR DESCRIPTION
### New features
- Added automatic batching of query voucher redemptions
- Added `--voucher-redemption-threshold`, `--voucher-redemption-batch-threshold` and `--voucher-redemption-max-batch-size` for controlling voucher batching behaviour

### Cleanup/fixes
- Sets `NODE_OPTIONS="--max-old-space-size=1536"` by default for the `indexer-agent` Docker container. This is appropriate for an environment with 2GB of RAM.
- Added `--rebate-claim-max-batch-size` to make max rebate claim batch size configurable.
- Move `parseGRT` for GRT-value flags into yargs coersion to standardise the location of flag transforms
- Improved validation of rebate batch claim parameters