### PR TITLE
Update networks.md hyperlink label to 0.27.0

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -10,7 +10,7 @@ For mainnet:
 | indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| graph-node      | [0.26.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.27.0) |
+| graph-node      | [0.27.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.27.0) |
 
 For testnet:
 
@@ -20,7 +20,7 @@ For testnet:
 | indexer-agent   | [0.20.2](https://github.com/graphprotocol/indexer/releases/tag/v0.20.2)    |
 | indexer-cli     | [0.20.1](https://github.com/graphprotocol/indexer/releases/tag/v0.20.1)    |
 | indexer-service | [0.20.1](https://github.com/graphprotocol/indexer/releases/tag/v0.20.1)    |
-| graph-node      | [0.26.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.27.0) |
+| graph-node      | [0.27.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.27.0) |
 
 ## Mainnet (https://network.thegraph.com)
 


### PR DESCRIPTION
The link provided in PR #446 updated the link to /v0.27.0 but did not include the update to the label - visually it appears that it is still recommending 0.26.0.