### PR TITLE
Upgrade @graphprotocol/contracts dependency

### DIFF
--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -29,8 +29,8 @@
     "graph-indexer-agent": "bin/graph-indexer-agent"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.4",
-    "@graphprotocol/contracts": "1.11.1",
+    "@graphprotocol/common-ts": "1.8.6",
+    "@graphprotocol/contracts": "1.13.0",
     "@graphprotocol/indexer-common": "^0.20.0",
     "@thi.ng/heaps": "^1.3.1",
     "@uniswap/sdk": "3.0.3",

--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -132,7 +132,8 @@ const setup = async () => {
 
   const networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
 

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -26,7 +26,7 @@
     "test:watch": "jest --watch --detectOpenHandles --verbose"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.4",
+    "@graphprotocol/common-ts": "1.8.6",
     "@graphprotocol/indexer-common": "^0.20.0",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.74",

--- a/packages/indexer-cli/src/__tests__/util.ts
+++ b/packages/indexer-cli/src/__tests__/util.ts
@@ -63,7 +63,8 @@ export const setup = async () => {
 
   const networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
   const indexNodeIDs = ['node_1']

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.4",
+    "@graphprotocol/common-ts": "1.8.6",
     "@graphprotocol/cost-model": "0.1.14",
     "@thi.ng/heaps": "1.2.38",
     "@urql/core": "2.4.4",

--- a/packages/indexer-common/src/indexer-management/__tests__/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/actions.ts
@@ -245,7 +245,8 @@ const setup = async () => {
   })
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
   transactionManager = new TransactionManager(

--- a/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/cost-models.ts
@@ -93,7 +93,8 @@ const setupAll = async () => {
   })
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
 

--- a/packages/indexer-common/src/indexer-management/__tests__/indexing-rules.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/indexing-rules.ts
@@ -144,7 +144,8 @@ const setupAll = async () => {
   })
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
   const indexNodeIDs = ['node_1']

--- a/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/poi-disputes.ts
@@ -206,7 +206,8 @@ const setupAll = async () => {
   })
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
   const indexNodeIDs = ['node_1']

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -46,7 +46,7 @@
     "clean": "rm -rf ./node_modules ./binary ./build ./coverage ./native/target ./native/artifacts.json ./native/index.node"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "1.8.4",
+    "@graphprotocol/common-ts": "1.8.6",
     "@mapbox/node-pre-gyp": "1.0.9",
     "cargo-cp-artifact": "0.1.6"
   },

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@google-cloud/profiler": "4.1.7",
-    "@graphprotocol/common-ts": "1.8.4",
+    "@graphprotocol/common-ts": "1.8.6",
     "@graphprotocol/indexer-common": "^0.20.0",
     "@graphprotocol/indexer-native": "^0.20.0",
     "@graphql-tools/load": "7.5.8",

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -69,7 +69,8 @@ const setup = async () => {
   })
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: 'https://gateway.testnet.thegraph.com/network',
+    endpoint:
+      'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
   const indexNodeIDs = ['node_1']

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,12 +777,12 @@
   resolved "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz"
   integrity sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==
 
-"@graphprotocol/common-ts@1.8.4":
-  version "1.8.4"
-  resolved "https://registry.npmjs.org/@graphprotocol/common-ts/-/common-ts-1.8.4.tgz#a20e8126a7da34239904b0d3ad7c225d56d6cc17"
-  integrity sha512-qHAW4gNYBxD2SahGsKCzn1dmeVII+POws4dNQ5h8vvq4DWjdDzhUrb/qQWcmqmsZQ9MI4lQEoB/s5WdFMeRMNw==
+"@graphprotocol/common-ts@1.8.6":
+  version "1.8.6"
+  resolved "https://registry.npmjs.org/@graphprotocol/common-ts/-/common-ts-1.8.6.tgz#d12fe02d3f4ce544087cf9b57af26e95ca1b3b80"
+  integrity sha512-HSJ5hv1CZ1JSx0tGkEWrlG7G1QranrnipCmqkrl0U3gwfKss1XwCXuFtqMarE1NxMmYj46xKsrBm4/drlw7wLg==
   dependencies:
-    "@graphprotocol/contracts" "1.11.1"
+    "@graphprotocol/contracts" "1.13.0"
     "@graphprotocol/pino-sentry-simple" "0.7.1"
     "@urql/core" "2.4.4"
     "@urql/exchange-execute" "1.2.2"
@@ -804,10 +804,10 @@
     prom-client "14.0.1"
     sequelize "6.19.0"
 
-"@graphprotocol/contracts@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@graphprotocol/contracts/-/contracts-1.11.1.tgz"
-  integrity sha512-z4klBGRf9X08iE+JQKHH5VfmPh/8btDVVof9pckDd5bSsnPG4TvvpDHJnPAw+TQRRtoiKmDIvNIGBajRTAtQzA==
+"@graphprotocol/contracts@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/@graphprotocol/contracts/-/contracts-1.13.0.tgz#0289f9ef725f342ad1c69a9ac70bc5129c3eb0a3"
+  integrity sha512-1s6559hsvOQv6bbEGYOvkvuO4DkurwNKeHQ4wM3qT3j0v96sEd1xJSXL9fIOTPyg53BDfz8pZHe2+xaohXvVbg==
   dependencies:
     ethers "^5.4.4"
 


### PR DESCRIPTION
The latest address book is required to run an indexer on Goerli, so the contracts dependency was updated to the version which includes it, v1.13.0.  Common-ts also depends on @graphprotocol/contracts, so it was upgraded as well.