### PR TITLE
indexer-service: Persist receipts with zero fees

### DIFF
--- a/packages/indexer-service/src/query-fees/allocations.ts
+++ b/packages/indexer-service/src/query-fees/allocations.ts
@@ -95,11 +95,6 @@ export class AllocationReceiptManager implements ReceiptManager {
       receiptData,
     )
 
-    // If the fee is 0, validate verifier and return allocation ID for the signer
-    if (receipt.fees.isZero()) {
-      return receipt
-    }
-
     this._queue({
       id: receipt.id,
       allocation: receipt.allocation,


### PR DESCRIPTION
Currently, the `indexer-service` do not persist receipts with zero fees.

They skip the processing queue as the `AllocationReceiptManager.add` method early exists if they have no fees.
https://github.com/graphprotocol/indexer/blob/dde26d93b88f38c62b0d216a79f5225b1619d709/packages/indexer-service/src/query-fees/allocations.ts#L98-L110

There might be use cases for keeping those receipts around, such as testing and development environments.

This PR removes the early return condition so that every receipt enters the processing queue.

Future improvements may address the auto-removal of such receipts after a given time.