### PR TITLE
Revert ESM packages for compatibility with Commonjs

### DIFF
--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts,.tsx --fix",
     "compile": "tsc",
     "prepare": "yarn format && yarn lint && yarn compile",
-    "start": "yarn prepare && node ./dist/index.js start",
+    "start": "node ./dist/index.js start",
     "test": "jest --runInBand --detectOpenHandles --passWithNoTests --verbose",
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo",
     "migrator:pending": "node src/db/cli/migrator pending",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts,.tsx --fix",
     "compile": "tsc",
     "prepare": "yarn format && yarn lint && yarn compile",
-    "start": "yarn prepare && node ./dist/index.js start",
+    "start": "node ./dist/index.js start",
     "test": "jest --passWithNoTests --detectOpenHandles --verbose --forceExit",
     "test:watch": "jest --watch --passWithNoTests --detectOpenHandles --verbose",
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo"
@@ -33,7 +33,7 @@
     "@graphql-tools/load": "7.5.8",
     "@graphql-tools/url-loader": "7.9.11",
     "@graphql-tools/wrap": "8.4.13",
-    "@thi.ng/cache": "2.1.6",
+    "@thi.ng/cache": "1.0.94",
     "@urql/core": "2.4.4",
     "apollo-link-http": "1.5.17",
     "axios": "0.26.1",
@@ -55,7 +55,7 @@
     "p-map": "4.0.0",
     "p-queue": "6.6.2",
     "p-retry": "4.6.1",
-    "read-pkg": "7.1.0",
+    "read-pkg": "5.2.0",
     "yargs": "17.4.1"
   },
   "devDependencies": {

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { readPackage } from 'read-pkg'
+import readPackage from 'read-pkg'
 import { Argv } from 'yargs'
 import { Wallet, providers, BigNumber } from 'ethers'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,11 +2234,6 @@
   resolved "https://registry.npmjs.org/@thi.ng/api/-/api-7.2.0.tgz"
   integrity sha512-4NcwHXxwPF/JgJG/jSFd9rjfQNguF0QrHvd6e+CEf4T0sFChqetW6ZmJ6/a2X+noDVntgulegA+Bx0HHzw+Tyw==
 
-"@thi.ng/api@^8.3.5":
-  version "8.3.5"
-  resolved "https://registry.npmjs.org/@thi.ng/api/-/api-8.3.5.tgz#dee48bcd770f85e8110d58ad39471d1102e4e38e"
-  integrity sha512-njE0LbFySy0Nzue4q3nmP0HDbiyLUdDtcbczZXQbXiyzmo6ab+jQrnr4JJRsN0fZ/CzEcG5L+LQfVVgr7O1a0w==
-
 "@thi.ng/arrays@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@thi.ng/arrays/-/arrays-1.0.3.tgz"
@@ -2251,38 +2246,19 @@
     "@thi.ng/errors" "^1.3.4"
     "@thi.ng/random" "^2.4.8"
 
-"@thi.ng/arrays@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/@thi.ng/arrays/-/arrays-2.2.1.tgz#0d79b67b5a66e13c964527dfb2eba14f3f75465c"
-  integrity sha512-LhmWYc5eFO/Odh/dzlOUTBqqO0ypj+2bhkiK1WP8QRDiL3bl1dT8PJh5RuADZp+eYYvDLYjcguZv+fpnCoOhNA==
+"@thi.ng/cache@1.0.94":
+  version "1.0.94"
+  resolved "https://registry.npmjs.org/@thi.ng/cache/-/cache-1.0.94.tgz#b2ff14a72474604656cddbfa7fb814eef23f3195"
+  integrity sha512-4APqEYyPnicFsljO5XRQWallT+v9IZLW10GZu7JUXcC9vqbWK0WP04ynLRnHK/ELKfshB9McEx3ogf8457W8Tg==
   dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/checks" "^3.1.5"
-    "@thi.ng/compare" "^2.1.5"
-    "@thi.ng/equiv" "^2.1.5"
-    "@thi.ng/errors" "^2.1.5"
-    "@thi.ng/random" "^3.2.5"
-
-"@thi.ng/cache@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.npmjs.org/@thi.ng/cache/-/cache-2.1.6.tgz#c942fbaa4df649ec1571298a860ac6228ef8b3f8"
-  integrity sha512-2iAEZFqdeG3DZYwsv4Fnwcs/P1sflCh7cjUrdHhKs4mH7UlZCT/ZMxB1ve8sAy2i+cZNylz4JTDjQT2rbbXH1Q==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/dcons" "^3.2.1"
-    "@thi.ng/transducers" "^8.3.1"
+    "@thi.ng/api" "^7.2.0"
+    "@thi.ng/dcons" "^2.3.34"
+    "@thi.ng/transducers" "^7.9.2"
 
 "@thi.ng/checks@^2.9.11":
   version "2.9.11"
   resolved "https://registry.npmjs.org/@thi.ng/checks/-/checks-2.9.11.tgz"
   integrity sha512-fBvWod32w24JlJsrrOdl+tlx+UNehCORi4rHaJ7l7HH+SEhD/lYTCXOBjwu9D/ztIUjMP5Q+n8cAqI5iPhbvAQ==
-  dependencies:
-    tslib "^2.3.1"
-
-"@thi.ng/checks@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/checks/-/checks-3.1.5.tgz#43e4acfc76e547a5765d215546fb25e41c4ade48"
-  integrity sha512-mmCP47naS8lndBdUXWk88FiXAFOqC+GEihG8GNF5R/LDNG+3egh7lX5i6qDLlBSTOvQwBKNf/VViDoN9PxsgiA==
   dependencies:
     tslib "^2.3.1"
 
@@ -2293,13 +2269,6 @@
   dependencies:
     "@thi.ng/api" "^7.2.0"
 
-"@thi.ng/compare@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/compare/-/compare-2.1.5.tgz#37888f959b800d63b941f6e0d0198e2440c8339c"
-  integrity sha512-/gD+NEFxFmjpJ53rP0I2ZljQThZDeeGHIlm0P04jXiJXh76ora6YyzswRRmIIkitOFbccyr9sGrO2gGNVcbbZA==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-
 "@thi.ng/compose@^1.4.36":
   version "1.4.36"
   resolved "https://registry.npmjs.org/@thi.ng/compose/-/compose-1.4.36.tgz"
@@ -2307,14 +2276,6 @@
   dependencies:
     "@thi.ng/api" "^7.2.0"
     "@thi.ng/errors" "^1.3.4"
-
-"@thi.ng/compose@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/compose/-/compose-2.1.5.tgz#07a452a371e80be3d11e36da200a8d47c5e995c2"
-  integrity sha512-4g/VdEgRvDhY9GtZWzBURZiBQAtE0gtBHJ91f4HGg2UQR4+8wCiPRNgB3lk7OttfEh7Y8+OfBRoZQvKkLwwAAg==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/errors" "^2.1.5"
 
 "@thi.ng/dcons@^2.3.34":
   version "2.3.34"
@@ -2329,38 +2290,15 @@
     "@thi.ng/random" "^2.4.8"
     "@thi.ng/transducers" "^7.9.2"
 
-"@thi.ng/dcons@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/@thi.ng/dcons/-/dcons-3.2.1.tgz#8e35df79efe5981edab091cf7912715bf0f856aa"
-  integrity sha512-SKjI4saxfqg4IP/UDWBssSuXV/LoTIq3oxod7rP+XHihcIuaZfMelqvTai2Ub+Kw2qq4ZwYjaP86q75bM2781A==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/checks" "^3.1.5"
-    "@thi.ng/compare" "^2.1.5"
-    "@thi.ng/equiv" "^2.1.5"
-    "@thi.ng/errors" "^2.1.5"
-    "@thi.ng/random" "^3.2.5"
-    "@thi.ng/transducers" "^8.3.1"
-
 "@thi.ng/equiv@^1.0.45":
   version "1.0.45"
   resolved "https://registry.npmjs.org/@thi.ng/equiv/-/equiv-1.0.45.tgz"
   integrity sha512-tdXaJfF0pFvT80Q7BOlhc7H7ja/RbVGzlGpE4LqjDWfXPPbLYwmq6EbQuHWeXuvT0qe+BsGnuO5UXAR5B8oGGQ==
 
-"@thi.ng/equiv@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/equiv/-/equiv-2.1.5.tgz#e598ab9fcd02a1da8a8d71ad73e8cf38a30b8672"
-  integrity sha512-KJB5/XfVBdefPFHGpcszRmQM0YXcpJ/J+/rgd/3opgM4rjFjqtqa3ND6Sof75mKgNH4wmTbdZtFY3rJ04bHKXw==
-
 "@thi.ng/errors@^1.3.4":
   version "1.3.4"
   resolved "https://registry.npmjs.org/@thi.ng/errors/-/errors-1.3.4.tgz"
   integrity sha512-hTk71OPKnioN349sdj2DAoY+69eSerB3MN4Zwz6mosr1QFzIMkfkNOtBeC+Gm0yi0V0EY5LeBYFgqb3oXbtTbw==
-
-"@thi.ng/errors@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/errors/-/errors-2.1.5.tgz#d5bb6a3dd461edf56ac2ddcc10ee7e0b8b028fef"
-  integrity sha512-bC0TtSNBUWuuNAW632mRX4ohfbhfHno6trFaEzd0K8Jb853ZvnB/PuueEgEPN1SmT+K4fvW05d5ql1VJbe9/ow==
 
 "@thi.ng/heaps@1.2.38":
   version "1.2.38"
@@ -2384,11 +2322,6 @@
   resolved "https://registry.npmjs.org/@thi.ng/hex/-/hex-1.0.4.tgz"
   integrity sha512-9ofIG4nXhEskGeOJthpi/9LXFIPrlZ/MmHpgLWa3wNqTVhODP/o++mu9jDKojHEpKvswkkFCE+mSVmMu8xo4mQ==
 
-"@thi.ng/hex@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@thi.ng/hex/-/hex-2.1.5.tgz#3dc43727ed1c21dc76de3901ae65e548955fb6eb"
-  integrity sha512-HQjvwNHUlKdz3l3O5F4aC8NUiYdt2k36LMl5hnLjA+yyjpDyRu5xB5FOr0LNjnjNbMOMvr9WrCMjfg1/oU+3xA==
-
 "@thi.ng/iterators@5.1.74":
   version "5.1.74"
   resolved "https://registry.npmjs.org/@thi.ng/iterators/-/iterators-5.1.74.tgz"
@@ -2405,13 +2338,6 @@
   dependencies:
     "@thi.ng/api" "^7.2.0"
 
-"@thi.ng/math@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.npmjs.org/@thi.ng/math/-/math-5.3.1.tgz#74ac81999b50ba8f58e8a083274c9c32feab9ad9"
-  integrity sha512-oJb/rBHO5N+x8GO5g54Ol3oR9dyyrcu+7NYjkR6q67/nKxIMmPHuYkvlrJWYsQDTxWC8YvY+CoXTDT4durFiMA==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-
 "@thi.ng/random@^2.4.8":
   version "2.4.8"
   resolved "https://registry.npmjs.org/@thi.ng/random/-/random-2.4.8.tgz"
@@ -2420,16 +2346,6 @@
     "@thi.ng/api" "^7.2.0"
     "@thi.ng/checks" "^2.9.11"
     "@thi.ng/hex" "^1.0.4"
-
-"@thi.ng/random@^3.2.5":
-  version "3.2.5"
-  resolved "https://registry.npmjs.org/@thi.ng/random/-/random-3.2.5.tgz#55e792a7c22e54b76d7bae9766be190002569553"
-  integrity sha512-mo4wpbeaOWhQI+EoD6k6ThilEqCd/Qr0aMw4zg/HhgKO9yIKLA01YVwkgNc01KVLUr9gGMxc1P8NPB6kvHlXdQ==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/checks" "^3.1.5"
-    "@thi.ng/errors" "^2.1.5"
-    "@thi.ng/hex" "^2.1.5"
 
 "@thi.ng/transducers@^7.9.2":
   version "7.9.2"
@@ -2444,20 +2360,6 @@
     "@thi.ng/errors" "^1.3.4"
     "@thi.ng/math" "^4.0.6"
     "@thi.ng/random" "^2.4.8"
-
-"@thi.ng/transducers@^8.3.1":
-  version "8.3.1"
-  resolved "https://registry.npmjs.org/@thi.ng/transducers/-/transducers-8.3.1.tgz#50ea1b53d5aaae856e1ca95a7a7528cd6c720abd"
-  integrity sha512-e5b8UeZ0Ai3Dkb+b8DHYb59qNCKRdEWmnDN+u5xIJnc9lBQv9A+OauYZ5H4Wu2RMJTlhl0fGDku3UXbnClWrZA==
-  dependencies:
-    "@thi.ng/api" "^8.3.5"
-    "@thi.ng/arrays" "^2.2.1"
-    "@thi.ng/checks" "^3.1.5"
-    "@thi.ng/compare" "^2.1.5"
-    "@thi.ng/compose" "^2.1.5"
-    "@thi.ng/errors" "^2.1.5"
-    "@thi.ng/math" "^5.3.1"
-    "@thi.ng/random" "^3.2.5"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2728,7 +2630,7 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz"
   integrity sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q==
 
-"@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.1":
+"@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
@@ -9164,15 +9066,15 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
-read-pkg@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz"
-  integrity sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==
+read-pkg@5.2.0, read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
   dependencies:
-    "@types/normalize-package-data" "^2.4.1"
-    normalize-package-data "^3.0.2"
-    parse-json "^5.2.0"
-    type-fest "^2.0.0"
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -9182,16 +9084,6 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
-
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
 
 read@1, read@~1.0.1:
   version "1.0.7"


### PR DESCRIPTION
The latest versions of `ReadPkg` and `@thi.ng/cache` are ECMAScript modules which are tricky to maintain compatibility with while we are still using commonjs imports. We'll continue to stick to these versions until we can upgrade the entire project to ESM (ongoing work).