### PR TITLE
Fix: indexer-common schema allow null node

### DIFF
--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -311,7 +311,7 @@ const SCHEMA_SDL = gql`
     synced: Boolean!
     health: String!
     fatalError: IndexingError
-    node: String!
+    node: String
     chains: [ChainIndexingStatus]
   }
 


### PR DESCRIPTION
Indexer common schema specification updated to be less strict - allow node to be null to account for unassigned deployments 
resolve #546 

Updated behavior example
```
Indexer Deployments
┌────────────────────────────────────────────────┬────────┬─────────┬────────────┬─────────┬─────────┬───────────────────┬──────────────────────┬─────────────────────┐
│ deployment                                     │ synced │ health  │ fatalError │ node    │ network │ latestBlockNumber │ chainHeadBlockNumber │ earliestBlockNumber │
├────────────────────────────────────────────────┼────────┼─────────┼────────────┼─────────┼─────────┼───────────────────┼──────────────────────┼─────────────────────┤
│ Qmdsp5yyFzMVUdSv5N9KndTisjXHrGDEXNaBxjyCTvDfPs │ true   │ healthy │ -          │ null    │ goerli  │ 8061655           │ 8061655              │ 7664657             │
├────────────────────────────────────────────────┼────────┼─────────┼────────────┼─────────┼─────────┼───────────────────┼──────────────────────┼─────────────────────┤
│ QmaCRFCJX3f1LACgqZFecDphpxrqMyJw1r2DCBHXmQRYY8 │ true   │ healthy │ -          │ default │ goerli  │ 8061655           │ 8061655              │ 7812428             │
└────────────────────────────────────────────────┴────────┴─────────┴────────────┴─────────┴─────────┴───────────────────┴──────────────────────┴─────────────────────┘
```