### PR TITLE
indexer-cli: indexing rule parser error catch

### DIFF
--- a/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
@@ -381,10 +381,10 @@ describe('Indexer rules tests', () => {
           'rules',
           'set',
           '0x0000000000000000000000000000000000000000-0',
-          'allocatoinAmount',
+          'allocationAmoewt',
           '1000',
         ],
-        'references/indexer-cost-set-invalid-arg',
+        'references/indexer-rules-invalid-set-arg',
         {
           expectedExitCode: 1,
           cwd: baseDir,

--- a/packages/indexer-cli/src/__tests__/references/indexer-rules-invalid-set-arg.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-rules-invalid-set-arg.stdout
@@ -1,0 +1,4 @@
+Error: Indexing rule attribute 'allocationAmoewt' not supported, did you mean?
+- allocationAmount
+- allocationLifetime
+- maxAllocationPercentage

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -177,3 +177,16 @@ export function outputColors(
     print.colors.disable()
   }
 }
+
+// Simple spell checker:
+// Suggest commands by shared letters (80% input match valid command letter sets)
+export function suggestCommands(
+  command: string,
+  supported_commands: string[],
+): Array<string> {
+  const letters = command.split('')
+  const suggestions = supported_commands.filter(
+    cmd => letters.filter(l => cmd.indexOf(l) == -1).length < command.length / 5,
+  )
+  return suggestions.length > 0 ? suggestions : supported_commands
+}

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -136,13 +136,12 @@ export const parseIndexingRule = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const obj = {} as any
   for (const [key, value] of Object.entries(rule)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const parser = (INDEXING_RULE_PARSERS as any)[key]
-    if (!parser) {
-      // In future maybe add suggestions
-      throw `Indexing rule attribute '${key}' doesn't exist, please check spelling`
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      obj[key] = (INDEXING_RULE_PARSERS as any)[key](value)
+    } catch {
+      throw new Error(key)
     }
-    obj[key] = parser(value)
   }
   return obj as Partial<IndexingRuleAttributes>
 }


### PR DESCRIPTION
When using wrong arguments for `indexer rules set`, the error message 
`TypeError: INDEXING_RULE_PARSERS[key] is not a function` 
is not very clear. 

Improve the error message to specify the invalid key: when provided a non-existing attribute, return messages like
`Indexing rule attribute 'allocatoinAmount' doesn't exist, please check spelling`

for next step: can make suggestions using modules like `spellchecker-cli`