### PR TITLE
indexer-common,-cli: add cost models delete

### DIFF
--- a/packages/indexer-cli/src/__tests__/references/indexer-cost.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-cost.stdout
@@ -3,4 +3,5 @@ Manage costing for subgraphs
   indexer cost set variables    Update cost model variables                               
   indexer cost set model        Update a cost model                                       
   indexer cost get              Get cost models and/or variables for one or all subgraphs 
+  indexer cost delete           Remove one or many cost models                            
   indexer cost                  Manage costing for subgraphs                              

--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -15,6 +15,7 @@ Manage indexer configuration
   indexer cost set variables         Update cost model variables                                      
   indexer cost set model             Update a cost model                                              
   indexer cost get                   Get cost models and/or variables for one or all subgraphs        
+  indexer cost delete                Remove one or many cost models                                   
   indexer cost                       Manage costing for subgraphs                                     
   indexer connect                    Connect to indexer management API                                
   indexer allocations reallocate     Reallocate to subgraph deployment                                

--- a/packages/indexer-cli/src/__tests__/references/indexer.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer.stdout
@@ -16,6 +16,7 @@ Manage indexer configuration
   indexer cost set model             Update a cost model                                              
   indexer cost get                   Get cost models and/or variables for one or all subgraphs        
   indexer cost                       Manage costing for subgraphs                                     
+  indexer cost delete           Remove one or many cost models                                        
   indexer connect                    Connect to indexer management API                                
   indexer allocations reallocate     Reallocate to subgraph deployment                                
   indexer allocations get            List one or more allocations                                     

--- a/packages/indexer-cli/src/commands/indexer/cost/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/delete.ts
@@ -1,0 +1,76 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import { fixParameters } from '../../../command-helpers'
+import { costModels, deleteCostModels, parseDeploymentID } from '../../../cost'
+import { CostModelAttributes } from '@graphprotocol/indexer-common'
+
+const HELP = `
+${chalk.bold('graph indexer cost delete')} [options] all
+${chalk.bold('graph indexer cost delete')} [options] global
+${chalk.bold('graph indexer cost delete')} [options] <deployment-id>
+
+${chalk.dim('Options:')}
+
+  -h, --help                    Show usage information
+  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
+`
+
+module.exports = {
+  name: 'delete',
+  alias: [],
+  description: 'Remove one or many cost models',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const { h, help, o, output } = parameters.options
+    const [rawDeployment] = fixParameters(parameters, { h, help }) || []
+    const outputFormat = o || output || 'table'
+
+    if (help || h) {
+      print.info(HELP)
+      return
+    }
+
+    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+      print.error(`Invalid output format "${outputFormat}"`)
+      process.exitCode = 1
+      return
+    }
+
+    try {
+      const config = loadValidatedConfig()
+      // Create indexer API client
+      const client = await createIndexerManagementClient({ url: config.api })
+      const deployment = parseDeploymentID(rawDeployment)
+      switch (deployment) {
+        case 'all': {
+          const deployments: string[] = (await costModels(client))
+            .filter((model): model is CostModelAttributes => !!model.deployment)
+            .map(model => model.deployment.toString())
+
+          const numberDeleted = await deleteCostModels(client, deployments)
+          print.success(
+            `Deleted ${numberDeleted} cost model(s) for: \n${deployments.join('\n')}`,
+          )
+          break
+        }
+        case 'global': {
+          await deleteCostModels(client, [deployment])
+          print.success(`Deleted cost model for ${deployment}`)
+          break
+        }
+        default: {
+          await deleteCostModels(client, [deployment.bytes32])
+          print.success(`Deleted cost model for ${rawDeployment}`)
+        }
+      }
+    } catch (error) {
+      print.error(error.toString())
+      process.exitCode = 1
+      return
+    }
+  },
+}

--- a/packages/indexer-cli/src/cost.ts
+++ b/packages/indexer-cli/src/cost.ts
@@ -269,3 +269,28 @@ export const setCostModel = async (
 
   return costModelFromGraphQL(result.data.setCostModel)
 }
+
+export const deleteCostModels = async (
+  client: IndexerManagementClient,
+  deployments: string[],
+): Promise<number> => {
+  const result = await client
+    .mutation(
+      gql`
+        mutation deleteCostModels($deployments: [String!]!) {
+          deleteCostModels(deployments: $deployments) {
+            deployment
+            model
+            variables
+          }
+        }
+      `,
+      { deployments },
+    )
+    .toPromise()
+
+  if (result.error) {
+    throw result.error
+  }
+  return result.data.deleteCostModels
+}

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -386,6 +386,7 @@ const SCHEMA_SDL = gql`
     deleteIndexingRules(identifiers: [String!]!): Boolean!
 
     setCostModel(costModel: CostModelInput!): CostModel!
+    deleteCostModels(deployments: [String!]!): Int!
 
     storeDisputes(disputes: [POIDisputeInput!]!): [POIDispute!]
     deleteDisputes(allocationIDs: [String!]!): Int!

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -139,4 +139,19 @@ export default {
 
     return (await model.save()).toGraphQL()
   },
+
+  deleteCostModels: async (
+    { deployments }: { deployments: string[] },
+    { models }: IndexerManagementResolverContext,
+  ): Promise<number> => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return await models.CostModel.sequelize!.transaction(async (transaction) => {
+      return await models.CostModel.destroy({
+        where: {
+          deployment: deployments,
+        },
+        transaction,
+      })
+    })
+  },
 }


### PR DESCRIPTION
Add delete command for cost models
Example usage
```
./bin/graph-indexer indexer cost delete all 
./bin/graph-indexer indexer cost delete global
./bin/graph-indexer indexer cost delete Qm...
```
