### PR TITLE
indexer-cli,common: actions update command

### DIFF
--- a/packages/indexer-cli/src/__tests__/indexer/action.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/action.test.ts
@@ -1,0 +1,68 @@
+import { cliTest, setup, teardown } from '../util'
+import path from 'path'
+
+const baseDir = path.join(__dirname, '..')
+
+describe('Indexer action tests', () => {
+  describe('With indexer management server', () => {
+    beforeEach(setup)
+    afterEach(teardown)
+    describe('Action help', () => {
+      cliTest('Indexer Actions', ['indexer', 'actions'], 'references/indexer-actions', {
+        expectedExitCode: 255,
+        cwd: baseDir,
+        timeout: 10000,
+      })
+      cliTest(
+        'Indexer Actions help',
+        ['indexer', 'actions', '--help'],
+        'references/indexer-actions',
+        {
+          expectedExitCode: 255,
+          cwd: baseDir,
+          timeout: 10000,
+        },
+      )
+    })
+
+    // describe('Action queue...', () => {
+    //   cliTest(
+    //     'Indexer actions queue allocate - success',
+    //     [
+    //       'indexer',
+    //       'actions',
+    //       'queue',
+    //       'allocate',
+    //       'QmZZtzZkfzCWMNrajxBf22q7BC9HzoT5iJUK3S8qA6zNZr',
+    //       '100',
+    //     ],
+    //     'references/indexer-action-queue-allocate',
+    //     {
+    //       expectedExitCode: 0,
+    //       cwd: baseDir,
+    //       timeout: 10000,
+    //     },
+    //   )
+    //   cliTest(
+    //     'Indexer actions queue - no args',
+    //     ['indexer', 'actions', 'queue'],
+    //     'references/indexer-actions-queue-no-args',
+    //     {
+    //       expectedExitCode: 1,
+    //       cwd: baseDir,
+    //       timeout: 10000,
+    //     },
+    //   )
+    //   cliTest(
+    //     'Indexer action queue - invalid deployment ID ',
+    //     ['indexer', 'actions', 'queue', 'allocate', 'Qmemememememe', '100'],
+    //     'references/indexer-actions-invalid-id',
+    //     {
+    //       expectedExitCode: 1,
+    //       cwd: baseDir,
+    //       timeout: 10000,
+    //     },
+    //   )
+    // })
+  })
+})

--- a/packages/indexer-cli/src/__tests__/references/indexer-actions-queue-no-arg.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-actions-queue-no-arg.stdout
@@ -1,0 +1,15 @@
+✖ Error: Invalid 'ActionType' "undefined", must be one of ['allocate', 'unallocate', 'reallocate']
+
+graph indexer actions queue [options] <ActionType> <targetDeployment> <param1> <param2> <param3> <param4>
+graph indexer actions queue [options] allocate <deploymentID> <amount>
+graph indexer actions queue [options] unallocate <deploymentID> <allocationID> <poi> <force>
+graph indexer actions queue [options] reallocate <deploymentID> <allocationID> <amount> <poi> <force>
+
+Options:
+
+  -h, --help                    Show usage information
+  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML 
+  -s, --source <STRING>         Specify the source of the action decision
+  -r, --reason <STRING>         Specify the reason for the action to be taken
+  -p, --priority <INT>          Define a priority order for the action
+

--- a/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
@@ -1,0 +1,10 @@
+Manage indexer actions
+
+  indexer actions update     Update one or more actions                 
+  indexer actions queue      Queue an action item                       
+  indexer actions get        List one or more actions                   
+  indexer actions execute    Execute approved items in the action queue 
+  indexer actions delete     Delete an item in the queue                
+  indexer actions cancel     Cancel an item in the queue                
+  indexer actions approve    Approve an action item                     
+  indexer actions            Manage indexer actions                     

--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -22,6 +22,7 @@ Manage indexer configuration
   indexer allocations create         Create an allocation                                             
   indexer allocations close          Close an allocation                                              
   indexer allocations                Manage indexer allocations                                       
+  indexer actions update             Update one or more actions                                       
   indexer actions queue              Queue an action item                                             
   indexer actions get                List one or more actions                                         
   indexer actions execute            Execute approved items in the action queue                       

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -5,6 +5,7 @@ import {
   ActionResult,
   ActionStatus,
   ActionType,
+  ActionUpdateParams,
   IndexerManagementClient,
   OrderDirection,
 } from '@graphprotocol/indexer-common'
@@ -356,4 +357,46 @@ export async function deleteActions(
   }
 
   return result.data.deleteActions
+}
+
+export async function updateActions(
+  client: IndexerManagementClient,
+  filter: ActionFilter,
+  action: ActionUpdateParams,
+  first?: number,
+): Promise<ActionResult[]> {
+  const result = await client
+    .mutation(
+      gql`
+        mutation updateActions(
+          $filter: [ActionFilter!]!
+          $action: ActionUpdateParams!
+          $first: Int
+        ) {
+          updateActions(filter: $filter, action: $action, first: $first) {
+            id
+            type
+            allocationID
+            deploymentID
+            amount
+            poi
+            force
+            source
+            reason
+            priority
+            transaction
+            status
+            failureReason
+          }
+        }
+      `,
+      { filter, action, first },
+    )
+    .toPromise()
+
+  if (result.error) {
+    throw result.error
+  }
+
+  return result.data.updateActions
 }

--- a/packages/indexer-cli/src/commands/indexer/actions.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions.ts
@@ -10,6 +10,6 @@ module.exports = {
     const { print } = toolbox
     print.info(toolbox.command?.description)
     print.printCommands(toolbox, ['indexer', 'actions'])
-    process.exitCode = 1
+    process.exitCode = -1
   },
 }

--- a/packages/indexer-cli/src/commands/indexer/actions/update.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/update.ts
@@ -1,0 +1,253 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import {
+  parseBoolean,
+  Action,
+  ActionResult,
+  ActionType,
+  ActionStatus,
+  ActionUpdateParams,
+} from '@graphprotocol/indexer-common'
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import { fixParameters, printObjectOrArray, validatePOI } from '../../../command-helpers'
+import { updateActions } from '../../../actions'
+const HELP = `
+${chalk.bold('graph indexer actions update')} [options]
+${chalk.bold('graph indexer actions update')} [options] <--filter id:id>
+${chalk.bold('graph indexer actions update')} [options] <--filter id:all>
+
+${chalk.dim('Options:')}
+
+  -h, --help                                                        Show usage information
+      --filter  id|type|status|source                               Filter by fields
+      --type    allocate|unallocate|reallocate|collect              Update type
+      --status  queued|approved|pending|success|failed|canceled     Update status
+      --amount <amount>                                             Update amount
+      --poi    <poi>                                                Update POI
+      --force   true|false                                          Update force
+      --first [N]                                                   Fetch only the N first records (default: all records)
+  -o, --output table|json|yaml                                      Choose the output format: table (default), JSON, or YAML
+
+
+`
+
+module.exports = {
+  name: 'update',
+  alias: [],
+  description: 'Update one or more actions',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const inputSpinner = toolbox.print.spin('Processing inputs')
+
+    const { filter, type, status, amount, poi, force, h, help, o, output, first } =
+      parameters.options
+
+    fixParameters(parameters, { h, help }) || []
+    const outputFormat = o || output || 'table'
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let filters: any = {}
+    if (help || h) {
+      inputSpinner.stopAndPersist({ symbol: '💁', text: HELP })
+      return
+    }
+    try {
+      if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+        throw Error(
+          `Invalid output format "${outputFormat}" must be one of ['json', 'yaml' or 'table']`,
+        )
+      }
+
+      // Parse filters
+      //TODO: right now if filter isn't provided then everything is updated
+      // Do we want to limit this so there must be at least 1 filter?
+      if (filter) {
+        if (filter instanceof Array) {
+          // better to update this transformation to objects
+          filters = Object.fromEntries(filter.map(f => f.split(':')))
+        } else {
+          filters = Object.fromEntries([filter.split(':')])
+        }
+
+        Object.entries(filters).forEach(([k, v]) => {
+          switch (k) {
+            case 'type':
+              if (!['allocate', 'unallocate', 'reallocate'].includes(v as string)) {
+                throw Error(
+                  `Invalid 'ActionType' "${v}", must be one of ['allocate', 'unallocate', 'reallocate']`,
+                )
+              }
+              break
+            case 'status':
+              if (
+                ![
+                  'queued',
+                  'approved',
+                  'pending',
+                  'success',
+                  'failed',
+                  'canceled',
+                ].includes(v as string)
+              ) {
+                throw Error(
+                  `Invalid 'status' ${v} provided, must be one of ['queued', 'approved', 'pending', 'success', 'failed', 'canceled]`,
+                )
+              }
+
+              break
+            case 'source':
+              // any source can be a group
+              break
+            case 'reason':
+              // any reason can be a group
+              break
+            // case 'failureReason':
+            //   if (!k.match(`IE0..`)) {
+            //     throw Error(
+            //       `Invalid '--filter reason:___' provided, must be one of Indexer error code (IE0..)`,
+            //     )
+            //   }
+            //   break
+            case 'id':
+              if (v !== 'all' && isNaN(+(v as string))) {
+                throw Error(
+                  `Invalid 'actionID' provided ('${v}'), must be a numeric id or 'all'`,
+                )
+              }
+              if (v == 'all') {
+                if (filters.type || filters.reason) {
+                  throw Error(
+                    `Invalid query, cannot specify 'type', 'status', 'source' or 'reason' filters in addition to 'action:all'`,
+                  )
+                }
+              }
+              filters.id = +(v as string)
+
+              break
+            default: {
+              throw Error(
+                `Invalid '--filter' provided, must be one of ['type', 'status', 'source', 'reason', 'id']`,
+              )
+            }
+          }
+        })
+      }
+
+      // Check update field validity
+      if (type && !['allocate', 'unallocate', 'reallocate'].includes(type)) {
+        throw Error(
+          `Invalid 'ActionType' "${type}", must be one of ['allocate', 'unallocate', 'reallocate']`,
+        )
+      }
+
+      if (
+        status &&
+        !['queued', 'approved', 'pending', 'success', 'failed', 'canceled'].includes(
+          status,
+        )
+      ) {
+        throw Error(
+          `Invalid '--status' provided, must be one of ['queued', 'approved', 'pending', 'success', 'failed', 'canceled]`,
+        )
+      }
+
+      if (poi) {
+        if (!(await validatePOI(poi))) {
+          throw Error(`Invalid '--poi' provided`)
+        }
+      }
+
+      if (amount && +amount < 0) {
+        throw Error(`Invalid '--amount' provided, must be at least 0`)
+      }
+
+      if (!['undefined', 'number'].includes(typeof first)) {
+        throw Error(`Invalid value for '--first' option, must have a numeric value.`)
+      }
+
+      inputSpinner.succeed('Processed input parameters')
+    } catch (error) {
+      inputSpinner.fail(error.toString())
+      print.info(HELP)
+      process.exitCode = 1
+      return
+    }
+
+    const actionSpinner = toolbox.print.spin('Updating actions')
+
+    try {
+      const config = loadValidatedConfig()
+      const client = await createIndexerManagementClient({ url: config.api })
+
+      const updateActionItem: ActionUpdateParams = {
+        type: type
+          ? ActionType[type.toUpperCase() as keyof typeof ActionType]
+          : undefined,
+        status: status
+          ? ActionStatus[status.toUpperCase() as keyof typeof ActionStatus]
+          : undefined,
+        reason: `manual update`,
+        amount,
+        poi: await validatePOI(poi),
+        force: parseBoolean(force),
+      }
+
+      if (!updateActionItem) {
+        throw new Error(`Could not parse action update information`)
+      }
+
+      // Query filtered actions
+      let actions: ActionResult[] = []
+      switch (filters.id) {
+        case `all`: {
+          actions = await updateActions(client, {}, updateActionItem, first)
+          break
+        }
+        case `^[1-9]\\d*$`: {
+          actions = await updateActions(
+            client,
+            { id: +filters.id },
+            updateActionItem,
+            first,
+          )
+          break
+        }
+        default: {
+          actions = await updateActions(client, filters, updateActionItem, first)
+        }
+      }
+      actionSpinner.succeed('Actions query returned')
+
+      if (!actions || actions.length === 0) {
+        print.info('No actions found')
+        process.exitCode = 1
+        return
+      }
+
+      const displayProperties: (keyof Action)[] = [
+        'id',
+        'type',
+        'deploymentID',
+        'allocationID',
+        'amount',
+        'poi',
+        'force',
+        'priority',
+        'status',
+        'source',
+        'failureReason',
+        'transaction',
+        'reason',
+      ]
+
+      printObjectOrArray(print, outputFormat, actions, displayProperties)
+    } catch (error) {
+      actionSpinner.fail(error.toString())
+      process.exitCode = 1
+      return
+    }
+  },
+}

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -14,6 +14,18 @@ export interface ActionItem {
   params: ActionParamsInput
   type: ActionType
   reason: string
+  status?: ActionStatus
+}
+
+export interface ActionUpdateParams {
+  deploymentID?: string
+  allocationID?: string
+  amount?: string
+  poi?: string
+  force?: boolean
+  type?: ActionType
+  status?: ActionStatus
+  reason?: string
 }
 
 export interface ActionInput {
@@ -123,6 +135,7 @@ export const validateActionInputs = async (
 }
 
 export interface ActionFilter {
+  id?: number | undefined
   type?: ActionType | undefined
   status?: ActionStatus | undefined
   source?: string | undefined

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -205,9 +205,22 @@ const SCHEMA_SDL = gql`
   }
 
   input ActionFilter {
+    id: Int
     type: ActionType
     status: String
     source: String
+    reason: String
+  }
+
+  input ActionUpdateParams {
+    id: Int
+    deploymentID: String
+    allocationID: String
+    amount: Int
+    poi: String
+    force: Boolean
+    type: ActionType
+    status: ActionStatus
     reason: String
   }
 
@@ -404,6 +417,11 @@ const SCHEMA_SDL = gql`
     ): ReallocateAllocationResult!
 
     updateAction(action: ActionInput!): Action!
+    updateActions(
+      filter: [ActionFilter!]!
+      action: ActionUpdateParams!
+      first: Int
+    ): [ActionResult!]!
     queueActions(actions: [ActionInput!]!): [Action]!
     cancelActions(actionIDs: [String!]!): [Action]!
     deleteActions(actionIDs: [String!]!): Int!


### PR DESCRIPTION
Allow indexer to update actions by filtering action id (or `all`), status, type, reason and source if provided, and allow update to params for status, type, poi, amount, and force.

Filters are each tagged by `--filter`, and only actions that satisfy all filters are updated.

Example usage

To update action with id 5 to use 0x0 POI,
```
graph indexer actions update --filter action:5 --poi 0 --force true
```

To update failed unallocate actions that are in the queue, to be queued again with 0 POI and force resolve
```
graph indexer actions update --filter status:failed --filter type:unallocate --status queued --poi 0 --force true
```

Have not yet add automated tests