### PR TITLE
indexer-service detailed query logs

### DIFF
--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -154,6 +154,13 @@ export default {
         default: 'debug',
         group: 'Indexer Infrastructure',
       })
+      .option('query-timing-logs', {
+        description: 'Log time spent on each query received',
+        type: 'boolean',
+        default: false,
+        required: false,
+        group: 'Indexer Infrastructure',
+      })
       .option('vector-node', {
         description: 'URL of a vector node',
         type: 'string',
@@ -436,6 +443,7 @@ export default {
       metrics,
       receiptManager,
       signers,
+      queryTimingLogs: argv.queryTimingLogs,
     })
 
     const indexerManagementClient = await createIndexerManagementClient({

--- a/packages/indexer-service/src/query-fees/allocations.ts
+++ b/packages/indexer-service/src/query-fees/allocations.ts
@@ -79,7 +79,11 @@ export class AllocationReceiptManager implements ReceiptManager {
   }
 
   // Saves the receipt and returns the allocation for signing
-  async add(receiptData: string): Promise<Address> {
+  async add(receiptData: string): Promise<{
+    id: string
+    allocation: Address
+    fees: BigNumber
+  }> {
     // Security: Input validation
     if (!allocationReceiptValidator.test(receiptData)) {
       throw indexerError(IndexerErrorCode.IE031, 'Expecting 264 hex characters')
@@ -93,7 +97,7 @@ export class AllocationReceiptManager implements ReceiptManager {
 
     // If the fee is 0, validate verifier and return allocation ID for the signer
     if (receipt.fees.isZero()) {
-      return receipt.allocation
+      return receipt
     }
 
     this._queue({
@@ -103,7 +107,7 @@ export class AllocationReceiptManager implements ReceiptManager {
       signature,
     })
 
-    return receipt.allocation
+    return receipt
   }
 
   /// Flushes all receipts that have been registered by this moment in time.

--- a/packages/indexer-service/src/query-fees/index.ts
+++ b/packages/indexer-service/src/query-fees/index.ts
@@ -1,8 +1,13 @@
 import { Address } from '@graphprotocol/common-ts'
+import { BigNumber } from 'ethers'
 
 export * from './allocations'
 
 export interface ReceiptManager {
   // Saves the query fees and returns the allocation for signing
-  add(receiptData: string): Promise<Address>
+  add(receiptData: string): Promise<{
+    id: string
+    allocation: Address
+    fees: BigNumber
+  }>
 }


### PR DESCRIPTION
The goal is to enable monitoring of the fees paid for queries.

The change adds detailed query logs for paid queries w/:

Deployment (base58 IPFS hash)
Query execution time
GQL query / variables
GRT fees
Note that to add the GQL query response time measurement to Axios as recommended in the documentation, I had to do some non-TSisms. Hopefully there is a better way to do that.