### PR TITLE
indexer-common: Update actions query ordering inputs

### DIFF
--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -1,11 +1,12 @@
 import {
   ActionFilter,
   ActionInput,
-  ActionOrderBy,
+  ActionParams,
   ActionResult,
   ActionStatus,
   ActionType,
   IndexerManagementClient,
+  OrderDirection,
 } from '@graphprotocol/indexer-common'
 import { validateRequiredParams } from './command-helpers'
 import gql from 'graphql-tag'
@@ -275,13 +276,18 @@ export async function fetchAction(
 export async function fetchActions(
   client: IndexerManagementClient,
   actionFilter: ActionFilter,
-  actionOrder?: ActionOrderBy,
+  orderBy?: ActionParams,
+  orderDirection?: OrderDirection,
 ): Promise<ActionResult[]> {
   const result = await client
     .query(
       gql`
-        query actions($filter: ActionFilter!, $order: ActionOrderBy) {
-          actions(filter: $filter, orderBy: $order) {
+        query actions(
+          $filter: ActionFilter!
+          $orderBy: ActionParams
+          $orderDirection: OrderDirection
+        ) {
+          actions(filter: $filter, orderBy: $orderBy, orderDirection: $orderDirection) {
             id
             type
             allocationID
@@ -298,7 +304,7 @@ export async function fetchActions(
           }
         }
       `,
-      { filter: actionFilter, order: actionOrder },
+      { filter: actionFilter, orderBy, orderDirection },
     )
     .toPromise()
 

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -1,6 +1,5 @@
 import { ActionManager, NetworkMonitor } from './indexer-management'
 import { AllocationStatus } from './allocations'
-import { Sort } from './types'
 
 export interface ActionParamsInput {
   deploymentID?: string
@@ -156,18 +155,19 @@ export enum ActionStatus {
   CANCELED = 'canceled',
 }
 
-export interface ActionOrderBy {
-  id?: Sort | undefined
-  status?: Sort | undefined
-  type?: Sort | undefined
-  deploymentID?: Sort | undefined
-  allocationID?: Sort | undefined
-  amount?: Sort | undefined
-  poi?: Sort | undefined
-  force?: Sort | undefined
-  source?: Sort | undefined
-  reason?: Sort | undefined
-  priority?: Sort | undefined
-  createdAt?: Sort | undefined
-  updatedAt?: Sort | undefined
+export enum ActionParams {
+  ID = 'id',
+  STATUS = 'status',
+  TYPE = 'type',
+  DEPLOYMENT_ID = 'deploymentID',
+  ALLOCATION_ID = 'allocationID',
+  TRANSACTION = 'transaction',
+  AMOUNT = 'amount',
+  POI = 'poi',
+  FORCE = 'force',
+  SOURCE = 'source',
+  REASON = 'reason',
+  PRIORITY = 'priority',
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
 }

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -1,13 +1,14 @@
 import {
   Action,
   ActionFilter,
-  ActionOrderBy,
+  ActionParams,
   ActionStatus,
   AllocationManagementMode,
   AllocationStatus,
   IndexerManagementModels,
   isActionFailure,
   NetworkMonitor,
+  OrderDirection,
 } from '@graphprotocol/indexer-common'
 import { AllocationManager } from './allocations'
 import { Order, Transaction } from 'sequelize'
@@ -152,15 +153,18 @@ export class ActionManager {
     return updatedActions
   }
 
-  async fetchActions(filter: ActionFilter, order?: ActionOrderBy): Promise<Action[]> {
+  async fetchActions(
+    filter: ActionFilter,
+    orderBy?: ActionParams,
+    orderDirection?: OrderDirection,
+  ): Promise<Action[]> {
     const filterObject = JSON.parse(JSON.stringify(filter))
-    const orderObject: Order = order
-      ? Object.keys(order).map((e, i) => [e, Object.values(order)[i].toUpperCase()])
-      : [['id', 'DESC']]
-    const queryResult = await this.models.Action.findAll({
+    const orderObject: Order = orderBy
+      ? [[orderBy.toString(), orderDirection ?? 'desc']]
+      : [['id', 'desc']]
+    return await this.models.Action.findAll({
       where: filterObject,
       order: orderObject,
     })
-    return queryResult
   }
 }

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -58,6 +58,11 @@ export interface IndexerManagementResolverContext {
 const SCHEMA_SDL = gql`
   scalar BigInt
 
+  enum OrderDirection {
+    asc
+    desc
+  }
+
   enum Sort {
     asc
     desc
@@ -170,6 +175,23 @@ const SCHEMA_SDL = gql`
     source: String!
     reason: String
     priority: Int
+  }
+
+  enum ActionParams {
+    id
+    status
+    type
+    deploymentID
+    allocationID
+    transaction
+    amount
+    poi
+    force
+    source
+    reason
+    priority
+    createdAt
+    updatedAt
   }
 
   input ActionOrderBy {
@@ -371,7 +393,11 @@ const SCHEMA_SDL = gql`
     allocations(filter: AllocationFilter!): [Allocation!]!
 
     action(actionID: String!): Action
-    actions(filter: ActionFilter, orderBy: ActionOrderBy): [Action]!
+    actions(
+      filter: ActionFilter
+      orderBy: ActionParams
+      orderDirection: OrderDirection
+    ): [Action]!
   }
 
   type Mutation {

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -6,10 +6,11 @@ import {
   Action,
   ActionFilter,
   ActionInput,
+  ActionParams,
   ActionResult,
   ActionStatus,
-  ActionOrderBy,
   IndexerManagementModels,
+  OrderDirection,
   validateActionInputs,
 } from '@graphprotocol/indexer-common'
 import { Transaction } from 'sequelize'
@@ -49,7 +50,6 @@ async function executeQueueOperation(
           proposedAction: action,
           proposedSource: action.source,
           actionSources: duplicateAction[0].source,
-          test: duplicateAction[0].source === action.source,
         },
       )
       const [, updatedAction] = await models.Action.update(
@@ -97,14 +97,19 @@ export default {
   },
 
   actions: async (
-    { filter, orderBy }: { filter: ActionFilter; orderBy: ActionOrderBy },
+    {
+      filter,
+      orderBy,
+      orderDirection,
+    }: { filter: ActionFilter; orderBy: ActionParams; orderDirection: OrderDirection },
     { actionManager, logger }: IndexerManagementResolverContext,
   ): Promise<object[]> => {
     logger.debug(`Execute 'actions' query`, {
       filter,
       orderBy,
+      orderDirection,
     })
-    return await actionManager.fetchActions(filter, orderBy)
+    return await actionManager.fetchActions(filter, orderBy, orderDirection)
   },
 
   queueActions: async (

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -7,9 +7,9 @@ export enum AllocationManagementMode {
   OVERSIGHT = 'oversight',
 }
 
-export enum Sort {
-  asc = 'asc',
-  desc = 'desc',
+export enum OrderDirection {
+  ASC = 'asc',
+  DESC = 'desc',
 }
 
 export interface BlockPointer {


### PR DESCRIPTION
Use `orderBy` and `orderDirection` inputs for user provided ordering of actions queries.  This API is meant to be similar to other GraphQL APIs, specifically the [subgraph query API](https://thegraph.com/docs/en/querying/graphql-api/#sorting).