### PR TITLE
docs: Update graph-node to 0.25.2

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -10,7 +10,7 @@ For mainnet:
 | indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| graph-node      | [0.25.1](https://github.com/graphprotocol/graph-node/releases/tag/v0.25.1) |
+| graph-node      | [0.25.2](https://github.com/graphprotocol/graph-node/releases/tag/v0.25.2) |
 
 For testnet:
 
@@ -20,7 +20,7 @@ For testnet:
 | indexer-agent   | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
 | indexer-cli     | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
 | indexer-service | [0.19.0](https://github.com/graphprotocol/indexer/releases/tag/v0.19.0)    |
-| graph-node      | [0.25.1](https://github.com/graphprotocol/graph-node/releases/tag/v0.25.1) |
+| graph-node      | [0.25.2](https://github.com/graphprotocol/graph-node/releases/tag/v0.25.2) |
 
 ## Mainnet (https://network.thegraph.com)
 


### PR DESCRIPTION
This release has more than a month, this should be merged asap.