### PR TITLE
indexer-agent: worth-allocate conditional fix

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -752,8 +752,8 @@ export class Network {
                     stakedTokens.gte(deploymentRule.minStake)) ||
                   // signal >= minSignal && signal <= maxSignal?
                   (deploymentRule.minSignal &&
-                    signalledTokens.gte(deploymentRule.minSignal)) ||
-                  (deploymentRule.maxSignal &&
+                    signalledTokens.gte(deploymentRule.minSignal) &&
+                    deploymentRule.maxSignal &&
                     signalledTokens.lte(deploymentRule.maxSignal)) ||
                   // avgQueryFees >= minAvgQueryFees?
                   (deploymentRule.minAverageQueryFees &&


### PR DESCRIPTION
Small fix - max and min signals should be both defined and satisfied for the signal conditional to pass, as indicated in the code comment