### PR TITLE
Set default for cost models plurals, add tests

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -396,8 +396,12 @@ class Agent {
       ticker: timer(600_000),
       networkDeploymentAllocationDecisions,
     }).tryMap(
-      async () => {
-        return await this.indexer.costModels()
+      async ({ networkDeploymentAllocationDecisions }) => {
+        return await this.indexer.costModels(
+          networkDeploymentAllocationDecisions
+            .filter(a => a.toAllocate)
+            .map(a => a.deployment),
+        )
       },
       {
         onError: error =>

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -327,26 +327,31 @@ export class Indexer {
       }
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE017, error)
-      this.logger.error('Failed to ensure default "global" indexing rule', {
+      this.logger.warn('Failed to ensure default "global" indexing rule', {
         err,
       })
       throw err
     }
   }
 
-  async costModels(): Promise<CostModelAttributes[]> {
+  async costModels(
+    deployments: SubgraphDeploymentID[],
+  ): Promise<CostModelAttributes[]> {
     try {
       const result = await this.indexerManagement
         .query(
           gql`
-            query costModels {
-              costModels {
+            query costModels($deployments: [String!]!) {
+              costModels(deployments: $deployments) {
                 deployment
                 model
                 variables
               }
             }
           `,
+          {
+            deployments,
+          },
         )
         .toPromise()
 
@@ -355,7 +360,7 @@ export class Indexer {
       }
       return result.data.costModels
     } catch (error) {
-      this.logger.error(`Failed to query indexer management API`, { error })
+      this.logger.warn(`Failed to query cost models`, { error })
       throw error
     }
   }

--- a/packages/indexer-common/src/indexer-management/models/cost-model.ts
+++ b/packages/indexer-common/src/indexer-management/models/cost-model.ts
@@ -79,7 +79,7 @@ export const defineCostModelModels = (sequelize: Sequelize): CostModelModels => 
       },
       deployment: {
         type: DataTypes.STRING,
-        allowNull: true,
+        allowNull: false,
         primaryKey: true,
         validate: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -77,6 +77,19 @@ export default {
       where: deployments ? { deployment: deployments } : undefined,
       order: [['deployment', 'ASC']],
     })
+    const definedDeployments = new Set(costModels.map((model) => model.deployment))
+    const undefinedDeployments = deployments?.filter((d) => !definedDeployments.has(d))
+    const globalModel = await models.CostModel.findOne({
+      where: { deployment: COST_MODEL_GLOBAL },
+    })
+    if (globalModel && undefinedDeployments) {
+      const mergedCostModels = undefinedDeployments.map((d) => {
+        globalModel.setDataValue('deployment', d)
+        return globalModel.toGraphQL()
+      })
+      return costModels.map((model) => model.toGraphQL()).concat(mergedCostModels)
+    }
+
     return costModels.map((model) => model.toGraphQL())
   },
 

--- a/packages/indexer-service/src/server/cost.ts
+++ b/packages/indexer-service/src/server/cost.ts
@@ -167,7 +167,7 @@ export const createCostServer = async ({
             const result = await context.client
               .query(
                 gql`
-                  query costModel($deployment: [String!]) {
+                  query costModel($deployment: String!) {
                     costModel(deployment: $deployment) {
                       deployment
                       model


### PR DESCRIPTION
Received report on query to cost model still returns null when global cost model has been set. 

- Update indexer-serivce `costModels` queries to return global cost models for the deployments without cost model defined.
- Add basic tests in `indexer-common` as we debug the potential issue