### PR TITLE
indexer-common: start block query - ensure numeric type

### DIFF
--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -140,7 +140,7 @@ export class IndexingStatusResolver {
               `,
               {
                 subgraph: deployment.ipfsHash,
-                blockNumber: block.number,
+                blockNumber: +block.number,
                 blockHash: block.hash,
                 indexer: indexerAddress,
               },


### PR DESCRIPTION
small catch for the potential BlockPointers being returned as string that isn't being parsed to types properly using https://github.com/graphprotocol/indexer/blob/06f0c4465aa4ead000a6ec3db94b44ff551a0a94/packages/indexer-common/src/indexing-status.ts#L35-L38
