### PR TITLE
Indexer-cli: add actions delete options

### DIFF
--- a/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
@@ -4,7 +4,7 @@ Manage indexer actions
   indexer actions queue      Queue an action item                       
   indexer actions get        List one or more actions                   
   indexer actions execute    Execute approved items in the action queue 
-  indexer actions delete     Delete an item in the queue                
+  indexer actions delete     Delete one or many actions in the queue    
   indexer actions cancel     Cancel an item in the queue                
   indexer actions approve    Approve an action item                     
   indexer actions            Manage indexer actions                     

--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -26,7 +26,7 @@ Manage indexer configuration
   indexer actions queue              Queue an action item                                             
   indexer actions get                List one or more actions                                         
   indexer actions execute            Execute approved items in the action queue                       
-  indexer actions delete             Delete an item in the queue                                      
+  indexer actions delete             Delete one or many actions in the queue                          
   indexer actions cancel             Cancel an item in the queue                                      
   indexer actions approve            Approve an action item                                           
   indexer actions                    Manage indexer actions                                           

--- a/packages/indexer-cli/src/commands/indexer/actions/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/delete.ts
@@ -4,27 +4,29 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { fixParameters } from '../../../command-helpers'
-import { deleteActions } from '../../../actions'
+import { deleteActions, fetchActions } from '../../../actions'
 
 const HELP = `
+${chalk.bold('graph indexer actions delete')} [options] all
 ${chalk.bold('graph indexer actions delete')} [options] [<actionID1> ...]
 
 ${chalk.dim('Options:')}
 
-  -h, --help                    Show usage information
-  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML 
+  -h, --help                                                        Show usage information
+      --status  queued|approved|pending|success|failed|canceled     Filter by status
+  -o, --output table|json|yaml                                      Choose the output format: table (default), JSON, or YAML 
 `
 
 module.exports = {
   name: 'delete',
   alias: [],
-  description: 'Delete an item in the queue',
+  description: 'Delete one or many actions in the queue',
   run: async (toolbox: GluegunToolbox) => {
     const { print, parameters } = toolbox
 
     const inputSpinner = toolbox.print.spin('Processing inputs')
 
-    const { h, help, o, output } = parameters.options
+    const { status, h, help, o, output } = parameters.options
     const [...actionIDs] = fixParameters(parameters, { h, help }) || []
 
     const outputFormat = o || output || 'table'
@@ -35,8 +37,6 @@ module.exports = {
       return
     }
 
-    let numericActionIDs: number[]
-
     try {
       if (!['json', 'yaml', 'table'].includes(outputFormat)) {
         throw Error(
@@ -44,11 +44,30 @@ module.exports = {
         )
       }
 
-      if (!actionIDs || actionIDs.length === 0) {
-        throw Error(`Missing required argument: 'actionID'`)
+      if (
+        status &&
+        !['queued', 'approved', 'pending', 'success', 'failed', 'canceled'].includes(
+          status,
+        )
+      ) {
+        throw Error(
+          `Invalid '--status' provided, must be one of ['queued', 'approved', 'pending', 'success', 'failed', 'canceled]`,
+        )
       }
 
-      numericActionIDs = actionIDs.map(action => +action)
+      if (actionIDs[0] == 'all') {
+        if (status || actionIDs.length > 1) {
+          throw Error(
+            `Invalid query, cannot specify '--status' filter or multiple ids in addition to 'action = all'`,
+          )
+        }
+      }
+
+      if (!status && (!actionIDs || actionIDs.length === 0)) {
+        throw Error(
+          `Required at least one argument: actionID(s), 'all', or '--status' filter`,
+        )
+      }
 
       inputSpinner.succeed('Processed input parameters')
     } catch (error) {
@@ -62,6 +81,13 @@ module.exports = {
     try {
       const config = loadValidatedConfig()
       const client = await createIndexerManagementClient({ url: config.api })
+
+      const numericActionIDs: number[] =
+        actionIDs[0] == 'all'
+          ? (await fetchActions(client, {})).map(action => action.id)
+          : status
+          ? (await fetchActions(client, { status })).map(action => action.id)
+          : actionIDs.map(action => +action)
 
       const numDeleted = await deleteActions(client, numericActionIDs)
 


### PR DESCRIPTION
Quick update to extend the `actions delete` command to allow for deleting `all` actions or by `--status` filter

Ex.
```
graph indexer actions delete all 
graph indexer actions delete --status=queued
```