### PR TITLE
Use signalledTokens instead of signalAmount for minSignal threshold

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -620,7 +620,7 @@ export class Network {
                 id
                 ipfsHash
                 stakedTokens
-                signalAmount
+                signalledTokens
                 queryFeesAmount
                 indexerAllocations {
                   indexer {
@@ -678,7 +678,9 @@ export class Network {
 
               if (deploymentRule) {
                 const stakedTokens = BigNumber.from(deployment.stakedTokens)
-                const signalAmount = BigNumber.from(deployment.signalAmount)
+                const signalledTokens = BigNumber.from(
+                  deployment.signalledTokens,
+                )
                 const avgQueryFees = BigNumber.from(
                   deployment.queryFeesAmount,
                 ).div(
@@ -691,7 +693,7 @@ export class Network {
                   deployment: {
                     id: deployment.id,
                     stakedTokens: stakedTokens.toString(),
-                    signalAmount: signalAmount.toString(),
+                    signalledTokens: signalledTokens.toString(),
                     avgQueryFees: avgQueryFees.toString(),
                   },
                   indexingRule: {
@@ -731,9 +733,9 @@ export class Network {
                     stakedTokens.gte(deploymentRule.minStake)) ||
                   // signal >= minSignal && signal <= maxSignal?
                   (deploymentRule.minSignal &&
-                    signalAmount.gte(deploymentRule.minSignal)) ||
+                    signalledTokens.gte(deploymentRule.minSignal)) ||
                   (deploymentRule.maxSignal &&
-                    signalAmount.lte(deploymentRule.maxSignal)) ||
+                    signalledTokens.lte(deploymentRule.maxSignal)) ||
                   // avgQueryFees >= minAvgQueryFees?
                   (deploymentRule.minAverageQueryFees &&
                     avgQueryFees.gte(deploymentRule.minAverageQueryFees))
@@ -799,7 +801,7 @@ export class Network {
                 subgraphDeployment {
                   id
                   stakedTokens
-                  signalAmount
+                  signalledTokens
                 }
               }
             }
@@ -856,7 +858,7 @@ export class Network {
               subgraphDeployment {
                 id
                 stakedTokens
-                signalAmount
+                signalledTokens
               }
             }
           }
@@ -913,7 +915,7 @@ export class Network {
               subgraphDeployment {
                 id
                 stakedTokens
-                signalAmount
+                signalledTokens
               }
             }
           }
@@ -1032,7 +1034,7 @@ export class Network {
                 subgraphDeployment {
                   id
                   stakedTokens
-                  signalAmount
+                  signalledTokens
                 }
               }
             }
@@ -1381,7 +1383,7 @@ export class Network {
         subgraphDeployment: {
           id: deployment,
           stakedTokens: BigNumber.from(0),
-          signalAmount: BigNumber.from(0),
+          signalledTokens: BigNumber.from(0),
         },
         allocatedTokens: BigNumber.from(eventInputs.tokens),
         createdAtBlockHash: '0x0',
@@ -1739,7 +1741,7 @@ export class Network {
         subgraphDeployment: {
           id: deployment,
           stakedTokens: BigNumber.from(0),
-          signalAmount: BigNumber.from(0),
+          signalledTokens: BigNumber.from(0),
         },
         allocatedTokens: BigNumber.from(eventInputs.tokens),
         createdAtBlockHash: receipt.blockHash,

--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -11,7 +11,7 @@ interface IndexerAllocation {
   createdAtEpoch: number
   closedAtEpoch: number | null
   subgraphDeployment: string
-  signalAmount: BigNumber
+  signalledTokens: BigNumber
   stakedTokens: BigNumber
 }
 
@@ -26,7 +26,7 @@ const ALLOCATION_CONVERTERS_FROM_GRAPHQL: Record<
   allocatedTokens: nullPassThrough((x: string) => BigNumber.from(x)),
   createdAtEpoch: nullPassThrough((x: string) => parseInt(x)),
   closedAtEpoch: nullPassThrough((x: string) => parseInt(x)),
-  signalAmount: nullPassThrough((x: string) => BigNumber.from(x)),
+  signalledTokens: nullPassThrough((x: string) => BigNumber.from(x)),
   stakedTokens: nullPassThrough((x: string) => BigNumber.from(x)),
 }
 
@@ -40,7 +40,7 @@ const ALLOCATION_FORMATTERS: Record<
   allocatedTokens: x => utils.commify(formatGRT(x)),
   createdAtEpoch: x => x,
   closedAtEpoch: x => x,
-  signalAmount: x => utils.commify(formatGRT(x)),
+  signalledTokens: x => utils.commify(formatGRT(x)),
   stakedTokens: x => utils.commify(formatGRT(x)),
 }
 

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -89,7 +89,7 @@ module.exports = {
                 createdAtEpoch
                 closedAtEpoch
                 subgraphDeployment
-                signalAmount
+                signalledTokens
                 stakedTokens
               }
 
@@ -282,7 +282,7 @@ module.exports = {
           'subgraphDeployment',
           'allocatedTokens',
           'createdAtEpoch',
-          'signalAmount',
+          'signalledTokens',
           'stakedTokens',
         ])
       }

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -6,7 +6,7 @@ import { BigNumber } from 'ethers'
 export interface SubgraphDeployment {
   id: SubgraphDeploymentID
   stakedTokens: BigNumber
-  signalAmount: BigNumber
+  signalledTokens: BigNumber
 }
 
 export interface Allocation {
@@ -39,7 +39,7 @@ export const parseGraphQLAllocation = (allocation: any): Allocation => ({
   subgraphDeployment: {
     id: new SubgraphDeploymentID(allocation.subgraphDeployment.id),
     stakedTokens: BigNumber.from(allocation.subgraphDeployment.stakedTokens),
-    signalAmount: BigNumber.from(allocation.subgraphDeployment.signalAmount),
+    signalledTokens: BigNumber.from(allocation.subgraphDeployment.signalledTokens),
   },
   indexer: toAddress(allocation.indexer.id),
   allocatedTokens: BigNumber.from(allocation.allocatedTokens),

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -158,7 +158,7 @@ const SCHEMA_SDL = gql`
     createdAtEpoch: Int!
     closedAtEpoch: Int
     subgraphDeployment: String!
-    signalAmount: BigInt!
+    signalledTokens: BigInt!
     stakedTokens: BigInt!
   }
 

--- a/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/indexer-status.ts
@@ -113,7 +113,7 @@ export default {
               subgraphDeployment {
                 id
                 stakedTokens
-                signalAmount
+                signalledTokens
               }
             }
           }
@@ -128,7 +128,7 @@ export default {
         ...allocation,
         subgraphDeployment: new SubgraphDeploymentID(allocation.subgraphDeployment.id)
           .ipfsHash,
-        signalAmount: allocation.subgraphDeployment.signalAmount,
+        signalledTokens: allocation.subgraphDeployment.signalledTokens,
         stakedTokens: allocation.subgraphDeployment.stakedTokens,
       }))
     } catch (error) {

--- a/packages/indexer-service/src/allocations.ts
+++ b/packages/indexer-service/src/allocations.ts
@@ -79,7 +79,7 @@ export const monitorEligibleAllocations = ({
                 subgraphDeployment {
                   id
                   stakedTokens
-                  signalAmount
+                  signalledTokens
                 }
               }
               recentlyClosedAllocations: totalAllocations(
@@ -98,7 +98,7 @@ export const monitorEligibleAllocations = ({
                 subgraphDeployment {
                   id
                   stakedTokens
-                  signalAmount
+                  signalledTokens
                 }
               }
             }


### PR DESCRIPTION
The `signalledTokens` field describes the amount of GRT signalled on a subgraph or subgraph deployment. `signalAmount` describes the amount of signal shares on a subgraph, which is based on the bonding curve and hence don't correspond 1:1 to the amount of GRT signalled.

It is therefore much more intuitive to use `signalledTokens` for the `minSignal` threshold in indexing rules.