### PR TITLE
indexer-common: allow reference proof null in schema

### DIFF
--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -63,10 +63,10 @@ const SCHEMA_SDL = gql`
     closedEpoch: Int!
     closedEpochStartBlockHash: String!
     closedEpochStartBlockNumber: Int!
-    closedEpochReferenceProof: String!
+    closedEpochReferenceProof: String
     previousEpochStartBlockHash: String!
     previousEpochStartBlockNumber: Int!
-    previousEpochReferenceProof: String!
+    previousEpochReferenceProof: String
     status: String!
   }
 
@@ -79,10 +79,10 @@ const SCHEMA_SDL = gql`
     closedEpoch: Int!
     closedEpochStartBlockHash: String!
     closedEpochStartBlockNumber: Int!
-    closedEpochReferenceProof: String!
+    closedEpochReferenceProof: String
     previousEpochStartBlockHash: String!
     previousEpochStartBlockNumber: Int!
-    previousEpochReferenceProof: String!
+    previousEpochReferenceProof: String
     status: String!
   }
 

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -161,13 +161,13 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
         allowNull: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          isHex: (value: any) => {
-            if (typeof value !== 'string') {
-              throw new Error('Allocation POI must be a string')
+          isHexOrNull: (value: any) => {
+            if (value && typeof value !== 'string') {
+              throw new Error('Allocation POI must be a string or null')
             }
 
-            // "0x..." is ok
-            if (utils.isHexString(value, 32)) {
+            // null or "0x..." is ok
+            if (!value || utils.isHexString(value, 32)) {
               return
             }
 
@@ -203,13 +203,13 @@ export const definePOIDisputeModels = (sequelize: Sequelize): POIDisputeModels =
         allowNull: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          isHex: (value: any) => {
-            if (typeof value !== 'string') {
-              throw new Error('Allocation POI must be a string')
+          isHexOrNull: (value: any) => {
+            if (value && typeof value !== 'string') {
+              throw new Error('Allocation POI must be a string or null')
             }
 
-            // "0x..." is ok
-            if (utils.isHexString(value, 32)) {
+            // null or "0x..." is ok
+            if (!value || utils.isHexString(value, 32)) {
               return
             }
 


### PR DESCRIPTION
Observing logs related to errors from null values for POIs returned from the graph-node.
```
      "type": "IndexerError",
      "message": "Failed to store potential POI disputes"
      "stack":
          IndexerError: Failed to store potential POI disputes
              at Object.indexerError (/Users/hopeyen/projects/indexer/packages/indexer-common/src/errors.ts:160:10)
              at Indexer.<anonymous> (/Users/hopeyen/projects/indexer/packages/indexer-agent/src/indexer.ts:375:19)
              at Generator.next (<anonymous>)
              at fulfilled (/Users/hopeyen/projects/indexer/packages/indexer-agent/src/indexer.ts:5:58)
              at runMicrotasks (<anonymous>)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
      "code": "IE039",
      "explanation": "https://github.com/graphprotocol/indexer/blob/master/docs/errors.md#ie039",
      "cause": {
        "type": "CombinedError",
        "message": "[GraphQL] Variable \"$disputes\" got invalid value null at \"disputes[0].closedEpochReferenceProof\"; Expected non-nullable type \"String!\" not to be null.\n[GraphQL] Variable \"$disputes\" got invalid value null at \"disputes[0].previousEpochReferenceProof\"; Expected non-nullable type \"String!\" not to be null..........
```

Nearly all types for reference proofs are null, and indexer agent already handle null reference POIs cases. Thus we allow them to be null in the Schema as well 