### PR TITLE
indexer-common: batch stake feasibility

### DIFF
--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -259,6 +259,7 @@ export async function fetchAction(
             priority
             transaction
             status
+            failureReason
           }
         }
       `,

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -79,11 +79,6 @@ export class ActionManager {
 
     join({ approvedActions }).pipe(async ({ approvedActions }) => {
       if (await this.batchReady(approvedActions)) {
-        this.logger.info('Executing batch of approved actions', {
-          actions: approvedActions,
-          note: 'If actions were approved very recently they may be missing from this list but will still be taken',
-        })
-
         const attemptedActions = await this.executeApprovedActions()
 
         this.logger.trace('Attempted to execute all approved actions', {
@@ -115,6 +110,10 @@ export class ActionManager {
           })
         ).sort(function (a, b) {
           return actionTypePriority.indexOf(a.type) - actionTypePriority.indexOf(b.type)
+        })
+
+        this.logger.info('Executing batch of approved actions', {
+          actions: approvedActions,
         })
 
         try {


### PR DESCRIPTION
Currently action transactions including stake check are prepared in parallel. Thus in batch execution, stake check might be failing individually but sufficient when considering other actions. 

Thus in this PR we add an additional handling when errors in a batch are all stake errors:
- Actions are ordered in Action types (unallocate > reallocate > allocate), within the types, you can specify priority of a specific action (0 is most important). 
- Feasible set of actions are filled sequentially and prepared once again
- Infeasible actions are failed with IE013 errors
- Added failureReason in `indexer-cli` `get` command. 
- Would be nice to add tests for helper function