### PR TITLE
CI: Use older version of Ubuntu to precompile native binaries

### DIFF
--- a/.github/workflows/publish-native-binaries.yml
+++ b/.github/workflows/publish-native-binaries.yml
@@ -19,7 +19,7 @@ jobs:
         system:
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-latest
+          - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.system.os }}
     steps:


### PR DESCRIPTION
Improve compatibility with linux distros.