### PR TITLE
indexer-agent,-service: remove index-node configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,6 @@ Indexer Infrastructure
   --indexer-geo-coordinates             Coordinates describing the Indexer's
                                         location using latitude and longitude
                                    [array] [default: ["31.780715","-41.179504"]]
-  --index-node-ids                      Node IDs of Graph nodes to use for
-                                        indexing (separated by commas)
-                                                              [array] [required]
   --indexer-management-port             Port to serve the indexer management API
                                         at              [number] [default: 8000]
   --metrics-port                        Port to serve Prometheus metrics at

--- a/packages/indexer-agent/README.md
+++ b/packages/indexer-agent/README.md
@@ -29,8 +29,6 @@ Indexer Infrastructure
   --indexer-geo-coordinates     Coordinates describing the Indexer's location
                                 using latitude and longitude
                                    [array] [default: ["31.780715","-41.179504"]]
-  --index-node-ids              Node IDs of Graph nodes to use for indexing
-                                (separated by commas)         [array] [required]
   --indexer-management-port     Port to serve the indexer management API at
                                                         [number] [default: 8000]
   --metrics-port                Port to serve Prometheus metrics at     [number]

--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -138,13 +138,11 @@ const setup = async () => {
     deployment: undefined,
   })
 
-  const indexNodeIDs = ['node_1']
   indexerManagementClient = await createIndexerManagementClient({
     models,
     address: toAddress(address),
     contracts: contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint: statusEndpoint,
     networkSubgraph,
     logger,
@@ -164,7 +162,6 @@ const setup = async () => {
     'test',
     indexingStatusResolver,
     indexerManagementClient,
-    ['test'],
     parseGRT('1000'),
     address,
     AllocationManagementMode.AUTO,

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -171,19 +171,6 @@ export default {
         required: false,
         group: 'Protocol',
       })
-      .option('index-node-ids', {
-        description:
-          'Node IDs of Graph nodes to use for indexing (separated by commas)',
-        type: 'string',
-        array: true,
-        required: true,
-        coerce: arg =>
-          arg.reduce(
-            (acc: string[], value: string) => [...acc, ...value.split(',')],
-            [],
-          ),
-        group: 'Indexer Infrastructure',
-      })
       .option('default-allocation-amount', {
         description:
           'Default amount of GRT to allocate to a subgraph deployment',
@@ -786,7 +773,6 @@ export default {
       address: indexerAddress,
       contracts,
       indexingStatusResolver,
-      indexNodeIDs: argv.indexNodeIds,
       deploymentManagementEndpoint: argv.graphNodeAdminEndpoint,
       networkSubgraph,
       logger,
@@ -818,7 +804,6 @@ export default {
       argv.graphNodeAdminEndpoint,
       indexingStatusResolver,
       indexerManagementClient,
-      argv.indexNodeIds,
       argv.defaultAllocationAmount,
       indexerAddress,
       allocationManagementMode,

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -70,17 +70,11 @@ const disputeFromGraphQL = (
   return obj as POIDisputeAttributes
 }
 
-interface indexNode {
-  id: string
-  deployments: string[]
-}
-
 export class Indexer {
   statusResolver: IndexingStatusResolver
   rpc: RpcClient
   indexerManagement: IndexerManagementClient
   logger: Logger
-  indexNodeIDs: string[]
   defaultAllocationAmount: BigNumber
   indexerAddress: string
   allocationManagementMode: AllocationManagementMode
@@ -90,7 +84,6 @@ export class Indexer {
     adminEndpoint: string,
     statusResolver: IndexingStatusResolver,
     indexerManagement: IndexerManagementClient,
-    indexNodeIDs: string[],
     defaultAllocationAmount: BigNumber,
     indexerAddress: string,
     allocationManagementMode: AllocationManagementMode,
@@ -108,7 +101,6 @@ export class Indexer {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.rpc = jayson.Client.http(adminEndpoint as any)
     }
-    this.indexNodeIDs = indexNodeIDs
     this.defaultAllocationAmount = defaultAllocationAmount
   }
 
@@ -159,52 +151,6 @@ export class Indexer {
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE018, error)
       this.logger.error(`Failed to query indexing status API`, { err })
-      throw err
-    }
-  }
-
-  async indexNodes(): Promise<indexNode[]> {
-    try {
-      const result = await this.statusResolver.statuses
-        .query(
-          gql`
-            {
-              indexingStatuses {
-                subgraphDeployment: subgraph
-                node
-              }
-            }
-          `,
-        )
-        .toPromise()
-
-      if (result.error) {
-        throw result.error
-      }
-
-      const indexNodes: indexNode[] = []
-      result.data.indexingStatuses.map(
-        (status: { subgraphDeployment: string; node: string }) => {
-          const node = indexNodes.find(node => node.id === status.node)
-          node
-            ? node.deployments.push(status.subgraphDeployment)
-            : indexNodes.push({
-                id: status.node,
-                deployments: [status.subgraphDeployment],
-              })
-        },
-      )
-
-      this.logger.trace(`Queried index nodes`, {
-        indexNodes,
-      })
-      return indexNodes
-    } catch (error) {
-      const err = indexerError(IndexerErrorCode.IE018, error)
-      this.logger.error(
-        `Failed to query index nodes API (Should get a different IE?)`,
-        { err },
-      )
       throw err
     }
   }
@@ -760,11 +706,7 @@ export class Indexer {
     }
   }
 
-  async deploy(
-    name: string,
-    deployment: SubgraphDeploymentID,
-    node_id: string,
-  ): Promise<void> {
+  async deploy(name: string, deployment: SubgraphDeploymentID): Promise<void> {
     try {
       this.logger.info(`Deploy subgraph deployment`, {
         name,
@@ -773,7 +715,6 @@ export class Indexer {
       const response = await this.rpc.request('subgraph_deploy', {
         name,
         ipfs_hash: deployment.ipfsHash,
-        node_id: node_id,
       })
       if (response.error) {
         throw response.error
@@ -817,61 +758,10 @@ export class Indexer {
     }
   }
 
-  async reassign(
-    deployment: SubgraphDeploymentID,
-    node: string,
-  ): Promise<void> {
-    try {
-      this.logger.info(`Reassign subgraph deployment`, {
-        deployment: deployment.display,
-        node,
-      })
-      const response = await this.rpc.request('subgraph_reassign', {
-        node_id: node,
-        ipfs_hash: deployment.ipfsHash,
-      })
-      if (response.error) {
-        throw response.error
-      }
-    } catch (error) {
-      if (error.message.includes('unchanged')) {
-        this.logger.debug(`Subgraph deployment assignment unchanged`, {
-          deployment: deployment.display,
-          node,
-        })
-        return
-      }
-      const err = indexerError(IndexerErrorCode.IE028, error)
-      this.logger.error(`Failed to reassign subgraph deployment`, {
-        deployment: deployment.display,
-        err,
-      })
-      throw err
-    }
-  }
-
   async ensure(name: string, deployment: SubgraphDeploymentID): Promise<void> {
     try {
-      // Randomly assign to unused nodes if they exist,
-      // otherwise use the node with lowest deployments assigned
-      const indexNodes = (await this.indexNodes()).filter(
-        (node: { id: string; deployments: Array<string> }) => {
-          return node.id && node.id !== 'removed'
-        },
-      )
-      const usedIndexNodeIDs = indexNodes.map(node => node.id)
-      const unusedNodes = this.indexNodeIDs.filter(
-        nodeID => !(nodeID in usedIndexNodeIDs),
-      )
-
-      const targetNode = unusedNodes
-        ? unusedNodes[Math.floor(Math.random() * unusedNodes.length)]
-        : indexNodes.sort((nodeA, nodeB) => {
-            return nodeA.deployments.length - nodeB.deployments.length
-          })[0].id
       await this.create(name)
-      await this.deploy(name, deployment, targetNode)
-      await this.reassign(deployment, targetNode)
+      await this.deploy(name, deployment)
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE020, error)
       this.logger.error(`Failed to ensure subgraph deployment is indexing`, {

--- a/packages/indexer-cli/src/__tests__/util.ts
+++ b/packages/indexer-cli/src/__tests__/util.ts
@@ -67,13 +67,11 @@ export const setup = async () => {
       'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
   indexerManagementClient = await createIndexerManagementClient({
     models,
     address: toAddress(address),
     contracts: contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint: statusEndpoint,
     networkSubgraph,
     logger,

--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -170,21 +170,12 @@ export const createAllocation = async (
   client: IndexerManagementClient,
   deployment: string,
   amount: BigNumber,
-  indexNode: string | undefined,
 ): Promise<CreateAllocationResult> => {
   const result = await client
     .mutation(
       gql`
-        mutation createAllocation(
-          $deployment: String!
-          $amount: String!
-          $indexNode: String
-        ) {
-          createAllocation(
-            deployment: $deployment
-            amount: $amount
-            indexNode: $indexNode
-          ) {
+        mutation createAllocation($deployment: String!, $amount: String!) {
+          createAllocation(deployment: $deployment, amount: $amount) {
             allocation
             deployment
             allocatedTokens
@@ -194,7 +185,6 @@ export const createAllocation = async (
       {
         deployment,
         amount: amount.toString(),
-        indexNode,
       },
     )
     .toPromise()

--- a/packages/indexer-cli/src/commands/indexer/allocations/create.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/create.ts
@@ -9,9 +9,7 @@ import { processIdentifier, SubgraphIdentifierType } from '@graphprotocol/indexe
 import { printObjectOrArray } from '../../../command-helpers'
 
 const HELP = `
-${chalk.bold(
-  'graph indexer allocations create',
-)} [options] <deployment-id> <amount> <index-node>
+${chalk.bold('graph indexer allocations create')} [options] <deployment-id> <amount>
 
 ${chalk.dim('Options:')}
 
@@ -45,7 +43,7 @@ module.exports = {
       return
     }
 
-    const [deploymentID, amount, indexNode] = parameters.array || []
+    const [deploymentID, amount] = parameters.array || []
 
     try {
       if (!deploymentID || !amount) {
@@ -72,7 +70,6 @@ module.exports = {
         client,
         deploymentString,
         allocationAmount,
-        indexNode,
       )
 
       spinner.succeed('Allocation created')

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -223,8 +223,6 @@ const invalidReallocateAction = {
   priority: 0,
 } as ActionInput
 
-const indexNodeIDs = ['node_1']
-
 let ethereum: ethers.providers.BaseProvider
 let sequelize: Sequelize
 let managementModels: IndexerManagementModels
@@ -313,7 +311,6 @@ const setup = async () => {
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint,
     networkSubgraph,
     receiptCollector,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
@@ -70,7 +70,6 @@ let models: IndexerManagementModels
 let address: string
 let contracts: NetworkContracts
 let logger: Logger
-let indexNodeIDs: string[]
 let statusEndpoint: string
 let indexingStatusResolver: IndexingStatusResolver
 let networkSubgraph: NetworkSubgraph
@@ -95,7 +94,6 @@ const setupAll = async () => {
     async: false,
     level: __LOG_LEVEL__ ?? 'error',
   })
-  indexNodeIDs = ['node_1']
   statusEndpoint = 'http://localhost:8030/graphql'
   indexingStatusResolver = new IndexingStatusResolver({
     logger: logger,
@@ -113,7 +111,6 @@ const setupAll = async () => {
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint: statusEndpoint,
     networkSubgraph,
     logger,
@@ -636,7 +633,6 @@ describe('Feature: Inject $DAI variable', () => {
       address,
       contracts,
       indexingStatusResolver,
-      indexNodeIDs,
       deploymentManagementEndpoint: statusEndpoint,
       networkSubgraph,
       logger,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
@@ -148,13 +148,11 @@ const setupAll = async () => {
       'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
   client = await createIndexerManagementClient({
     models,
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint: statusEndpoint,
     networkSubgraph,
     logger,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
@@ -210,13 +210,11 @@ const setupAll = async () => {
       'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
   client = await createIndexerManagementClient({
     models,
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     networkSubgraph,
     deploymentManagementEndpoint: statusEndpoint,
     logger,

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -223,7 +223,6 @@ export class AllocationManager {
             new SubgraphDeploymentID(action.deploymentID!),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             parseGRT(action.amount!),
-            undefined,
           )
         case ActionType.UNALLOCATE:
           return await this.prepareUnallocate(
@@ -262,7 +261,6 @@ export class AllocationManager {
     logger: Logger,
     deployment: SubgraphDeploymentID,
     amount: BigNumber,
-    indexNode: string | undefined,
   ): Promise<AllocateTransactionParams> {
     logger.info('Preparing to allocate', {
       deployment: deployment.ipfsHash,
@@ -327,7 +325,6 @@ export class AllocationManager {
       this.models,
       `indexer-agent/${deployment.ipfsHash.slice(-10)}`,
       deployment,
-      indexNode,
     )
 
     logger.debug('Obtain a unique Allocation ID')
@@ -454,9 +451,8 @@ export class AllocationManager {
     logger: Logger,
     deployment: SubgraphDeploymentID,
     amount: BigNumber,
-    indexNode: string | undefined,
   ): Promise<PopulatedTransaction> {
-    const params = await this.prepareAllocateParams(logger, deployment, amount, indexNode)
+    const params = await this.prepareAllocateParams(logger, deployment, amount)
     logger.debug(`Populating allocateFrom transaction`, {
       indexer: params.indexer,
       subgraphDeployment: params.subgraphDeploymentID,
@@ -477,15 +473,9 @@ export class AllocationManager {
   async allocate(
     deployment: SubgraphDeploymentID,
     amount: BigNumber,
-    indexNode: string | undefined,
   ): Promise<CreateAllocationResult> {
     try {
-      const params = await this.prepareAllocateParams(
-        this.logger,
-        deployment,
-        amount,
-        indexNode,
-      )
+      const params = await this.prepareAllocateParams(this.logger, deployment, amount)
 
       this.logger.debug(`Sending allocateFrom transaction`, {
         indexer: params.indexer,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -389,11 +389,7 @@ const SCHEMA_SDL = gql`
     storeDisputes(disputes: [POIDisputeInput!]!): [POIDispute!]
     deleteDisputes(allocationIDs: [String!]!): Int!
 
-    createAllocation(
-      deployment: String!
-      amount: String!
-      indexNode: String
-    ): CreateAllocationResult!
+    createAllocation(deployment: String!, amount: String!): CreateAllocationResult!
     closeAllocation(
       allocation: String!
       poi: String
@@ -427,7 +423,6 @@ export interface IndexerManagementClientOptions {
   address: string
   contracts: NetworkContracts
   indexingStatusResolver: IndexingStatusResolver
-  indexNodeIDs: string[]
   deploymentManagementEndpoint: string
   networkSubgraph: NetworkSubgraph
   logger: Logger
@@ -493,7 +488,6 @@ export const createIndexerManagementClient = async (
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint,
     networkSubgraph,
     logger,
@@ -517,7 +511,7 @@ export const createIndexerManagementClient = async (
 
   const dai: WritableEventual<string> = mutable()
 
-  const subgraphManager = new SubgraphManager(deploymentManagementEndpoint, indexNodeIDs)
+  const subgraphManager = new SubgraphManager(deploymentManagementEndpoint)
   let allocationManager: AllocationManager | undefined = undefined
   let actionManager: ActionManager | undefined = undefined
 

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -401,11 +401,7 @@ export default {
   },
 
   createAllocation: async (
-    {
-      deployment,
-      amount,
-      indexNode,
-    }: { deployment: string; amount: string; indexNode: string | undefined },
+    { deployment, amount }: { deployment: string; amount: string },
     {
       address,
       contracts,
@@ -479,7 +475,6 @@ export default {
         models,
         `indexer-agent/${subgraphDeployment.ipfsHash.slice(-10)}`,
         subgraphDeployment,
-        indexNode,
       )
 
       logger.debug('Obtain a unique Allocation ID')

--- a/packages/indexer-common/src/indexer-management/subgraphs.ts
+++ b/packages/indexer-common/src/indexer-management/subgraphs.ts
@@ -9,9 +9,8 @@ import pTimeout from 'p-timeout'
 
 export class SubgraphManager {
   client: RpcClient
-  indexNodeIDs: string[]
 
-  constructor(endpoint: string, indexNodeIDs: string[]) {
+  constructor(endpoint: string) {
     if (endpoint.startsWith('https')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.client = jayson.Client.https(endpoint as any)
@@ -19,7 +18,6 @@ export class SubgraphManager {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.client = jayson.Client.http(endpoint as any)
     }
-    this.indexNodeIDs = indexNodeIDs
   }
 
   async createSubgraph(logger: Logger, name: string): Promise<void> {
@@ -43,34 +41,15 @@ export class SubgraphManager {
     models: IndexerManagementModels,
     name: string,
     deployment: SubgraphDeploymentID,
-    indexNode: string | undefined,
   ): Promise<void> {
     try {
-      let targetNode: string
-      if (indexNode) {
-        targetNode = indexNode
-        if (!this.indexNodeIDs.includes(targetNode)) {
-          logger.warn(
-            `Specified deployment target node not present in indexNodeIDs supplied at startup, proceeding with deploy to target node anyway.`,
-            {
-              targetNode: indexNode,
-              indexNodeIDs: this.indexNodeIDs,
-            },
-          )
-        }
-      } else {
-        targetNode =
-          this.indexNodeIDs[Math.floor(Math.random() * this.indexNodeIDs.length)]
-      }
       logger.info(`Deploy subgraph`, {
         name,
         deployment: deployment.display,
-        targetNode,
       })
       const requestPromise = this.client.request('subgraph_deploy', {
         name,
         ipfs_hash: deployment.ipfsHash,
-        node_id: targetNode,
       })
       // Timeout deployment after 2 minutes
       const response = await pTimeout(requestPromise, 120000)
@@ -141,72 +120,20 @@ export class SubgraphManager {
     }
   }
 
-  async reassign(
-    logger: Logger,
-    deployment: SubgraphDeploymentID,
-    indexNode: string | undefined,
-  ): Promise<void> {
-    let targetNode: string
-    if (indexNode) {
-      targetNode = indexNode
-      if (!this.indexNodeIDs.includes(targetNode)) {
-        logger.warn(
-          `Specified deployment target node not present in indexNodeIDs supplied at startup, proceeding with deploy to target node anyway.`,
-          {
-            targetNode: indexNode,
-            indexNodeIDs: this.indexNodeIDs,
-          },
-        )
-      }
-    } else {
-      targetNode = this.indexNodeIDs[Math.floor(Math.random() * this.indexNodeIDs.length)]
-    }
-    try {
-      logger.info(`Reassign subgraph deployment`, {
-        deployment: deployment.display,
-        targetNode,
-      })
-      const response = await this.client.request('subgraph_reassign', {
-        node_id: targetNode,
-        ipfs_hash: deployment.ipfsHash,
-      })
-      if (response.error) {
-        throw response.error
-      }
-    } catch (error) {
-      if (error.message.includes('unchanged')) {
-        logger.debug(`Subgraph deployment assignment unchanged`, {
-          deployment: deployment.display,
-          targetNode,
-        })
-        throw error
-      }
-      const err = indexerError(IndexerErrorCode.IE028, error)
-      logger.error(`Failed to reassign subgraph deployment`, {
-        deployment: deployment.display,
-        err,
-      })
-      throw err
-    }
-  }
-
   async ensure(
     logger: Logger,
     models: IndexerManagementModels,
     name: string,
     deployment: SubgraphDeploymentID,
-    indexNode: string | undefined,
   ): Promise<void> {
     try {
       await this.createSubgraph(logger, name)
-      await this.deploy(logger, models, name, deployment, indexNode)
-      await this.reassign(logger, deployment, indexNode)
+      await this.deploy(logger, models, name, deployment)
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE020, error)
       logger.error(`Failed to ensure subgraph deployment is indexing`, {
         name,
         deployment: deployment.display,
-        targetNode: indexNode,
         err,
       })
       throw error

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -451,7 +451,6 @@ export default {
       address,
       contracts,
       indexingStatusResolver,
-      indexNodeIDs: ['node_1'], // This is just a dummy since the indexer-service doesn't manage deployments,
       deploymentManagementEndpoint: argv.graphNodeStatusEndpoint,
       networkSubgraph,
       logger,

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -73,13 +73,11 @@ const setup = async () => {
       'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet',
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
   client = await createIndexerManagementClient({
     models,
     address,
     contracts,
     indexingStatusResolver,
-    indexNodeIDs,
     deploymentManagementEndpoint: statusEndpoint,
     networkSubgraph,
     logger,


### PR DESCRIPTION
Remove indexer agent's assignments for subgraph deployments to specific index nodes, instead encourages the use of graph-node toml configs for flexible deployment rules. 

Currently the indexer agent and service take index-node id as provided at start-up, and round-robin the number of deployments on each node. We would like to make sure that graph node can balance deployments across available index-nodes with flexible deployment rules without conflicts from the agent. 

Resolves #504