### PR TITLE
indexer-common: query fee explicitly check for numeric type

### DIFF
--- a/packages/indexer-common/src/network.ts
+++ b/packages/indexer-common/src/network.ts
@@ -732,7 +732,13 @@ export class Network {
       // in order to maximise the value of the truncated batch
       // more query fees collected should mean higher value rebates
       const allocationIds = allocations
-        .sort((x, y) => (y.queryFeesCollected?.gt(x.queryFeesCollected || 0) ? 1 : -1))
+        .sort((x, y) =>
+          y.queryFeesCollected instanceof BigNumber
+            ? y.queryFeesCollected.gt(x.queryFeesCollected || 0)
+              ? 1
+              : -1
+            : -1,
+        )
         .map((allocation) => allocation.id)
         .slice(0, maxClaimsPerBatch)
 


### PR DESCRIPTION
```
action: "ClaimMany"
    err: {
      "type": "IndexerError",
      "message": "Failed to claim allocation",
      "stack":
          IndexerError: Failed to claim allocation
              at indexerError (/opt/indexer/packages/indexer-common/dist/errors.js:143:12)
              at Network.<anonymous> (/opt/indexer/packages/indexer-common/dist/network.js:993:60)
              at Generator.next (<anonymous>)
              at fulfilled (/opt/indexer/packages/indexer-common/dist/network.js:5:58)
              at runMicrotasks (<anonymous>)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
      "code": "IE016",
      "explanation": "https://github.com/graphprotocol/indexer/blob/master/docs/errors.md#ie016",
      "cause": {
        "type": "TypeError",
        "message": "_a.gt is not a function",
        "stack":
            TypeError: _a.gt is not a function
                at /opt/indexer/packages/indexer-common/dist/network.js:969:124
                at Array.sort (<anonymous>)
                at Network.<anonymous> (/opt/indexer/packages/indexer-common/dist/network.js:969:22)
                at Generator.next (<anonymous>)
                at fulfilled (/opt/indexer/packages/indexer-common/dist/network.js:5:58)
                at runMicrotasks (<anonymous>)
                at processTicksAndRejections (node:internal/process/task_queues:96:5)
      }
```

Unable to reproduce this on testnet but maybe it was because JS lost the bigNumber type for `queryFeesCollected: BigNumber | undefined`...? Maybe we should explicitly checking for type 
