### PR TITLE
bug-fix: parse graphQL of indexing status

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -977,9 +977,18 @@ class Agent {
           },
         )
       } else {
+        const previousEpochStartBlockNumber =
+          epochStartBlock.number -
+          (await this.network.contracts.epochManager.epochLength()).toNumber()
+        const failureBlock = indexingStatus.chains[0].latestBlock
+
+        // latest valid block (earliest possible is at previous epoch start
+        const validBlock = await this.network.ethereum.getBlock(
+          Math.min(previousEpochStartBlockNumber, failureBlock.number - 1),
+        )
         const latestValidPoi = await this.indexer.proofOfIndexing(
           allocation.subgraphDeployment.id,
-          indexingStatus?.chains[0].latestBlock,
+          validBlock,
           this.indexer.indexerAddress,
         )
         this.logger.error(`Received a null or zero POI for deployment`, {

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -13,6 +13,7 @@ import {
   BlockPointer,
   IndexingStatus,
   SubgraphIdentifierType,
+  parseGraphQLIndexingStatus,
 } from '@graphprotocol/indexer-common'
 import pRetry from 'p-retry'
 
@@ -474,12 +475,7 @@ export class Indexer {
       return (
         result.data.indexingStatuses
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .map((status: any) => ({
-            ...status,
-            subgraphDeployment: new SubgraphDeploymentID(
-              status.subgraphDeployment,
-            ),
-          }))
+          .map((status: any) => parseGraphQLIndexingStatus(status))
           .pop()
       )
     } catch (error) {

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -1,13 +1,39 @@
 import fetch from 'isomorphic-fetch'
 import { Client, createClient } from '@urql/core'
 import { Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
-import { IndexingStatus } from './types'
+import { BlockPointer, ChainIndexingStatus, IndexingStatus } from './types'
 import { indexerError, IndexerErrorCode } from './errors'
 
 export interface IndexingStatusFetcherOptions {
   logger: Logger
   statusEndpoint: string
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const parseGraphQLIndexingStatus = (indexingStatus: any): IndexingStatus => ({
+  subgraphDeployment: new SubgraphDeploymentID(indexingStatus.subgraphDeployment),
+  synced: indexingStatus.synced,
+  health: indexingStatus.health,
+  fatalError: indexingStatus.fatalError,
+  node: indexingStatus.node,
+  chains: indexingStatus.chains.map(parseGraphQLChain),
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const parseGraphQLChain = (chain: any): ChainIndexingStatus => ({
+  network: chain.network,
+  latestBlock: parseGraphQLBlockPointer(chain.latestBlock),
+  chainHeadBlock: parseGraphQLBlockPointer(chain.chainHeadBlock),
+  earliestBlock: chain.earliestBlock
+    ? parseGraphQLBlockPointer(chain.earliestBlock)
+    : null,
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const parseGraphQLBlockPointer = (block: any): BlockPointer => ({
+  number: +block.number,
+  hash: block.hash,
+})
 
 export class IndexingStatusResolver {
   logger: Logger

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -9,7 +9,7 @@ export interface EthereumIndexingStatus {
   network: string
   latestBlock: BlockPointer
   chainHeadBlock: BlockPointer
-  earliestBlock: BlockPointer
+  earliestBlock: BlockPointer | null
 }
 
 export type ChainIndexingStatus = EthereumIndexingStatus


### PR DESCRIPTION
With more checks to the indexing status, we discovered a missing type conversion that leads to the following error. With a more explicit conversion the issue should be resolved.
```
[2022-03-14 17:53:09.657 +0000] WARN (IndexerAgent/1 on c0a257d65da3): Proof of indexing could not be queried
    attempt: 8
    retriesLeft: 3
    err: "[GraphQL] Invalid value provided for argument `blockNumber`: String(\"4663370\")"
```