### PR TITLE
Indexer-agent: compound rewards when reallocate

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -1698,9 +1698,20 @@ export class Network {
         newAllocationId,
       )
 
+      // If there's enough free stake at hand to easily compound rewards, do so
+      const indexingRewards = await this.contracts.rewardsManager.getRewards(
+        existingAllocation.id,
+      )
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const compoundedAmount = indexingRewards.lt(freeStake)
+        ? amount.add(indexingRewards)
+        : amount
+
       logger.info(`Executing reallocate transaction`, {
         indexer: this.indexerAddress,
         amount: formatGRT(amount),
+        indexingRewards,
+        compoundedAmount: formatGRT(compoundedAmount),
         oldAllocation: existingAllocation.id,
         newAllocation: newAllocationId,
         deployment,


### PR DESCRIPTION
Currently the agent can renew allocations with the specified amount in indexing rules, whether it be original amount or updated amount.

This PR explores the implementation for the agent to automatically compound the amount of indexing rewards if there's enough available from the free stake during reallocation, so that indexers don't need to worry about newly received indexing reward. 

### Open-ended idea
Provide different `autoRenewal` options - ENUM to 'DoNotRenew', 'renewSimple', 'renewWithCompound'...?