### PR TITLE
Indexer-cli: only print identifier for offchain subgraphs

### DIFF
--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -236,7 +236,11 @@ export const printIndexingRules = (
     print.info(displayIndexingRules(outputFormat, onchainRules))
     if (offchainRules) {
       print.info('Offchain syncing subgraphs')
-      print.info(displayIndexingRules(outputFormat, offchainRules))
+      print.info(
+        offchainRules.map(rule => {
+          return rule.identifier
+        }),
+      )
     } else {
       print.info(`Not syncing any subgraphs offchain`)
     }


### PR DESCRIPTION
For offchain subgraphs, indexing rules fields like `allocationAmount` doesn't really matter, so the table view is more than enough. For a clearer output, we simply print out offchain subgraphs' list of identifiers. 