### PR TITLE
Fix indexing status query used for health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.16]
+        node-version: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -3,9 +3,11 @@ name: Indexer Agent Image
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - v*.*.*
+      - v*.*.*
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.indexer-agent
-          push: ${{github.event_name != 'pull_request'}}
+          # Enabling the line below restricts Docker images to only be built for branches
+          # push: ${{github.event_name != 'pull_request'}}
+          push: true
           tags: ${{steps.docker_meta.outputs.tags}}
           labels: ${{steps.docker_meta.outputs.labels}}
           build-args: NPM_TOKEN=${{secrets.graphprotocol_npm_token}}

--- a/.github/workflows/indexer-cli-image.yml
+++ b/.github/workflows/indexer-cli-image.yml
@@ -3,9 +3,11 @@ name: Indexer CLI Image
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - v*.*.*
+      - v*.*.*
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/indexer-cli-image.yml
+++ b/.github/workflows/indexer-cli-image.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.indexer-cli
-          push: ${{github.event_name != 'pull_request'}}
+          # Enabling the line below restricts Docker images to only be built for branches
+          # push: ${{github.event_name != 'pull_request'}}
+          push: true
           tags: ${{steps.docker_meta.outputs.tags}}
           labels: ${{steps.docker_meta.outputs.labels}}
           build-args: NPM_TOKEN=${{secrets.graphprotocol_npm_token}}

--- a/.github/workflows/indexer-service-image.yml
+++ b/.github/workflows/indexer-service-image.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           context: .
           file: Dockerfile.indexer-service
-          push: ${{github.event_name != 'pull_request'}}
+          # Enabling the line below restricts Docker images to only be built for branches
+          # push: ${{github.event_name != 'pull_request'}}
+          push: true
           tags: ${{steps.docker_meta.outputs.tags}}
           labels: ${{steps.docker_meta.outputs.labels}}
           build-args: NPM_TOKEN=${{secrets.graphprotocol_npm_token}}

--- a/.github/workflows/indexer-service-image.yml
+++ b/.github/workflows/indexer-service-image.yml
@@ -3,9 +3,11 @@ name: Indexer Service Image
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - v*.*.*
+      - v*.*.*
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/packages/indexer-service/src/server/deployment-health.ts
+++ b/packages/indexer-service/src/server/deployment-health.ts
@@ -22,7 +22,6 @@ export const createDeploymentHealthServer = ({
       },
       body: JSON.stringify({
         query: `query indexingStatus($subgraphs: [String!]!) {
-{
   indexingStatuses(subgraphs: $subgraphs) {
     health
     chains {


### PR DESCRIPTION
There was an extraneous `{` in the query that caused graph-node to trip over.