### PR TITLE
indexer-common: Avoid recreating recently failed actions

### DIFF
--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -1,5 +1,6 @@
 import { ActionManager, NetworkMonitor } from './indexer-management'
 import { AllocationStatus } from './allocations'
+import { WhereOperators } from 'sequelize'
 
 export interface ActionParamsInput {
   deploymentID?: string
@@ -126,6 +127,7 @@ export interface ActionFilter {
   status?: ActionStatus | undefined
   source?: string | undefined
   reason?: string | undefined
+  updatedAt?: WhereOperators | undefined
 }
 
 export interface ActionResult {

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -77,18 +77,14 @@ async function executeQueueOperation(
       )
       return updatedAction
     } else {
-      logger.warn(
+      const message =
         `Duplicate action found in queue that effects '${action.deploymentID}' but NOT overwritten because it has a different source and/or status. If you ` +
-          `would like to replace the item currently in the queue please cancel it and then queue the proposed action`,
-        {
-          actionInQueue: duplicateAction,
-          proposedAction: action,
-        },
-      )
-      throw Error(
-        `Duplicate action found in queue that effects '${action.deploymentID}' but NOT overwritten because it has a different source and/or status. If you ` +
-          `would like to replace the item currently in the queue please cancel it and then queue the proposed action`,
-      )
+        `would like to replace the item currently in the queue please cancel it and then queue the proposed action`
+      logger.warn(message, {
+        actionInQueue: duplicateAction,
+        proposedAction: action,
+      })
+      throw Error(message)
     }
   } else {
     throw Error(


### PR DESCRIPTION
Adds a new validation step to `executeQueueOperation`, which prevents the current action from entering the queue if it is found to be a retry from a previously failed attempt.

To do so, we query the database for actions with a `failed` status from the past 24h and check if it contains the current action.
