### PR TITLE
indexer-common: Use consistent deployment names

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -326,7 +326,7 @@ export class AllocationManager {
     await this.subgraphManager.ensure(
       logger,
       this.models,
-      `${deployment.ipfsHash.slice(0, 23)}/${deployment.ipfsHash.slice(23)}`,
+      `indexer-agent/${deployment.ipfsHash.slice(-10)}`,
       deployment,
       indexNode,
     )

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -482,9 +482,7 @@ export default {
       await subgraphManager.ensure(
         logger,
         models,
-        `${subgraphDeployment.ipfsHash.slice(0, 23)}/${subgraphDeployment.ipfsHash.slice(
-          23,
-        )}`,
+        `indexer-agent/${subgraphDeployment.ipfsHash.slice(-10)}`,
         subgraphDeployment,
         indexNode,
       )


### PR DESCRIPTION
Always create subgraphs with the following naming scheme: `indexer-agent/${deployment.ipfsHash.slice(-10)}`.