### PR TITLE
indexer-agent: Indexing rules update triggers active allocations query

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -304,15 +304,15 @@ class Agent {
       },
     )
 
-    const activeAllocations = timer(120_000).tryMap(
-      () => this.network.allocations(AllocationStatus.Active),
-      {
-        onError: () =>
-          this.logger.warn(
-            `Failed to obtain active allocations, trying again later`,
-          ),
-      },
-    )
+    const activeAllocations = join({
+      ticker: timer(120_000),
+      indexingRules,
+    }).tryMap(() => this.network.allocations(AllocationStatus.Active), {
+      onError: () =>
+        this.logger.warn(
+          `Failed to obtain active allocations, trying again later`,
+        ),
+    })
 
     const recentlyClosedAllocations = join({
       activeAllocations,


### PR DESCRIPTION
Include indexingRules in the trigger set for activeAllocations updates, so activeAllocations data is up to date when reconciling rules and allocations. 