### PR TITLE
Fix indexer-cli docker image

### DIFF
--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -39,6 +39,7 @@
     "morgan": "1.10.0",
     "ngeohash": "0.6.3",
     "p-filter": "2.1.0",
+    "p-map": "4.0.0",
     "p-reduce": "2.1.0",
     "p-retry": "4.6.1",
     "p-timeout": "4.1.0",


### PR DESCRIPTION
Added dependency on p-map package for indexer-common. This patch resolves #495 