### PR TITLE
AQI: actions delete command

### DIFF
--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -25,6 +25,7 @@ Manage indexer configuration
   indexer actions queue              Queue an action item                                             
   indexer actions get                List one or more actions                                         
   indexer actions execute            Execute approved items in the action queue                       
+  indexer actions delete             Delete an item in the queue                                      
   indexer actions cancel             Cancel an item in the queue                                      
   indexer actions approve            Approve an action item                                           
   indexer actions                    Manage indexer actions                                           

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -314,3 +314,39 @@ export async function fetchActions(
 
   return result.data.actions
 }
+
+export async function deleteActions(
+  client: IndexerManagementClient,
+  actionIDs: number[],
+): Promise<ActionResult[]> {
+  const result = await client
+    .mutation(
+      gql`
+        mutation deleteActions($actionIDs: [Int!]!) {
+          deleteActions(actionIDs: $actionIDs) {
+            id
+            type
+            allocationID
+            deploymentID
+            amount
+            poi
+            force
+            source
+            reason
+            priority
+            transaction
+            status
+            failureReason
+          }
+        }
+      `,
+      { actionIDs },
+    )
+    .toPromise()
+
+  if (result.error) {
+    throw result.error
+  }
+
+  return result.data.deleteActions
+}

--- a/packages/indexer-cli/src/commands/indexer/actions/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/delete.ts
@@ -1,0 +1,75 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import { fixParameters } from '../../../command-helpers'
+import { deleteActions } from '../../../actions'
+
+const HELP = `
+${chalk.bold('graph indexer actions delete')} [options] [<actionID1> ...]
+
+${chalk.dim('Options:')}
+
+  -h, --help                    Show usage information
+  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML 
+`
+
+module.exports = {
+  name: 'delete',
+  alias: [],
+  description: 'Delete an item in the queue',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const inputSpinner = toolbox.print.spin('Processing inputs')
+
+    const { h, help, o, output } = parameters.options
+    const [...actionIDs] = fixParameters(parameters, { h, help }) || []
+
+    const outputFormat = o || output || 'table'
+    const toHelp = help || h || undefined
+
+    if (toHelp) {
+      inputSpinner.stopAndPersist({ symbol: '💁', text: HELP })
+      return
+    }
+
+    let numericActionIDs: number[]
+
+    try {
+      if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+        throw Error(
+          `Invalid output format "${outputFormat}", must be one of ['json', 'yaml', 'table']`,
+        )
+      }
+
+      if (!actionIDs || actionIDs.length === 0) {
+        throw Error(`Missing required argument: 'actionID'`)
+      }
+
+      numericActionIDs = actionIDs.map(action => +action)
+
+      inputSpinner.succeed('Processed input parameters')
+    } catch (error) {
+      inputSpinner.fail(error.toString())
+      print.info(HELP)
+      process.exitCode = 1
+      return
+    }
+
+    const actionSpinner = toolbox.print.spin(`Deleting ${actionIDs.length} actions`)
+    try {
+      const config = loadValidatedConfig()
+      const client = await createIndexerManagementClient({ url: config.api })
+
+      const numDeleted = await deleteActions(client, numericActionIDs)
+
+      actionSpinner.succeed(`${numDeleted} actions deleted`)
+    } catch (error) {
+      actionSpinner.fail(error.toString())
+      process.exitCode = 1
+      return
+    }
+  },
+}

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -409,6 +409,7 @@ const SCHEMA_SDL = gql`
     updateAction(action: ActionInput!): Action!
     queueActions(actions: [ActionInput!]!): [Action]!
     cancelActions(actionIDs: [String!]!): [Action]!
+    deleteActions(actionIDs: [String!]!): Int!
     approveActions(actionIDs: [String!]!): [Action]!
     executeApprovedActions: [ActionResult!]!
   }

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -176,6 +176,22 @@ export default {
     return canceledActions
   },
 
+  deleteActions: async (
+    { actionIDs }: { actionIDs: number[] },
+    { logger, models }: IndexerManagementResolverContext,
+  ): Promise<number> => {
+    logger.debug(`Execute 'deleteActions' mutation`, {
+      actionIDs,
+    })
+    const numDeleted = await models.Action.destroy({ where: { id: actionIDs } })
+
+    if (numDeleted === 0) {
+      throw Error(`Delete action failed: No action items found with id in [${actionIDs}]`)
+    }
+
+    return numDeleted
+  },
+
   updateAction: async (
     { action }: { action: Action },
     { logger, models }: IndexerManagementResolverContext,


### PR DESCRIPTION
- Add `indexer actions delete` command to delete actions by IDs in indexer-cli

example
```
$HELP - graph indexer actions delete [options] [<actionID1> ...]

 ./bin/graph-indexer indexer actions delete 13 16 37
✔ Processed input parameters
✔ 3 actions deleted

 ./bin/graph-indexer indexer actions delete 8 9 10                            
✔ Processed input parameters
✖ [GraphQL] Delete action failed: No action items found with id in [8,9,10]
```
If useful, we can delete all actions by a certain status, but I'm worried if it is too easy? Indexers could also `get` with filters and then feed in action ids as an array
