### PR TITLE
indexer-agent, indexer-common: Add live metric for operator ETH balance

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -32,6 +32,7 @@ import { startCostModelAutomation } from '../cost'
 import { bindAllocationExchangeContract } from '../query-fees'
 import { AllocationReceiptCollector } from '../query-fees/allocations'
 import { createSyncingServer } from '../syncing-server'
+import { monitorEthBalance } from '../utils'
 
 export default {
   command: 'start',
@@ -686,6 +687,9 @@ export default {
     logger.info('Successfully connected to network', {
       restakeRewards: argv.restakeRewards,
     })
+
+    // Monitor ETH balance of the operator and write the latest value to a metric
+    await monitorEthBalance(logger, wallet, metrics)
 
     logger.info(`Launch syncing server`)
     await createSyncingServer({

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -41,6 +41,7 @@ import geohash from 'ngeohash'
 import delay from 'delay'
 import pFilter from 'p-filter'
 import pRetry from 'p-retry'
+import { formatEther } from 'ethers/lib/utils'
 
 const allocationIdProof = (
   signer: Signer,

--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -41,7 +41,6 @@ import geohash from 'ngeohash'
 import delay from 'delay'
 import pFilter from 'p-filter'
 import pRetry from 'p-retry'
-import { formatEther } from 'ethers/lib/utils'
 
 const allocationIdProof = (
   signer: Signer,

--- a/packages/indexer-agent/src/utils/balance-monitor.ts
+++ b/packages/indexer-agent/src/utils/balance-monitor.ts
@@ -16,7 +16,7 @@ export async function monitorEthBalance(
   wallet: Wallet,
   metrics: Metrics,
 ): Promise<void> {
-  const logger = logger.child({ component: 'ETHBalanceMonitor' })
+  logger = logger.child({ component: 'ETHBalanceMonitor' })
 
   logger.info('Monitor operator ETH balance (refreshes every 120s)')
 

--- a/packages/indexer-agent/src/utils/balance-monitor.ts
+++ b/packages/indexer-agent/src/utils/balance-monitor.ts
@@ -16,6 +16,8 @@ export async function monitorEthBalance(
   wallet: Wallet,
   metrics: Metrics,
 ): Promise<void> {
+  const logger = logger.child({ component: 'ETHBalanceMonitor' })
+
   logger.info('Monitor operator ETH balance (refreshes every 120s)')
 
   const balanceMetrics = registerMetrics(metrics)
@@ -25,6 +27,9 @@ export async function monitorEthBalance(
       const balance = await wallet.getBalance()
       const eth = parseFloat(utils.formatEther(balance))
       balanceMetrics.operatorEthBalance.set(eth)
+      logger.info('Current operator ETH balance', {
+        balance: eth,
+      })
     } catch (error) {
       logger.warn(`Failed to check latest ETH balance`, {
         err: indexerError(IndexerErrorCode.IE059),

--- a/packages/indexer-agent/src/utils/balance-monitor.ts
+++ b/packages/indexer-agent/src/utils/balance-monitor.ts
@@ -6,7 +6,7 @@ import { indexerError, IndexerErrorCode } from '@graphprotocol/indexer-common'
 const registerMetrics = (metrics: Metrics) => ({
   operatorEthBalance: new metrics.client.Gauge({
     name: 'indexer_agent_operator_eth_balance',
-    help: 'Amount of ETH in the operatow wallet; a low amount could cause transactions to fail',
+    help: 'Amount of ETH in the operator wallet; a low amount could cause transactions to fail',
     registers: [metrics.registry],
   }),
 })

--- a/packages/indexer-agent/src/utils/balance-monitor.ts
+++ b/packages/indexer-agent/src/utils/balance-monitor.ts
@@ -1,14 +1,9 @@
-import { Gauge } from 'prom-client'
 import { Wallet, utils } from 'ethers'
 
 import { Logger, Metrics, timer } from '@graphprotocol/common-ts'
 import { indexerError, IndexerErrorCode } from '@graphprotocol/indexer-common'
 
-interface EthBalanceMetrics {
-  operatorEthBalance: Gauge<string>
-}
-
-const registerMetrics = (metrics: Metrics): EthBalanceMetrics => ({
+const registerMetrics = (metrics: Metrics) => ({
   operatorEthBalance: new metrics.client.Gauge({
     name: 'indexer_agent_operator_eth_balance',
     help: 'Amount of ETH in the operatow wallet; a low amount could cause transactions to fail',

--- a/packages/indexer-agent/src/utils/balance-monitor.ts
+++ b/packages/indexer-agent/src/utils/balance-monitor.ts
@@ -1,0 +1,39 @@
+import { Gauge } from 'prom-client'
+import { Wallet, utils } from 'ethers'
+
+import { Logger, Metrics, timer } from '@graphprotocol/common-ts'
+import { indexerError, IndexerErrorCode } from '@graphprotocol/indexer-common'
+
+interface EthBalanceMetrics {
+  operatorEthBalance: Gauge<string>
+}
+
+const registerMetrics = (metrics: Metrics): EthBalanceMetrics => ({
+  operatorEthBalance: new metrics.client.Gauge({
+    name: 'indexer_agent_operator_eth_balance',
+    help: 'Amount of ETH in the operatow wallet; a low amount could cause transactions to fail',
+    registers: [metrics.registry],
+  }),
+})
+
+export async function monitorEthBalance(
+  logger: Logger,
+  wallet: Wallet,
+  metrics: Metrics,
+): Promise<void> {
+  logger.info('Monitor operator ETH balance (refreshes every 120s)')
+
+  const balanceMetrics = registerMetrics(metrics)
+
+  timer(120_000).pipe(async () => {
+    try {
+      const balance = await wallet.getBalance()
+      const eth = parseFloat(utils.formatEther(balance))
+      balanceMetrics.operatorEthBalance.set(eth)
+    } catch (error) {
+      logger.warn(`Failed to check latest ETH balance`, {
+        err: indexerError(IndexerErrorCode.IE059),
+      })
+    }
+  })
+}

--- a/packages/indexer-agent/src/utils/index.ts
+++ b/packages/indexer-agent/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './balance-monitor'

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -69,6 +69,7 @@ export enum IndexerErrorCode {
   IE056 = 'IE056',
   IE057 = 'IE057',
   IE058 = 'IE058',
+  IE059 = 'IE059',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -130,6 +131,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE056: 'Failed to remember allocation for collecting receipts later',
   IE057: 'Transaction reverted due to failing assertion in contract',
   IE058: 'Transaction failed because nonce has already been used',
+  IE059: 'Failed to check latest operator ETH balance',
 }
 
 export type IndexerErrorCause = unknown


### PR DESCRIPTION
This is refreshed every 2 minutes and can be used by indexers to set up alerting for when their operator is running out of ETH to make transactions.