### PR TITLE
indexer-native: Declare support for ARM in package.json

### DIFF
--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -21,8 +21,12 @@
     "linux"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm"
   ],
+  "engines": {
+    "node": ">=12.22.0"
+  },
   "scripts": {
     "build": "cd native && cargo-cp-artifact -a cdylib indexer_native ../binary/index.node -- cargo build --message-format=json-render-diagnostics",
     "build-debug": "yarn build --",


### PR DESCRIPTION
- ARM machines can build the module from source
- Pre-compiling to ARM targets is still not operational so `npm i -g @graphprotcol/indexer-native`, for instance,  will not work on ARM machines