### PR TITLE
indexer-common: Trace log data used to evaluate each deployment

### DIFF
--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -208,6 +208,11 @@ export function isDeploymentWorthAllocatingTowards(
           new SubgraphDeploymentID(rule.identifier).bytes32 === deployment.id.bytes32,
       ) || globalRule
 
+  logger.trace('Evaluating whether subgraphDeployment is worth allocating towards', {
+    deployment,
+    matchingRule: deploymentRule,
+  })
+
   // The deployment is not eligible for deployment if it doesn't have an allocation amount
   if (!deploymentRule?.allocationAmount) {
     logger.debug(`Could not find matching rule with defined 'allocationAmount':`, {


### PR DESCRIPTION
It's currently a bit tricky to debug allocation decisions. To improve debug process this PR adds an additional trace log at the beginning of `isDeploymentWorthAllocatingTowards()` which includes the deployment's data and the matching rule it is being evaluated against. 