### PR TITLE
indexer-cli: remove colors from yaml and json ouputs

### DIFF
--- a/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
@@ -374,6 +374,23 @@ describe('Indexer rules tests', () => {
           timeout: 10000,
         },
       )
+      cliTest(
+        'Indexer rules set - invalid arg',
+        [
+          'indexer',
+          'rules',
+          'set',
+          '0x0000000000000000000000000000000000000000-0',
+          'allocatoinAmount',
+          '1000',
+        ],
+        'references/indexer-cost-set-invalid-arg',
+        {
+          expectedExitCode: 1,
+          cwd: baseDir,
+          timeout: 10000,
+        },
+      )
     })
 
     describe('Rules get...', () => {

--- a/packages/indexer-cli/src/__tests__/references/indexer-cost-set-invalid-arg.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-cost-set-invalid-arg.stdout
@@ -1,0 +1,1 @@
+Indexing rule attribute 'allocatoinAmount' doesn't exist, please check spelling

--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -3,7 +3,7 @@ import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
 import { BigNumber, utils } from 'ethers'
-import { pickFields } from './command-helpers'
+import { outputColors, pickFields } from './command-helpers'
 import { IndexerManagementClient } from '@graphprotocol/indexer-common'
 import gql from 'graphql-tag'
 import {
@@ -116,6 +116,7 @@ export const printIndexerAllocations = (
     | null,
   keys: (keyof IndexerAllocation)[],
 ): void => {
+  outputColors(print, outputFormat)
   if (Array.isArray(allocationOrAllocations)) {
     const allocations = allocationOrAllocations.map(allocation =>
       formatIndexerAllocation(pickFields(allocation, keys)),

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -131,6 +131,7 @@ export function printObjectOrArray(
   data: object | object[],
   keys: string[],
 ): void {
+  outputColors(print, outputFormat)
   if (Array.isArray(data)) {
     const formatted = data.map(item => pickFields(item, keys))
     print.info(displayObjectArrayData(outputFormat, formatted))
@@ -164,4 +165,15 @@ export async function validatePOI(poi: string | undefined): Promise<string | und
     }
   }
   return poi
+}
+
+export function outputColors(
+  print: GluegunPrint,
+  outputFormat: 'table' | 'json' | 'yaml',
+): void {
+  if (outputFormat === 'table') {
+    print.colors.enable()
+  } else {
+    print.colors.disable()
+  }
 }

--- a/packages/indexer-cli/src/commands/indexer/connect.ts
+++ b/packages/indexer-cli/src/commands/indexer/connect.ts
@@ -44,5 +44,6 @@ module.exports = {
     const config = loadConfig()
     config.api = url.toString()
     writeConfig(config)
+    print.success(`Indexer management API URL configured as "${urlString}"`)
   },
 }

--- a/packages/indexer-cli/src/commands/indexer/rules/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/delete.ts
@@ -65,13 +65,13 @@ module.exports = {
           ),
         )
         /* eslint-enable @typescript-eslint/no-non-null-assertion */
-        print.info(`Deleted all indexing rules`)
+        print.success(`Deleted all indexing rules`)
       } else if (identifier === 'global') {
         await deleteIndexingRules(client, ['global'])
-        print.info(`Reset global indexing rules (the global rules cannot be deleted)`)
+        print.warning(`Reset global indexing rules (the global rules cannot be deleted)`)
       } else {
         await deleteIndexingRules(client, [identifier])
-        print.info(`Deleted indexing rules for "${identifier}" (${identifierType})`)
+        print.success(`Deleted indexing rules for "${identifier}" (${identifierType})`)
       }
     } catch (error) {
       print.error(error.toString())

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -7,7 +7,7 @@ import { createIndexerManagementClient } from '../../client'
 import gql from 'graphql-tag'
 import { printIndexingRules, indexingRuleFromGraphQL } from '../../rules'
 import { printIndexerAllocations, indexerAllocationFromGraphQL } from '../../allocations'
-import { formatData, pickFields } from '../../command-helpers'
+import { formatData, outputColors, pickFields } from '../../command-helpers'
 
 const HELP = `
 ${chalk.bold('graph indexer status')}
@@ -219,13 +219,14 @@ module.exports = {
       }
     }
 
+    outputColors(print, outputFormat)
     if (outputFormat === 'table') {
-      print.info('Registration')
+      print.highlight('Registration')
       print.info(formatData(data.registration, outputFormat))
       print.info('')
-      print.info('Endpoints')
+      print.highlight('Endpoints')
       if (data.endpoints.error) {
-        print.info(formatData([data.endpoints], outputFormat))
+        print.error(formatData([data.endpoints], outputFormat))
       } else {
         print.info(
           formatData(
@@ -258,7 +259,7 @@ module.exports = {
         }
       }
       print.info('')
-      print.info('Indexer Deployments')
+      print.highlight('Indexer Deployments')
       if (data.indexerDeployments) {
         print.info(
           formatData(
@@ -282,7 +283,7 @@ module.exports = {
         )
       }
       print.info('')
-      print.info('Indexer Allocations')
+      print.highlight('Indexer Allocations')
       if (data.indexerAllocations) {
         printIndexerAllocations(print, outputFormat, data.indexerAllocations, [
           'id',
@@ -294,7 +295,7 @@ module.exports = {
         ])
       }
       print.info('')
-      print.info('Indexing Rules')
+      print.highlight('Indexing Rules')
       if (data.indexingRules.length === 1 && data.indexingRules[0].error) {
         print.info(formatData(data.indexingRules[0], outputFormat))
       } else {

--- a/packages/indexer-cli/src/cost.ts
+++ b/packages/indexer-cli/src/cost.ts
@@ -8,7 +8,7 @@ import gql from 'graphql-tag'
 import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
-import { pickFields } from './command-helpers'
+import { outputColors, pickFields } from './command-helpers'
 
 export type SubgraphDeploymentIDIsh = SubgraphDeploymentID | 'all'
 
@@ -170,6 +170,7 @@ export const printCostModels = (
   costModelOrModels: Partial<CostModelAttributes> | Partial<CostModelAttributes>[] | null,
   fields: string[],
 ): void => {
+  outputColors(print, outputFormat)
   if (Array.isArray(costModelOrModels)) {
     const costModels = costModelOrModels.map(cost =>
       formatCostModel(pickFields(cost, fields), {

--- a/packages/indexer-cli/src/disputes.ts
+++ b/packages/indexer-cli/src/disputes.ts
@@ -8,6 +8,7 @@ import gql from 'graphql-tag'
 import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
+import { outputColors } from './command-helpers'
 
 const DISPUTE_FORMATTERS: Record<keyof POIDisputeAttributes, (x: never) => string> = {
   allocationID: x => x,
@@ -112,6 +113,7 @@ export const printDisputes = (
   outputFormat: 'table' | 'json' | 'yaml',
   disputes: Partial<POIDisputeAttributes>[] | null,
 ): void => {
+  outputColors(print, outputFormat)
   if (Array.isArray(disputes)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const formattedDisputes = disputes.map(dispute => formatDispute(dispute))

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -137,7 +137,12 @@ export const parseIndexingRule = (
   const obj = {} as any
   for (const [key, value] of Object.entries(rule)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    obj[key] = (INDEXING_RULE_PARSERS as any)[key](value)
+    const parser = (INDEXING_RULE_PARSERS as any)[key]
+    if (!parser) {
+      // In future maybe add suggestions
+      throw `Indexing rule attribute '${key}' doesn't exist, please check spelling`
+    }
+    obj[key] = parser(value)
   }
   return obj as Partial<IndexingRuleAttributes>
 }

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -9,7 +9,7 @@ import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
 import { BigNumber, utils } from 'ethers'
-import { pickFields } from './command-helpers'
+import { outputColors, pickFields } from './command-helpers'
 
 export type SubgraphDeploymentIDIsh = SubgraphDeploymentID | 'global' | 'all'
 
@@ -227,6 +227,7 @@ export const printIndexingRules = (
   ruleOrRules: Partial<IndexingRuleAttributes> | Partial<IndexingRuleAttributes>[] | null,
   keys: (keyof IndexingRuleAttributes)[],
 ): void => {
+  outputColors(print, outputFormat)
   if (Array.isArray(ruleOrRules)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rules = ruleOrRules.map(rule => formatIndexingRule(pickFields(rule, keys)))
@@ -240,7 +241,7 @@ export const printIndexingRules = (
 
     print.info(displayIndexingRules(outputFormat, onchainRules))
     if (offchainRules) {
-      print.info('Offchain syncing subgraphs')
+      print.highlight('Offchain sync list')
       print.info(
         offchainRules.map(rule => {
           return rule.identifier


### PR DESCRIPTION
To keep consistent between writing in the terminal and file, we remove all the colors codes when someone is outputting JSON or YAML

