### PR TITLE
Indexer Agent Configuration by File

### DIFF
--- a/packages/indexer-agent/config.yaml
+++ b/packages/indexer-agent/config.yaml
@@ -1,0 +1,1 @@
+ethereum-network: "mainnet"

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -50,6 +50,7 @@
     "p-reduce": "2.1.0",
     "p-retry": "4.6.1",
     "umzug": "3.0.0",
+    "yaml": "^2.0.0-10",
     "yargs": "17.4.1"
   },
   "devDependencies": {

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -1,5 +1,7 @@
+import fs from 'fs'
 import path from 'path'
 import { Argv } from 'yargs'
+import { parse as yaml_parse } from 'yaml'
 import { SequelizeStorage, Umzug } from 'umzug'
 import {
   connectContracts,
@@ -414,6 +416,13 @@ export default {
         required: false,
         default: 'auto',
         group: 'Indexer Infrastructure',
+      })
+      .config({
+        key: 'config-file',
+        description: 'Indexer agent configuration file (YAML format)',
+        parseFn: function (cfgFilePath: string) {
+          return yaml_parse(fs.readFileSync(cfgFilePath, 'utf-8'))
+        },
       })
   },
   handler: async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10824,6 +10824,11 @@ yaml@1.10.2, yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.0.0-10:
+  version "2.0.0-10"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-10.tgz#d5b59e2d14b8683313a534f2bbc648e211a2753e"
+  integrity sha512-FHV8s5ODFFQXX/enJEU2EkanNl1UDBUz8oa4k5Qo/sR+Iq7VmhCDkRMb0/mjJCNeAWQ31W8WV6PYStDE4d9EIw==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"


### PR DESCRIPTION
** RECREATING THIS PR** from PR #395 as the CI pipeline didn't like building off of a fork.

This pull requests implements file-based configuration for the indexer agent such that the configuration file supplements base defaults for a cluster. The idea here is that default values for mainnet, rinkeby, etc can be supplied as code in the repository, with more important parameters being injected via environment variables and CLI flags.

The order of precedence is as follows:

    CLI flags
    Environment variables
    Configuration file parameters

F.eks. running indexer-agent with a configuration file containing ethereum: https://ethereum-node-0:8545 and setting INDEXER_AGENT_ETHEREUM to https://ethereum.hosted.service/accountid/, the effective setting would be https://ethereum.hosted.service/accountid/.