### PR TITLE
Dockerfiles: Update base images to node:16.15-bullseye-slim

### DIFF
--- a/Dockerfile.indexer-agent
+++ b/Dockerfile.indexer-agent
@@ -1,7 +1,7 @@
 ########################################################################
 # Build image
 
-FROM node:16.13.1-slim as build
+FROM node:16.15-bullseye-slim as build
 
 ENV NODE_ENV production
 
@@ -29,7 +29,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:16.13.1-slim
+FROM node:16.15-bullseye-slim
 
 ENV NODE_ENV production
 # When simulating large transactions, sometimes indexer-agent runs out of memory.

--- a/Dockerfile.indexer-cli
+++ b/Dockerfile.indexer-cli
@@ -1,7 +1,7 @@
 ########################################################################
 # Build image
 
-FROM node:16.13.1-slim as build
+FROM node:16.15-bullseye-slim as build
 
 ENV NODE_ENV production
 
@@ -30,7 +30,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:16.13.1-slim
+FROM node:16.15-bullseye-slim
 
 ENV NODE_ENV production
 

--- a/Dockerfile.indexer-service
+++ b/Dockerfile.indexer-service
@@ -1,7 +1,7 @@
 ########################################################################
 # Build image
 
-FROM node:16.13.1-slim as build
+FROM node:16.15-bullseye-slim as build
 
 ENV NODE_ENV production
 
@@ -30,7 +30,7 @@ RUN yarn --frozen-lockfile --non-interactive --production=false
 ########################################################################
 # Runtime image
 
-FROM node:16.13.1-slim
+FROM node:16.15-bullseye-slim
 
 ENV NODE_ENV production
 

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -37,6 +37,7 @@
     "morgan": "1.10.0",
     "ngeohash": "0.6.3",
     "p-filter": "2.1.0",
+    "p-reduce": "2.1.0",
     "p-retry": "4.6.1",
     "p-timeout": "4.1.0",
     "sequelize": "6.18.0",


### PR DESCRIPTION
`node:16.13.1-slim` images use an older version of GLIBC not compatible with the
precompiled native binaries. 

This fixes docker image builds, but we'll need to find a solution so that users can build the packages on older versions of linux with older GLIBC versions. 