### PR TITLE
Update network parameters for Goerli testnet

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -158,8 +158,8 @@ Afterwards, stake this amount:
 
 | Parameter                   | Value |
 | --------------------------- | ----- |
-| Epoch length                | ~ 4h  |
-| Maximum allocation lifetime | ~ 1d  |
+| Epoch length                | ~ 2h (1h 51m)  |
+| Maximum allocation lifetime | ~ 8h (7h 23m) |
 
 ### Contracts
 


### PR DESCRIPTION
Updating network parameters to reflect current values on Goerli testnet:
- Epoch length is 554 blocks which is ~1h 51m.
- Max allocation lifetime is 4 epochs which is ~7h 23m.

These numbers seem odd because they were set pre merge for an average block time of 13 seconds (used to be 2h and 8h).