### PR TITLE
indexer-common: allow 0 staked allocations

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -782,7 +782,7 @@ Failed to allocate: Invalid allocation amount provided.
 
 **Solution**
 
-Allocation amounts must be non-zero, positive numbers. To resolve this issue ensure the corresponding indexer rule and/or action queue item have valid `allocationAmount` values.
+Allocation amounts must be non-negative numbers. To resolve this issue ensure the corresponding indexer rule and/or action queue item have `allocationAmount` specified to be greater or equal to 0.
 
 ## IE062
 

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -287,17 +287,6 @@ export class AllocationManager {
       )
     }
 
-    if (amount.eq('0')) {
-      logger.warn('Cannot allocate zero GRT', {
-        amount: amount.toString(),
-      })
-
-      throw indexerError(
-        IndexerErrorCode.IE061,
-        `Invalid allocation amount provided (${amount.toString()}). Must use nonzero allocation amount`,
-      )
-    }
-
     const currentEpoch = await this.contracts.epochManager.currentEpoch()
 
     // Identify how many GRT the indexer has staked
@@ -837,13 +826,6 @@ export class AllocationManager {
         IndexerErrorCode.IE061,
         'Cannot reallocate a negative amount of GRT',
       )
-    }
-
-    if (amount.eq('0')) {
-      logger.warn('Cannot reallocate zero GRT, skipping this allocation', {
-        amount: amount.toString(),
-      })
-      throw indexerError(IndexerErrorCode.IE061, `Cannot reallocate zero GRT`)
     }
 
     // Identify how many GRT the indexer has staked

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -453,16 +453,6 @@ export default {
       )
     }
 
-    if (allocationAmount.eq('0')) {
-      logger.warn('Cannot allocate zero GRT', {
-        amount: allocationAmount.toString(),
-      })
-      throw indexerError(
-        IndexerErrorCode.IE061,
-        `Invalid allocation amount provided (${allocationAmount.toString()}). Must use nonzero allocation amount`,
-      )
-    }
-
     try {
       const currentEpoch = await contracts.epochManager.currentEpoch()
 
@@ -914,13 +904,6 @@ export default {
           IndexerErrorCode.IE061,
           'Cannot reallocate a negative amount of GRT',
         )
-      }
-
-      if (allocationAmount.eq('0')) {
-        logger.warn('Cannot reallocate zero GRT, skipping this allocation', {
-          amount: allocationAmount.toString(),
-        })
-        throw indexerError(IndexerErrorCode.IE061, `Cannot reallocate zero GRT`)
       }
 
       logger.info(`Reallocate to subgraph deployment`, {

--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -151,7 +151,7 @@ enum ActivationCriteria {
   UNSUPPORTED = 'unsupported',
   NEVER = 'never',
   OFFCHAIN = 'offchain',
-  ZERO_ALLOCATION_AMOUNT = 'zero_allocation_amount',
+  INVALID_ALLOCATION_AMOUNT = 'invalid_allocation_amount',
 }
 
 interface RuleMatch {
@@ -210,14 +210,14 @@ export function isDeploymentWorthAllocatingTowards(
 
   // The deployment is not eligible for deployment if it doesn't have an allocation amount
   if (!deploymentRule?.allocationAmount) {
-    logger.debug(`Could not find matching rule with non-zero 'allocationAmount':`, {
+    logger.debug(`Could not find matching rule with defined 'allocationAmount':`, {
       deployment: deployment.id.display,
     })
     return new AllocationDecision(
       deployment.id,
       deploymentRule,
       false,
-      ActivationCriteria.ZERO_ALLOCATION_AMOUNT,
+      ActivationCriteria.INVALID_ALLOCATION_AMOUNT,
     )
   }
 


### PR DESCRIPTION
Updating logic check in the indexer agent per [GIP0027](https://forum.thegraph.com/t/gip-0027-create-altruistic-allocations-and-close-stale-allocations/3217/6) by simply removing the constraint on 0.

