### PR TITLE
docs: Update recommended indexer software component versions for testnet

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -17,9 +17,9 @@ For testnet:
 | Component       | Release                                                                    |
 | --------------- | -------------------------------------------------------------------------- |
 | contracts       | [1.2.0](https://github.com/graphprotocol/contracts/releases/tag/v1.2.0)    |
-| indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
+| indexer-agent   | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
+| indexer-cli     | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
+| indexer-service | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
 | graph-node      | [0.25.1](https://github.com/graphprotocol/graph-node/releases/tag/v0.25.1) |
 
 ## Mainnet (https://network.thegraph.com)

--- a/packages/indexer-cli/src/__tests__/references/help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/help.stdout
@@ -1,4 +1,4 @@
-graph-indexer version 0.18.6
+graph-indexer version 0.19.0
 
   graph-indexer                      -                                                                
   version (v)                        Output the version number                                        


### PR DESCRIPTION
Update doc to recommend indexers use the latest tag on Testnet.  Once multiple indexers have successfully tested on Testnet (or wherever they are comfortable) I'll update the recommended Mainnet setup as well.