### PR TITLE
Indexer-common: Always use base58 format for deployment ids 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:13
         env:
           POSTGRES_DB: indexer_tests
           POSTGRES_USER: testuser

--- a/packages/indexer-agent/.eslintrc.js
+++ b/packages/indexer-agent/.eslintrc.js
@@ -3,4 +3,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'semi': [2, 'never'],
+    '@typescript-eslint/no-extra-semi': 'off',
+  }
 }

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -57,7 +57,7 @@
     "@types/yargs": "15.0.9",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
-    "eslint": "8.5.0",
+    "eslint": "8.10.0",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",
     "ts-node": "^10.4.0",

--- a/packages/indexer-cli/.eslintrc.js
+++ b/packages/indexer-cli/.eslintrc.js
@@ -3,4 +3,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'semi': [2, 'never'],
+    '@typescript-eslint/no-extra-semi': 'off',
+  }
 }

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -36,7 +36,7 @@
     "@types/isomorphic-fetch": "0.0.35",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
-    "eslint": "8.5.0",
+    "eslint": "8.10.0",
     "typescript": "4.1.6"
   },
   "resolutions": {

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch --detectOpenHandles --verbose"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.1",
+    "@graphprotocol/common-ts": "1.8.2",
     "@graphprotocol/indexer-common": "^0.19.0",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.74",

--- a/packages/indexer-cli/src/commands/indexer/cost/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/get.ts
@@ -5,7 +5,7 @@ import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters } from '../../../command-helpers'
 import { costModel, costModels, parseDeploymentID, printCostModels } from '../../../cost'
-import { validateDeploymentID } from "@graphprotocol/indexer-common";
+import { validateDeploymentID } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold('graph indexer cost get')} [options] all

--- a/packages/indexer-cli/src/commands/indexer/cost/set/model.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/set/model.ts
@@ -11,7 +11,7 @@ import {
   printCostModels,
   setCostModel,
 } from '../../../../cost'
-import { validateDeploymentID } from "@graphprotocol/indexer-common";
+import { validateDeploymentID } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold('graph indexer cost set model')} [options] <deployment-id> <file>

--- a/packages/indexer-cli/src/commands/indexer/cost/set/variables.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/set/variables.ts
@@ -10,7 +10,7 @@ import {
   printCostModels,
   setCostModel,
 } from '../../../../cost'
-import { validateDeploymentID } from "@graphprotocol/indexer-common";
+import { validateDeploymentID } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold(

--- a/packages/indexer-cli/src/commands/indexer/rules/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/get.ts
@@ -49,10 +49,10 @@ module.exports = {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [identifier, identifierType] = await processIdentifier(id, { all: true, global: true })
 
-    const config = loadValidatedConfig()
+      const config = loadValidatedConfig()
 
-    // Create indexer API client
-    const client = await createIndexerManagementClient({ url: config.api })
+      // Create indexer API client
+      const client = await createIndexerManagementClient({ url: config.api })
 
       const ruleOrRules =
         identifier === 'all'

--- a/packages/indexer-cli/src/commands/indexer/rules/set.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/set.ts
@@ -10,7 +10,7 @@ import {
   setIndexingRule,
   printIndexingRules,
 } from '../../../rules'
-import { processIdentifier } from "@graphprotocol/indexer-common";
+import { processIdentifier } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold('graph indexer rules set')} [options] global          <key1> <value1> ...

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -368,7 +368,7 @@ export const setIndexingRule = async (
 
 export const deleteIndexingRules = async (
   client: IndexerManagementClient,
-  identifiers: SubgraphDeploymentIDIsh[],
+  identifiers: string[],
 ): Promise<void> => {
   const result = await client
     .mutation(

--- a/packages/indexer-common/.eslintrc.js
+++ b/packages/indexer-common/.eslintrc.js
@@ -3,4 +3,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'semi': [2, 'never'],
+    '@typescript-eslint/no-extra-semi': 'off',
+  }
 }

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -46,7 +46,7 @@
     "@types/node": "14.14.6",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
-    "eslint": "8.5.0",
+    "eslint": "8.10.0",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.1",
+    "@graphprotocol/common-ts": "1.8.2",
     "@graphprotocol/cost-model": "0.1.8",
     "@thi.ng/heaps": "1.2.38",
     "@urql/core": "2.3.6",

--- a/packages/indexer-common/src/indexer-management/__tests__/indexing-rules.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/indexing-rules.ts
@@ -86,7 +86,7 @@ const INDEXING_RULE_QUERY = gql`
 `
 
 const INDEXING_RULES_QUERY = gql`
-  query indexingRuls($merged: Boolean!) {
+  query indexingRules($merged: Boolean!) {
     indexingRules(merged: $merged) {
       identifier
       identifierType
@@ -285,7 +285,7 @@ describe('Indexing rules', () => {
 
   test('Set and get deployment rule (partial update)', async () => {
     const originalInput = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: '1',
       minSignal: '2',
@@ -306,13 +306,13 @@ describe('Indexing rules', () => {
       requireSupported: true,
     }
 
-    // Write the orginal
+    // Write the original
     await expect(
       client.mutation(SET_INDEXING_RULE_MUTATION, { rule: originalInput }).toPromise(),
     ).resolves.toHaveProperty('data.setIndexingRule', original)
 
     const update = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: null,
       maxSignal: '3',
@@ -336,8 +336,7 @@ describe('Indexing rules', () => {
     await expect(
       client
         .query(INDEXING_RULE_QUERY, {
-          identifier:
-            '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+          identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
           merged: false,
         })
         .toPromise(),
@@ -356,6 +355,7 @@ describe('Indexing rules', () => {
       ...update,
       ...updateAgain,
     }
+    expectedAgain.identifier = 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC'
 
     // Update the rule
     await expect(
@@ -366,8 +366,7 @@ describe('Indexing rules', () => {
     await expect(
       client
         .query(INDEXING_RULE_QUERY, {
-          identifier:
-            '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+          identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
           merged: false,
         })
         .toPromise(),
@@ -420,6 +419,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       requireSupported: false,
     }
+    deploymentExpected.identifier = 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC'
 
     // Write the orginals
     await expect(
@@ -458,7 +458,7 @@ describe('Indexing rules', () => {
 
   test('Set, delete and get rule', async () => {
     const input = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: '1',
       minSignal: '2',
@@ -505,7 +505,7 @@ describe('Indexing rules', () => {
 
   test('Clear a parameter', async () => {
     const input = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: '1',
       requireSupported: true,
@@ -569,7 +569,7 @@ describe('Indexing rules', () => {
     }
 
     const deploymentInput = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: '1',
       minSignal: '2',
@@ -642,8 +642,7 @@ describe('Indexing rules', () => {
     await expect(
       client
         .query(INDEXING_RULE_QUERY, {
-          identifier:
-            '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+          identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
           merged: true,
         })
         .toPromise(),
@@ -716,7 +715,7 @@ describe('Indexing rules', () => {
     }
 
     const deploymentInput = {
-      identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
+      identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
       allocationAmount: '1',
       minSignal: '2',

--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -1,5 +1,6 @@
 import { base58 } from 'ethers/lib/utils'
 import { utils } from 'ethers'
+import { SubgraphDeploymentID } from '@graphprotocol/common-ts'
 
 export enum SubgraphIdentifierType {
   DEPLOYMENT = 'deployment',
@@ -119,5 +120,11 @@ export async function processIdentifier(
     )
   }
   type = fulfilled[0].value
-  return [identifier, type]
+
+  return [
+    type == SubgraphIdentifierType.DEPLOYMENT
+      ? new SubgraphDeploymentID(identifier).ipfsHash
+      : identifier,
+    type,
+  ]
 }

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -6,7 +6,7 @@
   "author": "Zac Burns <That3Percent@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.1",
+    "@graphprotocol/common-ts": "1.8.2",
     "neon-cli": "^0.8.0"
   },
   "scripts": {

--- a/packages/indexer-service/.eslintrc.js
+++ b/packages/indexer-service/.eslintrc.js
@@ -3,4 +3,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'semi': [2, 'never'],
+    '@typescript-eslint/no-extra-semi': 'off',
+  }
 }

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google-cloud/profiler": "4.1.5",
-    "@graphprotocol/common-ts": "1.8.1",
+    "@graphprotocol/common-ts": "1.8.2",
     "@graphprotocol/indexer-common": "^0.19.0",
     "@graphprotocol/indexer-native": "^0.19.0",
     "@graphql-tools/delegate": "8.4.3",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -74,7 +74,7 @@
     "@types/yargs": "15.0.9",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
-    "eslint": "8.5.0",
+    "eslint": "8.10.0",
     "jest": "27.4.5",
     "lerna": "4.0.0",
     "nock": "13.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,33 +727,6 @@
   resolved "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz#9d8705ecb2baa41b6b2673f3a8e9b7b7e1abc52a"
   integrity sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==
 
-"@graphprotocol/common-ts@1.8.1":
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/@graphprotocol/common-ts/-/common-ts-1.8.1.tgz#a23f6d45855f78ea6668e76421ab616d8bd2f14a"
-  integrity sha512-xYkQbww0el0Luc9aN/SpRMQ6rz9x2K6JjlUHCXnVI1rysFGjSfwYiw9NqKCZzr+6oI6kvKVRyx8uzw/9ovx6Lg==
-  dependencies:
-    "@graphprotocol/contracts" "1.9.0"
-    "@graphprotocol/pino-sentry-simple" "0.7.1"
-    "@urql/core" "2.3.6"
-    "@urql/exchange-execute" "1.2.2"
-    body-parser "1.19.1"
-    bs58 "4.0.1"
-    cors "2.8.5"
-    cross-fetch "3.1.4"
-    ethers "5.5.2"
-    express "4.17.2"
-    graphql "16.2.0"
-    graphql-tag "2.12.6"
-    helmet "4.6.0"
-    morgan "1.10.0"
-    ngeohash "0.6.3"
-    pg "8.7.1"
-    pg-hstore "2.3.4"
-    pino "7.6.0"
-    pino-multi-stream "6.0.0"
-    prom-client "14.0.1"
-    sequelize "6.12.0"
-
 "@graphprotocol/common-ts@1.8.2":
   version "1.8.2"
   resolved "https://registry.npmjs.org/@graphprotocol/common-ts/-/common-ts-1.8.2.tgz#f6d8dd2b27ea2f99804d5805e4eab022e41b0bb9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,14 +316,14 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@eslint/eslintrc@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
-  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
+"@eslint/eslintrc@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz#7ce1547a5c46dfe56e1e45c3c9ed18038c721c6a"
+  integrity sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.2.0"
+    espree "^9.3.1"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
@@ -2937,11 +2937,6 @@ ansi-colors@^3.2.1:
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -4467,13 +4462,6 @@ enquirer@2.3.4:
   dependencies:
     ansi-colors "^3.2.1"
 
-enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
 ent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -4593,10 +4581,10 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
-  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -4613,29 +4601,33 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
+eslint-visitor-keys@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
-eslint@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-8.5.0.tgz#ddd2c1afd8f412036f87ae2a063d2aa296d3175f"
-  integrity sha512-tVGSkgNbOfiHyVte8bCM8OmX+xG9PzVG/B4UCF60zx7j61WIVY/AqJECDgpLD4DbbESD0e174gOg3ZlrX15GDg==
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@8.10.0:
+  version "8.10.0"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz#931be395eb60f900c01658b278e05b6dae47199d"
+  integrity sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==
   dependencies:
-    "@eslint/eslintrc" "^1.0.5"
+    "@eslint/eslintrc" "^1.2.0"
     "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
-    enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.0"
+    eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.1.0"
-    espree "^9.2.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -4643,7 +4635,7 @@ eslint@8.5.0:
     functional-red-black-tree "^1.0.1"
     glob-parent "^6.0.1"
     globals "^13.6.0"
-    ignore "^4.0.6"
+    ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
@@ -4654,22 +4646,20 @@ eslint@8.5.0:
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
-    progress "^2.0.0"
     regexpp "^3.2.0"
-    semver "^7.2.1"
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.2.0:
-  version "9.3.0"
-  resolved "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz#c1240d79183b72aaee6ccfa5a90bc9111df085a8"
-  integrity sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
+espree@^9.3.1:
+  version "9.3.1"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz#8793b4bc27ea4c778c19908e0719e7b8f4115bcd"
+  integrity sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==
   dependencies:
     acorn "^8.7.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.1.0"
+    eslint-visitor-keys "^3.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -5933,7 +5923,7 @@ ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -8622,11 +8612,6 @@ process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 prom-client@14.0.1:
   version "14.0.1"
   resolved "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
@@ -9233,7 +9218,7 @@ semver-store@^0.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
- Update resolvers to convert subgraph deployment ids to base58 format before saving into the DB. 
- Update eslint and add semi-colon rules.