### PR TITLE
Upgrade @graphprotocol/cost-model, improve publish setup

### DIFF
--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
+    "/bin",
     "/dist"
   ],
   "repository": "https://github.com/graphprotocol/indexer",

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -4,13 +4,14 @@
   "description": "Indexer CLI for The Graph Network",
   "main": "./dist/cli.js",
   "files": [
+    "/bin",
     "/dist"
   ],
   "repository": "https://github.com/graphprotocol/cli",
   "author": "The Graph Foundation",
   "license": "MIT",
   "bin": {
-    "graph-indexer-agent": "bin/graph-indexer"
+    "graph-indexer": "bin/graph-indexer"
   },
   "scripts": {
     "format": "prettier --write 'src/**/*.ts'",

--- a/packages/indexer-cli/src/__tests__/references/help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/help.stdout
@@ -1,4 +1,4 @@
-graph-indexer version 0.19.0
+graph-indexer version 0.19.1
 
   graph-indexer                      -                                                                
   version (v)                        Output the version number                                        

--- a/packages/indexer-native/native/Cargo.toml
+++ b/packages/indexer-native/native/Cargo.toml
@@ -12,7 +12,7 @@ name = "indexer_native"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.9"
+neon-build = "0.9.1"
 
 [dependencies]
 neon = "0.9"

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -3,6 +3,7 @@
   "version": "0.19.1",
   "description": "Performance sensitive indexer code",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "files": [
     "/lib",
     "/native",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
+    "/bin",
     "/dist"
   ],
   "repository": "https://github.com/graphprotocol/indexer",


### PR DESCRIPTION
- Upgrade `neon` cargo dependency in `indexer-native`
- Include `/bin` in published package files for CLI packages
- Fix `indexer-cli` executable name
- Fix `indexer-cli` --help test