### PR TITLE
indexer-common,indexer-agent: Include reason for actions being added to queue

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -8,6 +8,7 @@ import {
   toAddress,
 } from '@graphprotocol/common-ts'
 import {
+  AllocationManagementMode,
   createIndexerManagementClient,
   defineIndexerManagementModels,
   IndexerManagementClient,
@@ -166,6 +167,7 @@ const setup = async () => {
     ['test'],
     parseGRT('1000'),
     address,
+    AllocationManagementMode.AUTO,
   )
 }
 

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -808,6 +808,7 @@ export default {
       argv.indexNodeIds,
       argv.defaultAllocationAmount,
       indexerAddress,
+      allocationManagementMode,
     )
     const networkSubgraphDeployment = argv.networkSubgraphDeployment
       ? new SubgraphDeploymentID(argv.networkSubgraphDeployment)
@@ -857,7 +858,6 @@ export default {
         (s: string) => new SubgraphDeploymentID(s),
       ),
       receiptCollector,
-      allocationManagementMode,
     })
   },
 }

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -197,7 +197,7 @@ export class Indexer {
         },
       )
 
-      this.logger.info(`Queried index nodes`, {
+      this.logger.trace(`Queried index nodes`, {
         indexNodes,
       })
       return indexNodes
@@ -731,14 +731,14 @@ export class Indexer {
       activeDeploymentAllocations
         .filter(allocation => allocation.createdAtEpoch < epoch)
         .map(allocation => allocation.id)
-    logger.info(
-      `Deployment is not (or no longer) worth allocating towards, close allocation if it is from a previous epoch`,
-      {
-        eligibleForClose: activeDeploymentAllocationsEligibleForClose,
-      },
-    )
     // Make sure to close all active allocations on the way out
     if (activeDeploymentAllocationsEligibleForClose.length > 0) {
+      logger.info(
+        `Deployment is not (or no longer) worth allocating towards, close allocation`,
+        {
+          eligibleForClose: activeDeploymentAllocationsEligibleForClose,
+        },
+      )
       await pMap(
         // We can only close allocations from a previous epoch;
         // try the others again later

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -1,6 +1,5 @@
 import { Logger, Metrics, SubgraphDeploymentID } from '@graphprotocol/common-ts'
 import {
-  AllocationManagementMode,
   Network,
   NetworkSubgraph,
   ReceiptCollector,
@@ -19,5 +18,4 @@ export interface AgentConfig {
   registerIndexer: boolean
   offchainSubgraphs: SubgraphDeploymentID[]
   receiptCollector: ReceiptCollector
-  allocationManagementMode: AllocationManagementMode
 }

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -12,6 +12,7 @@ export interface ActionParamsInput {
 export interface ActionItem {
   params: ActionParamsInput
   type: ActionType
+  reason: string
 }
 
 export interface ActionInput {

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -1131,5 +1131,6 @@ export class AllocationManager {
       )
     }
     return isDeploymentWorthAllocatingTowards(logger, subgraphDeployment, indexingRules)
+      .toAllocate
   }
 }

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -542,7 +542,7 @@ export class NetworkMonitor {
       }
     }
 
-    this.logger.trace(`Fetched subgraph deployments published to network`, {
+    this.logger.debug(`Finished fetching subgraph deployments published to network`, {
       publishedSubgraphs: queryProgress.fetched,
     })
     return deployments

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -41,6 +41,7 @@ async function executeQueueOperation(
       duplicateAction[0].source === action.source &&
       duplicateAction[0].status === action.status
     ) {
+      // TODO: Log this only when update will actually change existing item
       logger.info(
         `Action found in queue that effects the same deployment as proposed queue action, updating existing action`,
         {

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -134,6 +134,7 @@ const setup = async () => {
     graphNode: 'http://localhost:8000/',
     metrics,
     receiptManager,
+    queryTimingLogs: false,
     signers,
   })
 


### PR DESCRIPTION
With the ultimate goal of including meaningful reason strings for each action added to the actions queue a number of changes have been made in this PR. 

The process of resolving which deployments are worth allocating towards has been updated to now result in an array of allocation decisions with length equal to the number of subgraph deployments on the network, including both toAllocate and not toAllocate decisions (rather than an array of only subgraph ids to allocate to).  

```typescript
AllocationDecision {
  declare deployment: SubgraphDeploymentID
  declare toAllocate: boolean
  declare ruleMatch: RuleMatch
  }
```

In addition, the process of resolving allocation actions has been updated. `reconcileAllocations`  and `reconcileDeploymentAllocations` have been replaced with `reconcileActions`,`reconcileDeploymentActions` and in the process been simplified and allowed for concurrency in reconciling many actions.  

A few more structural changes have also been made to move some network querying functions into the `NetworkMonitor`. 