### PR TITLE
indexer-common,cli: actions update command

### DIFF
--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "format": "prettier --write 'src/**/*.ts'",
     "lint": "eslint . --ext .ts,.tsx --fix",
-    "compile": "tsc",
+    "compile": "tsc --build",
     "prepare": "yarn format && yarn lint && yarn compile",
     "disputes": "yarn prepare && ./dist/cli.js indexer disputes get",
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo",

--- a/packages/indexer-cli/src/__tests__/indexer/actions.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/actions.test.ts
@@ -9,7 +9,7 @@ describe('Indexer actions tests', () => {
     afterAll(teardown)
     describe('Actions help', () => {
       cliTest('Indexer actions', ['indexer', 'actions'], 'references/indexer-actions', {
-        expectedExitCode: 1,
+        expectedExitCode: 255,
         cwd: baseDir,
         timeout: 10000,
       })
@@ -18,7 +18,7 @@ describe('Indexer actions tests', () => {
         ['indexer', 'actions', '--help'],
         'references/indexer-actions',
         {
-          expectedExitCode: 1,
+          expectedExitCode: 255,
           cwd: baseDir,
           timeout: 10000,
         },

--- a/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-actions.stdout
@@ -1,5 +1,6 @@
 Manage indexer actions
 
+  indexer actions update     Update one or more actions                 
   indexer actions queue      Queue an action item                       
   indexer actions get        List one or more actions                   
   indexer actions execute    Execute approved items in the action queue 

--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -22,6 +22,7 @@ Manage indexer configuration
   indexer allocations create         Create an allocation                                             
   indexer allocations close          Close an allocation                                              
   indexer allocations                Manage indexer allocations                                       
+  indexer actions update             Update one or more actions                                       
   indexer actions queue              Queue an action item                                             
   indexer actions get                List one or more actions                                         
   indexer actions execute            Execute approved items in the action queue                       

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -153,7 +153,7 @@ export async function validateRequiredParams(
   }
 }
 
-export async function validatePOI(poi: string | undefined): Promise<string | undefined> {
+export function validatePOI(poi: string | undefined): string | undefined {
   if (poi !== undefined) {
     if (typeof poi == 'number' && poi == 0) {
       poi = utils.hexlify(Array(32).fill(0))
@@ -161,7 +161,9 @@ export async function validatePOI(poi: string | undefined): Promise<string | und
     // Ensure user provided POI is formatted properly - '0x...' (32 bytes)
     const isHex = utils.isHexString(poi, 32)
     if (!isHex) {
-      throw new Error('Must be a 32 byte length hex string')
+      throw new Error(
+        `Invalid POI provided ('${poi}'): Must be a 32 byte length hex string`,
+      )
     }
   }
   return poi

--- a/packages/indexer-cli/src/commands/indexer/actions.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions.ts
@@ -10,6 +10,6 @@ module.exports = {
     const { print } = toolbox
     print.info(toolbox.command?.description)
     print.printCommands(toolbox, ['indexer', 'actions'])
-    process.exitCode = 1
+    process.exitCode = -1
   },
 }

--- a/packages/indexer-cli/src/commands/indexer/actions/approve.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/approve.ts
@@ -59,7 +59,7 @@ module.exports = {
         })
         numericActionIDs = queuedActions.map(action => action.id)
         if (numericActionIDs.length === 0) {
-          throw Error(`No 'queued' actions found.`)
+          throw Error(`No 'queued' actions found`)
         }
       } else {
         numericActionIDs = actionIDs.map(action => +action)

--- a/packages/indexer-cli/src/commands/indexer/actions/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/get.ts
@@ -139,7 +139,7 @@ module.exports = {
       }
 
       if (!['undefined', 'number'].includes(typeof first)) {
-        throw Error(`Invalid value for '--first' option, must have a numeric value.`)
+        throw Error(`Invalid value for '--first' option, must have a numeric value`)
       }
 
       if (!['undefined', 'string'].includes(typeof fields)) {

--- a/packages/indexer-cli/src/commands/indexer/actions/queue.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/queue.ts
@@ -4,8 +4,8 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { printObjectOrArray } from '../../../command-helpers'
-import { buildActionInput, queueActions } from '../../../actions'
-import { ActionInput, ActionStatus, ActionType } from '@graphprotocol/indexer-common'
+import { buildActionInput, queueActions, validateActionType } from '../../../actions'
+import { ActionInput, ActionStatus } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold(
@@ -65,14 +65,8 @@ module.exports = {
         )
       }
 
-      if (!['allocate', 'unallocate', 'reallocate'].includes(type)) {
-        throw Error(
-          `Invalid 'ActionType' "${type}", must be one of ['allocate', 'unallocate', 'reallocate']`,
-        )
-      }
-
       actionInputParams = await buildActionInput(
-        ActionType[type.toUpperCase() as keyof typeof ActionType],
+        validateActionType(type),
         { targetDeployment, param1, param2, param3, param4 },
         decisionSource,
         decisionReason,

--- a/packages/indexer-cli/src/commands/indexer/actions/update.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/update.ts
@@ -1,0 +1,121 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import { Action, ActionFilter, ActionUpdateInput } from '@graphprotocol/indexer-common'
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import { fixParameters, printObjectOrArray } from '../../../command-helpers'
+import {
+  buildActionFilter,
+  parseActionUpdateInput,
+  updateActions,
+} from '../../../actions'
+import { partition } from '@thi.ng/iterators'
+
+const HELP = `
+${chalk.bold('graph indexer actions update')} [options] [<key1> <value1> ...]
+
+${chalk.dim('Options:')}
+
+  -h, --help                                                        Show usage information
+      --id          <actionID>                                          Filter by actionID
+      --type        allocate|unallocate|reallocate                      Filter by type
+      --status      queued|approved|pending|success|failed|canceled     Filter by status
+      --source      <source>                                            Filter by source
+      --reason      <reason>                                            Filter by reason string
+  -o, --output      table|json|yaml                                     Choose the output format: table (default), JSON, or YAML
+`
+
+module.exports = {
+  name: 'update',
+  alias: [],
+  description: 'Update one or more actions',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const inputSpinner = toolbox.print.spin('Processing inputs')
+
+    const { id, type, status, source, reason, h, help, o, output } = parameters.options
+
+    const [...setValues] = fixParameters(parameters, { h, help }) || []
+    let updateActionInput: ActionUpdateInput = {}
+    let actionFilter: ActionFilter = {}
+
+    const outputFormat = o || output || 'table'
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (help || h) {
+      inputSpinner.stopAndPersist({ symbol: '💁', text: HELP })
+      return
+    }
+    try {
+      if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+        throw Error(
+          `Invalid output format "${outputFormat}" must be one of ['json', 'yaml' or 'table']`,
+        )
+      }
+
+      // 1. Convert all `null` strings to real nulls, and other values
+      //    to regular JS strings (which for some reason they are not...)
+      const kvs = setValues.map(param => (param === 'null' ? null : param.toString()))
+
+      // 2. Check that all key/value pairs are complete and
+      // there's no value missing at the end
+      if (kvs.length % 2 !== 0) {
+        throw Error(`An uneven number of key/value pairs was passed in: ${kvs.join(' ')}`)
+      }
+
+      updateActionInput = parseActionUpdateInput({
+        ...Object.fromEntries([...partition(2, 2, kvs)]),
+      })
+
+      actionFilter = buildActionFilter(id, type, status, source, reason)
+
+      inputSpinner.succeed('Processed input parameters')
+    } catch (error) {
+      inputSpinner.fail(error.toString())
+      print.info(HELP)
+      process.exitCode = 1
+      return
+    }
+
+    const actionSpinner = toolbox.print.spin('Updating actions')
+
+    try {
+      const config = loadValidatedConfig()
+      const client = await createIndexerManagementClient({ url: config.api })
+
+      const actionsUpdated = await updateActions(client, actionFilter, updateActionInput)
+
+      if (!actionsUpdated || actionsUpdated.length === 0) {
+        print.info('No actions found')
+        process.exitCode = 1
+        return
+      }
+
+      actionSpinner.succeed(`'${actionsUpdated.length}' actions updated`)
+
+      const displayProperties: (keyof Action)[] = [
+        'id',
+        'type',
+        'deploymentID',
+        'allocationID',
+        'amount',
+        'poi',
+        'force',
+        'priority',
+        'status',
+        'source',
+        'failureReason',
+        'transaction',
+        'reason',
+      ]
+
+      printObjectOrArray(print, outputFormat, actionsUpdated, displayProperties)
+    } catch (error) {
+      actionSpinner.fail(error.toString())
+      process.exitCode = 1
+      return
+    }
+  },
+}

--- a/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { BigNumber, utils } from 'ethers'
+import { BigNumber } from 'ethers'
 import { reallocateAllocation } from '../../../allocations'
-import { printObjectOrArray } from '../../../command-helpers'
+import { printObjectOrArray, validatePOI } from '../../../command-helpers'
 
 const HELP = `
 ${chalk.bold('graph indexer allocations reallocate')} [options] <id> <amount> <poi>
@@ -59,24 +59,8 @@ module.exports = {
       return
     }
 
-    if (poi !== undefined) {
-      if (typeof poi == 'number' && poi == 0) {
-        poi = utils.hexlify(Array(32).fill(0))
-      }
-      try {
-        // Ensure user provided POI is formatted properly - '0x...' (32 bytes)
-        const isHex = utils.isHexString(poi, 32)
-        if (!isHex) {
-          throw new Error('Must be a 32 byte length hex string')
-        }
-      } catch (error) {
-        spinner.fail(`Invalid POI provided, '${poi}'. ` + error.toString())
-        process.exitCode = 1
-        return
-      }
-    }
-
     try {
+      await validatePOI(poi)
       const allocationAmount = BigNumber.from(amount)
       const config = loadValidatedConfig()
       const client = await createIndexerManagementClient({ url: config.api })

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -16,6 +16,18 @@ export interface ActionItem {
   params: ActionParamsInput
   type: ActionType
   reason: string
+  status?: ActionStatus
+}
+
+export interface ActionUpdateInput {
+  deploymentID?: string
+  allocationID?: string
+  amount?: string
+  poi?: string
+  force?: boolean
+  type?: ActionType
+  status?: ActionStatus
+  reason?: string
 }
 
 export interface ActionInput {
@@ -125,6 +137,7 @@ export const validateActionInputs = async (
 }
 
 export interface ActionFilter {
+  id?: number | undefined
   type?: ActionType
   status?: ActionStatus
   source?: string
@@ -158,6 +171,8 @@ export interface ActionResult {
   reason: string
   status: ActionStatus
   priority: number | undefined
+  failureReason: string | null
+  transaction: string | null
 }
 
 export enum ActionType {

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -4,6 +4,7 @@ import {
   actionFilterToWhereOptions,
   ActionParams,
   ActionStatus,
+  ActionUpdateInput,
   AllocationManagementMode,
   AllocationResult,
   AllocationStatus,
@@ -189,5 +190,25 @@ export class ActionManager {
       order: orderObject,
       limit: first,
     })
+  }
+
+  public static async updateActions(
+    models: IndexerManagementModels,
+    action: ActionUpdateInput,
+    filter: ActionFilter,
+  ): Promise<[number, Action[]]> {
+    if (Object.keys(filter).length === 0) {
+      throw Error(
+        'Cannot bulk update actions without a filter, please provide a least 1 filter value',
+      )
+    }
+    return await models.Action.update(
+      { ...action },
+      {
+        where: actionFilterToWhereOptions(filter),
+        returning: true,
+        validate: true,
+      },
+    )
   }
 }

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -171,6 +171,18 @@ const SCHEMA_SDL = gql`
     priority: Int
   }
 
+  input ActionUpdateInput {
+    id: Int
+    deploymentID: String
+    allocationID: String
+    amount: Int
+    poi: String
+    force: Boolean
+    type: ActionType
+    status: ActionStatus
+    reason: String
+  }
+
   enum ActionParams {
     id
     status
@@ -205,6 +217,7 @@ const SCHEMA_SDL = gql`
   }
 
   input ActionFilter {
+    id: Int
     type: ActionType
     status: String
     source: String
@@ -404,6 +417,7 @@ const SCHEMA_SDL = gql`
     ): ReallocateAllocationResult!
 
     updateAction(action: ActionInput!): Action!
+    updateActions(filter: ActionFilter!, action: ActionUpdateInput!): [Action]!
     queueActions(actions: [ActionInput!]!): [Action]!
     cancelActions(actionIDs: [String!]!): [Action]!
     deleteActions(actionIDs: [String!]!): Int!

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -10,6 +10,7 @@ import {
   ActionResult,
   ActionStatus,
   ActionType,
+  ActionUpdateInput,
   IndexerManagementModels,
   OrderDirection,
   validateActionInputs,
@@ -261,6 +262,35 @@ export default {
       )
     }
     return updatedActions[0]
+  },
+
+  updateActions: async (
+    {
+      filter,
+      action,
+    }: {
+      filter: ActionFilter
+      action: ActionUpdateInput
+    },
+    { logger, models }: IndexerManagementResolverContext,
+  ): Promise<ActionResult[]> => {
+    logger.debug(`Execute 'updateActions' mutation`, {
+      filter,
+      action,
+    })
+
+    const results = await ActionManager.updateActions(models, action, filter)
+
+    if (results[0] === 0) {
+      const msg = `Actions update failed: No action was matched by the filter, '${JSON.stringify(
+        filter,
+      )}'`
+      logger.debug(msg)
+      throw Error(msg)
+    }
+    logger.info(`'${results[0]}' actions updated`)
+
+    return results[1]
   },
 
   approveActions: async (


### PR DESCRIPTION
This PR introduces an `actions update ...` command for updating one or more actions in the action queue. In order to support this command to update many actions in a single request an `updateActions` resolver has been added as well.

In the CLI the user can use options to filter the actions that will be updated and the user can provide key value pairs for the action keys that will be updated. 
```
graph indexer actions update [options] [<key1> <value1> ...]
```

Example usage, update all failed, reallocate actions to have force=true:
```
graph indexer actions update --status failed --type reallocate force true
```

Along with the added functionality a new test of the updateActions resolver has been included.  In a subsequent PR I'll add CLI level tests of success and failure modes for the update command.  

Shout out to @hopeyen for doing most of the work here on this feature! I was just there to do some final interface updates and push it across the finish line. 