### PR TITLE
strict versioning for indexer packages

### DIFF
--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@graphprotocol/common-ts": "1.8.6",
     "@graphprotocol/contracts": "1.16.0",
-    "@graphprotocol/indexer-common": "^0.20.5-alpha.0",
+    "@graphprotocol/indexer-common": "0.20.5-alpha.0",
     "@thi.ng/heaps": "^1.3.1",
     "@uniswap/sdk": "3.0.3",
     "axios": "0.26.1",

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "1.8.6",
-    "@graphprotocol/indexer-common": "^0.20.5-alpha.0",
+    "@graphprotocol/indexer-common": "0.20.5-alpha.0",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.74",
     "@urql/core": "2.4.4",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@google-cloud/profiler": "4.1.7",
     "@graphprotocol/common-ts": "1.8.6",
-    "@graphprotocol/indexer-common": "^0.20.5-alpha.0",
-    "@graphprotocol/indexer-native": "^0.20.5-alpha.0",
+    "@graphprotocol/indexer-common": "0.20.5-alpha.0",
+    "@graphprotocol/indexer-native": "0.20.5-alpha.0",
     "@graphql-tools/load": "7.5.8",
     "@graphql-tools/url-loader": "7.9.11",
     "@graphql-tools/wrap": "8.4.13",


### PR DESCRIPTION
To avoid using the package of version 0.25.x that was accidentally published in 368ffd12b6eee4eb7b65aaad9f7357e465df6eba , we define `indexer-common` and `indexer-native` to be strictly using the latest tag `0.20.5-x` 