### PR TITLE
indexer-common: re-organize error logging

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -873,3 +873,17 @@ Failed to query BlockHashFromNumber from graph node
 **Solution**
 
 Graph-node could not find the block hash given network and block number, check if graph-node has access to a network client that has synced to the required block. 
+
+## IE071
+
+**Summary**
+
+Epoch subgraph required for subgraphs indexing networks in which rpc is unprovided to the indexer agent
+
+**Description**
+
+This is a sub-error of `IE069`. It is reported when the indexer agent doesn't have access to an epoch subgraph endpoint to identify the epoch start block for chains other than the settlement network as indicated by start-up option `--ethereum-network`. 
+
+**Solution**
+
+Please provide a `epoch-subgraph-endpoint` and make sure graph node has consistent network configurations (`mainnet`, `goerli`, `gnosis`) and is on or after version 0.28.0.

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -1,6 +1,3 @@
-import { IndexingStatusResolver } from '@graphprotocol/indexer-common'
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-
 import { Address, SubgraphDeploymentID, toAddress } from '@graphprotocol/common-ts'
 import { BigNumber } from 'ethers'
 
@@ -195,20 +192,5 @@ export const alias = (identifier: string): string => {
     return Object.keys(CAIPIds).filter((name) => CAIPIds[name] == identifier)[0]
   } catch (error) {
     throw new Error(`Failed to match chain ids to a network alias`)
-  }
-}
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export const buildEpochBlock = async (
-  status: IndexingStatusResolver,
-  block: any,
-): Promise<NetworkEpochBlock> => {
-  return {
-    network: block.network.id,
-    epochNumber: +block.epochNumber,
-    startBlockNumber: +block.blockNumber,
-    startBlockHash: await status.blockHashFromNumber(
-      alias(block.network.id),
-      +block.blockNumber,
-    ),
   }
 }

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -81,6 +81,7 @@ export enum IndexerErrorCode {
   IE068 = 'IE068',
   IE069 = 'IE069',
   IE070 = 'IE070',
+  IE071 = 'IE071',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -154,7 +155,8 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE067: 'Failed to query POI for current epoch start block',
   IE068: 'User-provided POI did not match reference POI from graph-node',
   IE069: 'Failed to query Epoch Block Oracle Subgraph',
-  IE070: 'Failed to query BlockHashFromNumber from graph-node',
+  IE070: 'Failed to query latest valid epoch and block hash',
+  IE071: 'Add Epoch subgraph support for non-protocol chains',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -294,8 +294,6 @@ async function resolvePOI(
   poi: string | undefined,
   force: boolean,
 ): Promise<string> {
-  // Obtain epoch start block based on subgraph deployment network's
-  const currentEpochStartBlock = await networkMonitor.fetchPOIBlockPointer(allocation)
   // poi = undefined, force=true  -- submit even if poi is 0x0
   // poi = defined,   force=true  -- no generatedPOI needed, just submit the POI supplied (with some sanitation?)
   // poi = undefined, force=false -- submit with generated POI if one available
@@ -310,13 +308,14 @@ async function resolvePOI(
           return (
             (await indexingStatusResolver.proofOfIndexing(
               allocation.subgraphDeployment.id,
-              currentEpochStartBlock,
+              await networkMonitor.fetchPOIBlockPointer(allocation),
               allocation.indexer,
             )) || utils.hexlify(Array(32).fill(0))
           )
       }
       break
     case false: {
+      const currentEpochStartBlock = await networkMonitor.fetchPOIBlockPointer(allocation)
       const generatedPOI = await indexingStatusResolver.proofOfIndexing(
         allocation.subgraphDeployment.id,
         currentEpochStartBlock,

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -213,7 +213,7 @@ export class IndexingStatusResolver {
             .toPromise()
 
           if (!result.data || !result.data.blockHashFromNumber || result.error) {
-            throw indexerError(IndexerErrorCode.IE070)
+            throw new Error(`Failed to query graph node for blockHashFromNumber`)
           }
 
           this.logger.trace('Resolved block hash', {


### PR DESCRIPTION
- Add more explicit error logs
- Avoid querying block information when action (`unallocate` or `reallocate`) is forced and poi is provided.