### PR TITLE
`indexer-cli`, `indexer-common`: Introduce the `--first` CLI option

### DIFF
--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -276,6 +276,7 @@ export async function fetchAction(
 export async function fetchActions(
   client: IndexerManagementClient,
   actionFilter: ActionFilter,
+  first?: number,
   orderBy?: ActionParams,
   orderDirection?: OrderDirection,
 ): Promise<ActionResult[]> {
@@ -284,10 +285,16 @@ export async function fetchActions(
       gql`
         query actions(
           $filter: ActionFilter!
+          $first: Int
           $orderBy: ActionParams
           $orderDirection: OrderDirection
         ) {
-          actions(filter: $filter, orderBy: $orderBy, orderDirection: $orderDirection) {
+          actions(
+            filter: $filter
+            orderBy: $orderBy
+            orderDirection: $orderDirection
+            first: $first
+          ) {
             id
             type
             allocationID
@@ -304,7 +311,7 @@ export async function fetchActions(
           }
         }
       `,
-      { filter: actionFilter, orderBy, orderDirection },
+      { filter: actionFilter, orderBy, orderDirection, first },
     )
     .toPromise()
 

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -157,6 +157,7 @@ export class ActionManager {
     filter: ActionFilter,
     orderBy?: ActionParams,
     orderDirection?: OrderDirection,
+    first?: number,
   ): Promise<Action[]> {
     const filterObject = JSON.parse(JSON.stringify(filter))
     const orderObject: Order = orderBy
@@ -165,6 +166,7 @@ export class ActionManager {
     return await this.models.Action.findAll({
       where: filterObject,
       order: orderObject,
+      limit: first,
     })
   }
 }

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -376,6 +376,7 @@ const SCHEMA_SDL = gql`
       filter: ActionFilter
       orderBy: ActionParams
       orderDirection: OrderDirection
+      first: Int
     ): [Action]!
   }
 

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -118,15 +118,22 @@ export default {
       filter,
       orderBy,
       orderDirection,
-    }: { filter: ActionFilter; orderBy: ActionParams; orderDirection: OrderDirection },
+      first,
+    }: {
+      filter: ActionFilter
+      orderBy: ActionParams
+      orderDirection: OrderDirection
+      first: number
+    },
     { actionManager, logger }: IndexerManagementResolverContext,
   ): Promise<object[]> => {
     logger.debug(`Execute 'actions' query`, {
       filter,
       orderBy,
       orderDirection,
+      first,
     })
-    return await actionManager.fetchActions(filter, orderBy, orderDirection)
+    return await actionManager.fetchActions(filter, orderBy, orderDirection, first)
   },
 
   queueActions: async (


### PR DESCRIPTION
This PRs allows the `Action` resolver to limit the number of records returned by the query.

