### PR TITLE
indexer-common: Remove max signal check, towards deprecating max signal

### DIFF
--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -274,10 +274,7 @@ export function isDeploymentWorthAllocatingTowards(
         )
       } else if (
         deploymentRule.minSignal &&
-        signalledTokens.gte(deploymentRule.minSignal) &&
-        deploymentRule.maxSignal
-          ? signalledTokens.lte(deploymentRule.maxSignal)
-          : true
+        signalledTokens.gte(deploymentRule.minSignal)
       ) {
         return new AllocationDecision(
           deployment.id,


### PR DESCRIPTION
The max signal conditional is an unused feature adding unnecessary complexity to the allocation decision logic . This PR removes the usage of it from isDeploymentWorthAllocatingTowards() ahead of deprecating it in the APIs. 