### PR TITLE
indexer-agent: fix gas price in tx management logs

### DIFF
--- a/packages/indexer-agent/src/network.ts
+++ b/packages/indexer-agent/src/network.ts
@@ -364,17 +364,20 @@ export class Network {
           .sub(feeData.maxPriorityFeePerGas!)
           .div(2)
         if (baseFeePerGas.toNumber() >= this.baseFeePerGasMax) {
-          if (attempt == 1) {
+          if (attempt === 1) {
             logger.warning(
               `Max base fee per gas has been reached, waiting until the base fee falls below to resume transaction execution.`,
-              { maxBaseFeePerGas: this.baseFeePerGasMax, baseFeePerGas },
+              {
+                maxBaseFeePerGas: this.baseFeePerGasMax,
+                baseFeePerGas: baseFeePerGas.toNumber(),
+              },
             )
           } else {
             logger.info(
               `Base gas fee per gas estimation still above max threshold`,
               {
                 maxBaseFeePerGas: this.baseFeePerGasMax,
-                baseFeePerGas,
+                baseFeePerGas: baseFeePerGas.toNumber(),
                 priceEstimateAttempt: attempt,
               },
             )
@@ -389,18 +392,18 @@ export class Network {
         // Legacy transaction type
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (feeData.gasPrice!.toNumber() >= this.baseFeePerGasMax) {
-          if (attempt == 1) {
+          if (attempt === 1) {
             logger.warning(
               `Max gas price has been reached, waiting until gas price estimates fall below to resume transaction execution.`,
               {
                 baseFeePerGasMax: this.baseFeePerGasMax,
-                currentGasPriceEstimate: feeData.gasPrice,
+                currentGasPriceEstimate: feeData.gasPrice.toNumber(),
               },
             )
           } else {
             logger.info(`Gas price estimation still above max threshold`, {
               baseFeePerGasMax: this.baseFeePerGasMax,
-              currentGasPriceEstimate: feeData.gasPrice,
+              currentGasPriceEstimate: feeData.gasPrice.toNumber(),
               priceEstimateAttempt: attempt,
             })
           }


### PR DESCRIPTION
Fixes BigNumber logs like this:
```
{"level":30,"time":1647523071123,"pid":1,"hostname":"99c572502af3","name":"IndexerAgent","component":"Network","indexer":"0x365507a4eEF5341cF00340F702F7f6E74217d96e","operator":"0x0EBAB0EB90E97DD211Aa5D4fb19E7048ae4aa4e5","allocation":"0x1B6551918c4175eCB82bA1191857ad5D4C751E27","deployment":{"bytes32":"0x45a6851c2f977fc91a390eb6f4c67a035296581244bc83cf8b74c5371f438436","ipfsHash":"QmT2Y7SHXGRt7EKXzFPYMjnrgX64PQr86EjbsHoDLNzwLy"},"createdAtEpoch":438,"poi":"0x53b8688603062200577d77eb5af515bf346b709d0d5dee11860cff936e5120c4","createdAtBlockHash":"0x7d6fcb374cafbe4c9fa30ac7cfe50a38c91fb68667e82f6b4182ebbc94bef6fc","action":"close","maxBaseFeePerGas":100000000000,"baseFeePerGas":{"type":"BigNumber","hex":"0x357dea1405"},"priceEstimateAttempt":6,"msg":"Base gas fee per gas estimation still above max threshold"}
```