### PR TITLE
indexer-cli: command to batch approve queued

### DIFF
--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -128,6 +128,7 @@ export interface ActionFilter {
 }
 
 export interface ActionResult {
+  id: number
   type: ActionType
   deploymentID: string
   allocationID: string | null

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -180,6 +180,7 @@ const SCHEMA_SDL = gql`
     status: String!
     transaction: String
     failureReason: String
+    priority: Int
   }
 
   input ActionFilter {


### PR DESCRIPTION
Resolves #449 

If there's more than one actions with queued status, indexers can use `indexer-cli` as such to approve all the queued actions
```
./bin/graph-indexer indexer actions approve queued
```

If there's no queued actions, expect error `Failed to process action ids, check queue for available actions`.

Alternatively we can add a new query type for `approveActions` to include parameter for `ActionStatus`?

