### PR TITLE
indexer-cli, indexer-common: earliestblock allow null

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -270,7 +270,7 @@ module.exports = {
                 network: chain.network,
                 latestBlockNumber: chain.latestBlock.number,
                 chainHeadBlockNumber: chain.chainHeadBlock.number,
-                earliestBlockNumber: chain.earliestBlock.number,
+                earliestBlockNumber: chain.earliestBlock?.number,
               })),
             ),
             outputFormat,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -146,7 +146,7 @@ const SCHEMA_SDL = gql`
     network: String!
     latestBlock: BlockPointer!
     chainHeadBlock: BlockPointer!
-    earliestBlock: BlockPointer!
+    earliestBlock: BlockPointer
   }
 
   type IndexerDeployment {


### PR DESCRIPTION
Currently if there is a deployment in postgres db with no start block, indexers cannot query `status`
```
Error fetching status information: [GraphQL] Cannot return null for non-nullable field ChainIndexingStatus.earliestBlock.
```

It makes sense to allow null for earliestBlock so that indexers can still query `status` with these deployments.