### PR TITLE
indexer-common: Fix bug in isDeploymentWorthAllocatingTowards()

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -816,10 +816,7 @@ export default {
     if (networkSubgraphDeployment !== undefined) {
       // Make sure the network subgraph is being indexed
       await indexer.ensure(
-        `${networkSubgraphDeployment.ipfsHash.slice(
-          0,
-          23,
-        )}/${networkSubgraphDeployment.ipfsHash.slice(23)}`,
+        `indexer-agent/${networkSubgraphDeployment.ipfsHash.slice(-10)}`,
         networkSubgraphDeployment,
       )
     }

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -8,7 +8,7 @@ interface IndexerErrorMetrics {
 
 let indexerErrorMetrics: IndexerErrorMetrics | undefined
 
-const ERROR_BASE_URL = `https://github.com/graphprotocol/indexer/blob/master/docs/errors.md`
+const ERROR_BASE_URL = `https://github.com/graphprotocol/indexer/blob/main/docs/errors.md`
 
 export enum IndexerErrorCode {
   IE001 = 'IE001',

--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -275,8 +275,9 @@ export function isDeploymentWorthAllocatingTowards(
       } else if (
         deploymentRule.minSignal &&
         signalledTokens.gte(deploymentRule.minSignal) &&
-        deploymentRule.maxSignal &&
-        signalledTokens.lte(deploymentRule.maxSignal)
+        deploymentRule.maxSignal
+          ? signalledTokens.lte(deploymentRule.maxSignal)
+          : true
       ) {
         return new AllocationDecision(
           deployment.id,


### PR DESCRIPTION
The bug affected indexing-rules using `minSignal` thresholds without a 'maxSignal' threshold set.  In this scenario the indexer-agent would find all rules above the `minSignal` threshold not worthy of allocating to because they didn't also have a `maxSignal` threshold set. This check has now been fixed to only use the `maxSignal` threshold if one is set. 

I also took the opportunity to make some minor updates to: 
  - update error reference page url: use `main` branch 
  - use consistent subgraph naming convention: `indexer-agent/${networkSubgraphDeployment.ipfsHash.slice(-10)}`.