### PR TITLE
indexer-agent,-common: consistent network id format

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -197,7 +197,7 @@ class Agent {
     const protocolChainLatestValidEpoch = timer(600_000).tryMap(
       async () =>
         await this.networkMonitor.latestValidEpoch(
-          this.networkMonitor.networkAlias,
+          this.networkMonitor.networkCAIPID,
         ),
       {
         onError: error =>

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -727,7 +727,6 @@ export default {
       ? await EpochSubgraph.create({
           logger,
           endpoint: argv.epochSubgraphEndpoint,
-          network: networkMeta.name,
         })
       : undefined
 
@@ -770,7 +769,7 @@ export default {
     await receiptCollector.queuePendingReceiptsFromDatabase()
 
     const networkMonitor = new NetworkMonitor(
-      CAIPIds[networkMeta.name],
+      CAIPIds[argv.ethereumNetwork],
       contracts,
       toAddress(indexerAddress),
       logger,

--- a/packages/indexer-common/src/allocations/types.ts
+++ b/packages/indexer-common/src/allocations/types.ts
@@ -175,7 +175,7 @@ export const parseGraphQLEpochs = (epoch: any): Epoch => ({
 })
 
 export interface NetworkEpochBlock {
-  network: string
+  networkID: string
   epochNumber: number
   startBlockNumber: number
   startBlockHash: string

--- a/packages/indexer-common/src/epoch-subgraph.ts
+++ b/packages/indexer-common/src/epoch-subgraph.ts
@@ -6,19 +6,16 @@ import { QueryResult } from './network-subgraph'
 export interface EpochSubgraphCreateOptions {
   logger: Logger
   endpoint: string
-  network: string
 }
 
 interface EpochSubgraphOptions {
   logger: Logger
   endpoint: string
-  network: string
 }
 
 export class EpochSubgraph {
   logger: Logger
   endpointClient: AxiosInstance
-  network: string
 
   private constructor(options: EpochSubgraphOptions) {
     this.logger = options.logger
@@ -33,14 +30,11 @@ export class EpochSubgraph {
       // Don't transform responses
       transformResponse: (data) => data,
     })
-
-    this.network = options.network
   }
 
   public static async create({
     logger: parentLogger,
     endpoint,
-    network,
   }: EpochSubgraphCreateOptions): Promise<EpochSubgraph> {
     const logger = parentLogger.child({
       component: 'EpochSubgraph',
@@ -51,7 +45,6 @@ export class EpochSubgraph {
     const epochSubgraph = new EpochSubgraph({
       logger,
       endpoint,
-      network,
     })
     // Any checks to be made after creating?
 

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -297,7 +297,6 @@ const setup = async () => {
     logger,
     endpoint:
       'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
-    network: 'goerli',
   })
 
   const networkMonitor = new NetworkMonitor(

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -195,6 +195,7 @@ export class IndexingStatusResolver {
     network: string,
     blockNumber: number,
   ): Promise<string> {
+    this.logger.trace(`Quering blockHashFromNumber`, { network, blockNumber })
     try {
       return await pRetry(
         async (attempt) => {


### PR DESCRIPTION
- Swap Ethereum provider returned network name to indexer agent's start up `ethereum-network`. TODO: come up with better tracking of network name
- More explicit network name types between CAIP-ids and their aliases. 