### PR TITLE
Actions Queue: add auto batch options and conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,11 @@ Indexer Infrastructure
                                         block gas limit  [number] [default: 100]
   --log-level                           Log level    [string] [default: "debug"]
   --allocation-management               Indexer agent allocation management
-                                        automation mode (auto|manual)
+                                        automation mode (auto|manual|oversight)
                                                       [string] [default: "auto"]
+  --auto-allocation-min-batch-size                 Minimum number of allocation 
+                                        transactions inside a batch for AUTO 
+                                        management mode    [number] [default: 1]
 
 Network Subgraph
   --network-subgraph-deployment   Network subgraph deployment           [string]

--- a/packages/indexer-agent/README.md
+++ b/packages/indexer-agent/README.md
@@ -38,6 +38,12 @@ Indexer Infrastructure
                                 'false' rewards will be returned to the wallet
                                                        [boolean] [default: true]
   --log-level                   Log level            [string] [default: "debug"]
+  --allocation-management               Indexer agent allocation management
+                                        automation mode (auto|manual|oversight)
+                                                      [string] [default: "auto"]
+  --auto-allocation-min-batch-size                 Minimum number of allocation 
+                                        transactions inside a batch for auto 
+                                        management mode    [number] [default: 1]
 
 Network Subgraph
   --network-subgraph-deployment  Network subgraph deployment            [string]

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -421,6 +421,12 @@ export default {
         default: 'auto',
         group: 'Indexer Infrastructure',
       })
+      .option('auto-allocation-min-batch-size', {
+        description: `Minimum number of allocation transactions inside a batch for auto allocation management. No obvious upperbound, with default of 1`,
+        type: 'number',
+        default: 1,
+        group: 'Indexer Infrastructure',
+      })
       .config({
         key: 'config-file',
         description: 'Indexer agent configuration file (YAML format)',
@@ -759,6 +765,10 @@ export default {
     )
 
     logger.info('Launch indexer management API server')
+    const allocationManagementMode =
+      AllocationManagementMode[
+        argv.allocationManagement.toUpperCase() as keyof typeof AllocationManagementMode
+      ]
     const indexerManagementClient = await createIndexerManagementClient({
       models: managementModels,
       address: indexerAddress,
@@ -779,6 +789,8 @@ export default {
       },
       transactionManager: network.transactionManager,
       receiptCollector,
+      allocationManagementMode,
+      autoAllocationMinBatchSize: argv.autoAllocationMinBatchSize,
     })
 
     await createIndexerManagementServer({
@@ -845,10 +857,7 @@ export default {
         (s: string) => new SubgraphDeploymentID(s),
       ),
       receiptCollector,
-      allocationManagementMode:
-        AllocationManagementMode[
-          argv.allocationManagement.toUpperCase() as keyof typeof AllocationManagementMode
-        ],
+      allocationManagementMode,
     })
   },
 }

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -29,6 +29,7 @@ import { SubgraphManager } from './subgraphs'
 import { AllocationReceiptCollector } from '../allocations/query-fees'
 import {
   ActionManager,
+  AllocationManagementMode,
   AllocationManager,
   NetworkMonitor,
 } from '@graphprotocol/indexer-common'
@@ -408,6 +409,8 @@ export interface IndexerManagementClientOptions {
   ethereum?: ethers.providers.BaseProvider
   transactionManager?: TransactionManager
   receiptCollector?: AllocationReceiptCollector
+  allocationManagementMode?: AllocationManagementMode
+  autoAllocationMinBatchSize?: number
 }
 
 export class IndexerManagementClient extends Client {
@@ -470,6 +473,8 @@ export const createIndexerManagementClient = async (
     features,
     transactionManager,
     receiptCollector,
+    allocationManagementMode,
+    autoAllocationMinBatchSize,
   } = options
   const schema = buildSchema(print(SCHEMA_SDL))
   const resolvers = {
@@ -510,7 +515,14 @@ export const createIndexerManagementClient = async (
         subgraphManager,
         transactionManager,
       )
-      actionManager = new ActionManager(allocationManager, logger, models)
+      actionManager = new ActionManager(
+        allocationManager,
+        networkMonitor,
+        logger,
+        models,
+        allocationManagementMode,
+        autoAllocationMinBatchSize,
+      )
 
       logger.info('Begin monitoring the queue for approved actions to execute')
       await actionManager.monitorQueue()

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -38,6 +38,13 @@ export class NetworkMonitor {
     private ethereum: providers.BaseProvider,
   ) {}
 
+  async currentEpoch(): Promise<number> {
+    return (await this.contracts.epochManager.currentEpoch()).toNumber()
+  }
+  async maxAllocationEpoch(): Promise<number> {
+    return await this.contracts.staking.maxAllocationEpochs()
+  }
+
   async allocation(allocationID: string): Promise<Allocation | undefined> {
     const result = await this.networkSubgraph.query(
       gql`
@@ -80,7 +87,12 @@ export class NetworkMonitor {
       const result = await this.networkSubgraph.query(
         gql`
           query allocations($indexer: String!, $status: AllocationStatus!) {
-            allocations(where: { indexer: $indexer, status: $status }, first: 1000) {
+            allocations(
+              where: { indexer: $indexer, status: $status }
+              first: 1000
+              orderBy: createdAtBlockNumber
+              orderDirection: asc
+            ) {
               id
               indexer {
                 id


### PR DESCRIPTION
When an indexer uses AUTO management mode, the agent automatically approve actions for the worker to execute. 

To avoid worker executing those transactions right away, we provide `indexer-agent` optional start up parameters:
- `--auto-min-batch-size`: require a minimum batch size 
- `--auto-max-wait-time`: wait for certain minutes after the first approved actions' update time

These 2 parameters are useful when an indexer let the agent perform automatic batched transactions, allow time for indexers to modify actions, and in particular save gas costs on allocations. 

Another condition we added is that actions will still execute right away when an on-chain transactions is expiring - the agent automatically produce and approve reallocation actions and it seems sensible to allow worker to execute them as quickly as possible.

Action queue worker will continue as usual if any of the 3 conditions are met. 

Additionally, within a batch, actions of type `unallocate` are ordered before of type `reallocate` which is before `allocate`.