### PR TITLE
indexer-cli: replace gluegun toolkit print.highlight with chalk colors

### DIFF
--- a/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
@@ -412,6 +412,16 @@ describe('Indexer rules tests', () => {
 
     describe('Rules get...', () => {
       cliTest(
+        'Indexer rules output format error',
+        ['indexer', 'rules', 'get', 'all', '--output', 'josn'],
+        'references/indexer-output-format',
+        {
+          expectedExitCode: 1,
+          cwd: baseDir,
+          timeout: 10000,
+        },
+      )
+      cliTest(
         'Indexer rules get deployment - success',
         ['indexer', 'rules', 'get', 'QmZZtzZkfzCWMNrajxBf22q7BC9HzoT5iJUK3S8qA6zNZr'],
         'references/indexer-rule-deployment-rules',
@@ -445,6 +455,23 @@ describe('Indexer rules tests', () => {
         'Indexer rules get subgraph - success - options',
         ['indexer', 'rules', 'get', '0x0000000000000000000000000000000000000000-2'],
         'references/indexer-rule-subgraph-options',
+        {
+          expectedExitCode: 0,
+          cwd: baseDir,
+          timeout: 10000,
+        },
+      )
+      cliTest(
+        'Indexer rules get deployment yaml - success',
+        [
+          'indexer',
+          'rules',
+          'get',
+          'QmZZtzZkfzCWMNrajxBf22q7BC9HzoT5iJUK3S8qA6zNZr',
+          '--output',
+          'yaml',
+        ],
+        'references/indexer-rule-deployment-yaml',
         {
           expectedExitCode: 0,
           cwd: baseDir,

--- a/packages/indexer-cli/src/__tests__/references/indexer-output-format.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-output-format.stdout
@@ -1,0 +1,1 @@
+Invalid output format "josn"

--- a/packages/indexer-cli/src/__tests__/references/indexer-rule-deployment-yaml.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-rule-deployment-yaml.stdout
@@ -1,0 +1,15 @@
+identifier: QmZZtzZkfzCWMNrajxBf22q7BC9HzoT5iJUK3S8qA6zNZr
+identifierType: deployment
+allocationAmount: null
+allocationLifetime: null
+autoRenewal: true
+parallelAllocations: null
+maxAllocationPercentage: null
+minSignal: null
+maxSignal: null
+minStake: null
+minAverageQueryFees: null
+custom: null
+decisionBasis: rules
+requireSupported: true
+safety: true

--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -3,7 +3,7 @@ import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
 import { BigNumber, utils } from 'ethers'
-import { outputColors, pickFields } from './command-helpers'
+import { OutputFormat, parseOutputFormat, pickFields } from './command-helpers'
 import { IndexerManagementClient } from '@graphprotocol/indexer-common'
 import gql from 'graphql-tag'
 import {
@@ -109,14 +109,14 @@ export const indexerAllocationFromGraphQL = (
 
 export const printIndexerAllocations = (
   print: GluegunPrint,
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   allocationOrAllocations:
     | Partial<IndexerAllocation>
     | Partial<IndexerAllocation>[]
     | null,
   keys: (keyof IndexerAllocation)[],
 ): void => {
-  outputColors(print, outputFormat)
+  parseOutputFormat(print, outputFormat)
   if (Array.isArray(allocationOrAllocations)) {
     const allocations = allocationOrAllocations.map(allocation =>
       formatIndexerAllocation(pickFields(allocation, keys)),
@@ -131,12 +131,12 @@ export const printIndexerAllocations = (
 }
 
 export const displayIndexerAllocations = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   allocations: Partial<IndexerAllocation>[],
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(allocations, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(allocations).trim()
     : allocations.length === 0
     ? 'No allocations found'
@@ -151,12 +151,12 @@ export const displayIndexerAllocations = (
       ).trim()
 
 export const displayIndexerAllocation = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   allocation: Partial<IndexerAllocation>,
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(allocation, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(allocation).trim()
     : table([Object.keys(allocation), Object.values(allocation)], {
         border: getBorderCharacters('norc'),

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -27,6 +27,12 @@
 // parameters array and returns the result of that.
 
 import { table, getBorderCharacters } from 'table'
+
+export enum OutputFormat {
+  Table = 'table',
+  Json = 'json',
+  Yaml = 'yaml',
+}
 import yaml from 'yaml'
 import { GluegunParameters, GluegunPrint } from 'gluegun'
 import { utils } from 'ethers'
@@ -59,11 +65,11 @@ export const fixParameters = (
 export const formatData = (
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   data: any,
-  format: 'json' | 'yaml' | 'table',
+  format: OutputFormat,
 ): string =>
-  format === 'json'
+  format === OutputFormat.Json
     ? JSON.stringify(data, null, 2)
-    : format === 'yaml'
+    : format === OutputFormat.Yaml
     ? yaml.stringify(data).trim()
     : Array.isArray(data)
     ? data.length === 0
@@ -97,13 +103,10 @@ export function pickFields(
   return obj
 }
 
-export function displayObjectData(
-  outputFormat: 'table' | 'json' | 'yaml',
-  data: object,
-): string {
-  return outputFormat === 'json'
+export function displayObjectData(outputFormat: OutputFormat, data: object): string {
+  return outputFormat === OutputFormat.Json
     ? JSON.stringify(data, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(data).trim()
     : table([Object.keys(data), Object.values(data)], {
         border: getBorderCharacters('norc'),
@@ -111,12 +114,12 @@ export function displayObjectData(
 }
 
 export function displayObjectArrayData(
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   data: object[],
 ): string {
-  return outputFormat === 'json'
+  return outputFormat === OutputFormat.Json
     ? JSON.stringify(data, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(data).trim()
     : data.length === 0
     ? 'No items found'
@@ -127,11 +130,10 @@ export function displayObjectArrayData(
 
 export function printObjectOrArray(
   print: GluegunPrint,
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   data: object | object[],
   keys: string[],
 ): void {
-  outputColors(print, outputFormat)
   if (Array.isArray(data)) {
     const formatted = data.map(item => pickFields(item, keys))
     print.info(displayObjectArrayData(outputFormat, formatted))
@@ -172,14 +174,23 @@ export function validatePOI(poi: string | undefined): string | undefined {
   return poi
 }
 
-export function outputColors(
+export function parseOutputFormat(
   print: GluegunPrint,
-  outputFormat: 'table' | 'json' | 'yaml',
-): void {
-  if (outputFormat === 'table') {
-    print.colors.enable()
-  } else {
-    print.colors.disable()
+  outputFormat: string,
+): OutputFormat | undefined {
+  switch (outputFormat) {
+    case OutputFormat.Table:
+      print.colors.enable()
+      return OutputFormat.Table
+    case OutputFormat.Json:
+      print.colors.disable()
+      return OutputFormat.Json
+    case OutputFormat.Yaml:
+      print.colors.disable()
+      return OutputFormat.Yaml
+    default:
+      print.error(`Invalid output format "${outputFormat}"`)
+      return
   }
 }
 

--- a/packages/indexer-cli/src/commands/indexer/actions/approve.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/approve.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters, printObjectOrArray } from '../../../command-helpers'
+import {
+  fixParameters,
+  printObjectOrArray,
+  parseOutputFormat,
+} from '../../../command-helpers'
 import { approveActions, fetchActions } from '../../../actions'
 import { ActionStatus } from '@graphprotocol/indexer-common'
 
@@ -29,11 +33,15 @@ module.exports = {
     const { h, help, o, output } = parameters.options
     const [...actionIDs] = fixParameters(parameters, { h, help }) || []
 
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
     const toHelp = help || h || undefined
 
     if (toHelp) {
       inputSpinner.stopAndPersist({ symbol: '💁', text: HELP })
+      return
+    }
+    if (!outputFormat) {
+      process.exitCode = 1
       return
     }
 
@@ -42,12 +50,6 @@ module.exports = {
     const config = loadValidatedConfig()
     const client = await createIndexerManagementClient({ url: config.api })
     try {
-      if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-        throw Error(
-          `Invalid output format "${outputFormat}", must be one of ['json', 'yaml', 'table']`,
-        )
-      }
-
       if (!actionIDs || actionIDs.length === 0) {
         throw Error(`Missing required argument: 'actionID'`)
       }

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { disputes, printDisputes } from '../../../disputes'
+import { parseOutputFormat } from '../../../command-helpers'
 
 const HELP = `
 ${chalk.bold(
@@ -25,15 +26,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [status, minAllocationClosedEpoch] = parameters.array || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }

--- a/packages/indexer-cli/src/commands/indexer/rules/clear.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/clear.ts
@@ -4,8 +4,8 @@ import { partition } from '@thi.ng/iterators'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
-import { setIndexingRule, printIndexingRules, parseIndexingRule } from '../../../rules'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
+import { setIndexingRule, displayRules, parseIndexingRule } from '../../../rules'
 import { processIdentifier } from '@graphprotocol/indexer-common'
 
 const HELP = `
@@ -33,15 +33,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id, ...keys] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -92,7 +90,7 @@ module.exports = {
 
       const client = await createIndexerManagementClient({ url: config.api })
       const rule = await setIndexingRule(client, inputRule)
-      printIndexingRules(print, outputFormat, identifier, rule, [])
+      print.info(displayRules(outputFormat, identifier, rule, []))
     } catch (error) {
       print.error(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/rules/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/delete.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
 import { indexingRules, deleteIndexingRules } from '../../../rules'
 import { processIdentifier } from '@graphprotocol/indexer-common'
 
@@ -26,15 +26,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }

--- a/packages/indexer-cli/src/commands/indexer/rules/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/get.ts
@@ -3,8 +3,8 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
-import { indexingRule, indexingRules, printIndexingRules } from '../../../rules'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
+import { indexingRule, indexingRules, displayRules } from '../../../rules'
 import { IndexingRuleAttributes, processIdentifier } from '@graphprotocol/indexer-common'
 
 const HELP = `
@@ -28,15 +28,13 @@ module.exports = {
 
     const { h, help, merged, o, output } = parameters.options
     const [id, ...keys] = fixParameters(parameters, { h, help, merged }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -58,12 +56,13 @@ module.exports = {
           ? await indexingRules(client, !!merged)
           : await indexingRule(client, identifier, !!merged)
 
-      printIndexingRules(
-        print,
-        outputFormat,
-        identifier,
-        ruleOrRules,
-        keys as (keyof IndexingRuleAttributes)[],
+      print.info(
+        displayRules(
+          outputFormat,
+          identifier,
+          ruleOrRules,
+          keys as (keyof IndexingRuleAttributes)[],
+        ),
       )
     } catch (error) {
       print.error(error.toString())

--- a/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
 import { IndexingDecisionBasis, processIdentifier } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseIndexingRule } from '../../../rules'
+import { setIndexingRule, displayRules, parseIndexingRule } from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules maybe')} [options] global
@@ -26,15 +26,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -55,7 +53,7 @@ module.exports = {
 
       const client = await createIndexerManagementClient({ url: config.api })
       const rule = await setIndexingRule(client, inputRule)
-      printIndexingRules(print, outputFormat, identifier, rule, [])
+      print.info(displayRules(outputFormat, identifier, rule, []))
     } catch (error) {
       print.error(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/rules/offchain.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/offchain.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
 import { IndexingDecisionBasis, processIdentifier } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseIndexingRule } from '../../../rules'
+import { setIndexingRule, displayRules, parseIndexingRule } from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules offchain')}  [options] global
@@ -28,15 +28,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -58,7 +56,7 @@ module.exports = {
       // Update the indexing rule according to the key/value pairs
       const client = await createIndexerManagementClient({ url: config.api })
       const rule = await setIndexingRule(client, inputRule)
-      printIndexingRules(print, outputFormat, identifier, rule, [])
+      print.info(displayRules(outputFormat, identifier, rule, []))
     } catch (error) {
       print.error(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/rules/set.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/set.ts
@@ -4,11 +4,15 @@ import { partition } from '@thi.ng/iterators'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters, suggestCommands } from '../../../command-helpers'
+import {
+  fixParameters,
+  parseOutputFormat,
+  suggestCommands,
+} from '../../../command-helpers'
 import {
   parseIndexingRule,
   setIndexingRule,
-  printIndexingRules,
+  displayRules,
   indexingRule,
 } from '../../../rules'
 import { processIdentifier } from '@graphprotocol/indexer-common'
@@ -33,15 +37,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id, ...keyValues] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -82,7 +84,7 @@ module.exports = {
           process.exitCode = 1
         }
         const rule = await setIndexingRule(client, inputRule)
-        printIndexingRules(print, outputFormat, identifier, rule, [])
+        print.info(displayRules(outputFormat, identifier, rule, []))
       } catch (error) {
         // Failed to parse input, make suggestions
         // Generate a instance of indexing rules for valid attributes

--- a/packages/indexer-cli/src/commands/indexer/rules/start.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/start.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
 import { IndexingDecisionBasis, processIdentifier } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseIndexingRule } from '../../../rules'
+import { setIndexingRule, displayRules, parseIndexingRule } from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules start')}  [options] global
@@ -28,15 +28,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -58,7 +56,7 @@ module.exports = {
       // Update the indexing rule according to the key/value pairs
       const client = await createIndexerManagementClient({ url: config.api })
       const rule = await setIndexingRule(client, inputRule)
-      printIndexingRules(print, outputFormat, identifier, rule, [])
+      print.info(displayRules(outputFormat, identifier, rule, []))
     } catch (error) {
       print.error(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/rules/stop.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/stop.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import { fixParameters, parseOutputFormat } from '../../../command-helpers'
 import { IndexingDecisionBasis, processIdentifier } from '@graphprotocol/indexer-common'
-import { setIndexingRule, printIndexingRules, parseIndexingRule } from '../../../rules'
+import { setIndexingRule, displayRules, parseIndexingRule } from '../../../rules'
 
 const HELP = `
 ${chalk.bold('graph indexer rules stop')}  [options] global
@@ -28,15 +28,13 @@ module.exports = {
 
     const { h, help, o, output } = parameters.options
     const [id] = fixParameters(parameters, { h, help }) || []
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -57,7 +55,7 @@ module.exports = {
 
       const client = await createIndexerManagementClient({ url: config.api })
       const rule = await setIndexingRule(client, inputRule)
-      printIndexingRules(print, outputFormat, identifier, rule, [])
+      print.info(displayRules(outputFormat, identifier, rule, []))
     } catch (error) {
       print.error(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -5,9 +5,9 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../config'
 import { createIndexerManagementClient } from '../../client'
 import gql from 'graphql-tag'
-import { printIndexingRules, indexingRuleFromGraphQL } from '../../rules'
+import { displayRules, indexingRuleFromGraphQL } from '../../rules'
 import { printIndexerAllocations, indexerAllocationFromGraphQL } from '../../allocations'
-import { formatData, outputColors, pickFields } from '../../command-helpers'
+import { formatData, parseOutputFormat, pickFields } from '../../command-helpers'
 
 const HELP = `
 ${chalk.bold('graph indexer status')}
@@ -25,15 +25,13 @@ module.exports = {
     const { print } = toolbox
 
     const { h, help, o, output } = toolbox.parameters.options
-    const outputFormat = o || output || 'table'
+    const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {
       print.info(HELP)
       return
     }
-
-    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
-      print.error(`Invalid output format "${outputFormat}"`)
+    if (!outputFormat) {
       process.exitCode = 1
       return
     }
@@ -220,12 +218,10 @@ module.exports = {
       }
     }
 
-    outputColors(print, outputFormat)
     if (outputFormat === 'table') {
-      print.highlight('Registration')
+      print.info(chalk.cyan('Registration'))
       print.info(formatData(data.registration, outputFormat))
-      print.info('')
-      print.highlight('Endpoints')
+      print.info(chalk.cyan('\nEndpoints'))
       if (data.endpoints.error) {
         print.error(formatData([data.endpoints], outputFormat))
       } else {
@@ -259,8 +255,7 @@ module.exports = {
           }
         }
       }
-      print.info('')
-      print.highlight('Indexer Deployments')
+      print.info(chalk.cyan('\nIndexer Deployments'))
       if (data.indexerDeployments) {
         print.info(
           formatData(
@@ -283,8 +278,7 @@ module.exports = {
           ),
         )
       }
-      print.info('')
-      print.highlight('Indexer Allocations')
+      print.info(chalk.cyan('\nIndexer Allocations'))
       if (data.indexerAllocations) {
         printIndexerAllocations(print, outputFormat, data.indexerAllocations, [
           'id',
@@ -295,12 +289,11 @@ module.exports = {
           'stakedTokens',
         ])
       }
-      print.info('')
-      print.highlight('Indexing Rules')
+      print.info(chalk.cyan('\nIndexing Rules'))
       if (data.indexingRules.length === 1 && data.indexingRules[0].error) {
         print.info(formatData(data.indexingRules[0], outputFormat))
       } else {
-        printIndexingRules(print, outputFormat, 'all', data.indexingRules, [])
+        print.info(displayRules(outputFormat, 'all', data.indexingRules, []))
       }
     } else {
       print.info(formatData(data, outputFormat))

--- a/packages/indexer-cli/src/cost.ts
+++ b/packages/indexer-cli/src/cost.ts
@@ -8,7 +8,7 @@ import gql from 'graphql-tag'
 import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
-import { outputColors, pickFields } from './command-helpers'
+import { OutputFormat, pickFields } from './command-helpers'
 
 export type SubgraphDeploymentIDIsh = SubgraphDeploymentID | 'all' | 'global'
 
@@ -135,12 +135,12 @@ export const costModelToGraphQL = (
 }
 
 export const displayCostModels = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   costModels: Partial<CostModelAttributes>[],
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(costModels, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(costModels).trim()
     : costModels.length === 0
     ? 'No data'
@@ -152,12 +152,12 @@ export const displayCostModels = (
       ).trim()
 
 export const displayCostModel = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   cost: Partial<CostModelAttributes>,
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(cost, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(cost).trim()
     : table([Object.keys(cost), Object.values(cost)], {
         border: getBorderCharacters('norc'),
@@ -165,12 +165,11 @@ export const displayCostModel = (
 
 export const printCostModels = (
   print: GluegunPrint,
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   deployment: SubgraphDeploymentIDIsh | null,
   costModelOrModels: Partial<CostModelAttributes> | Partial<CostModelAttributes>[] | null,
   fields: string[],
 ): void => {
-  outputColors(print, outputFormat)
   if (Array.isArray(costModelOrModels)) {
     const costModels = costModelOrModels.map(cost =>
       formatCostModel(pickFields(cost, fields), {

--- a/packages/indexer-cli/src/disputes.ts
+++ b/packages/indexer-cli/src/disputes.ts
@@ -8,7 +8,7 @@ import gql from 'graphql-tag'
 import yaml from 'yaml'
 import { GluegunPrint } from 'gluegun'
 import { table, getBorderCharacters } from 'table'
-import { outputColors } from './command-helpers'
+import { parseOutputFormat, OutputFormat } from './command-helpers'
 
 const DISPUTE_FORMATTERS: Record<keyof POIDisputeAttributes, (x: never) => string> = {
   allocationID: x => x,
@@ -80,12 +80,12 @@ const disputeFromGraphQL = (
 }
 
 export const displayDisputes = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   disputes: Partial<POIDisputeAttributes>[],
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(disputes, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(disputes).trim()
     : disputes.length === 0
     ? 'No data'
@@ -97,12 +97,12 @@ export const displayDisputes = (
       ).trim()
 
 export const displayDispute = (
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   dispute: Partial<POIDisputeAttributes>,
 ): string =>
-  outputFormat === 'json'
+  outputFormat === OutputFormat.Json
     ? JSON.stringify(dispute, null, 2)
-    : outputFormat === 'yaml'
+    : outputFormat === OutputFormat.Yaml
     ? yaml.stringify(dispute).trim()
     : table([Object.keys(dispute), Object.values(dispute)], {
         border: getBorderCharacters('norc'),
@@ -110,10 +110,9 @@ export const displayDispute = (
 
 export const printDisputes = (
   print: GluegunPrint,
-  outputFormat: 'table' | 'json' | 'yaml',
+  outputFormat: OutputFormat,
   disputes: Partial<POIDisputeAttributes>[] | null,
 ): void => {
-  outputColors(print, outputFormat)
   if (Array.isArray(disputes)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const formattedDisputes = disputes.map(dispute => formatDispute(dispute))


### PR DESCRIPTION
Uncertain dependencies for toolkit's print object being passed around, avoid it by using chalk colors (is it so hard to make life colorful...?:)

resolves #468 


