### PR TITLE
Release `graph-node` `v0.29.0` on testnet

### DIFF
--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -6,7 +6,7 @@ Network information can be found at https://thegraph.com/explorer/network. The G
 
 | Component       | Release                                                                    |
 | --------------- | -------------------------------------------------------------------------- |
-| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  x|
+| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
 | indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |

--- a/docs/networks/testnet.md
+++ b/docs/networks/testnet.md
@@ -10,7 +10,7 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 | indexer-agent   | [0.20.5-alpha.1](https://github.com/graphprotocol/indexer/releases/tag/v0.20.5-alpha.1)    |
 | indexer-cli     | [0.20.5-alpha.1](https://github.com/graphprotocol/indexer/releases/tag/v0.20.5-alpha.1)    |
 | indexer-service | [0.20.5-alpha.1](https://github.com/graphprotocol/indexer/releases/tag/v0.20.5-alpha.1)    |
-| graph-node      | [0.29.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.29.0-rc.0)       |
+| graph-node      | [0.29.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.29.0)       |
 
 ## Network Parameters
 


### PR DESCRIPTION
https://github.com/graphprotocol/graph-node/releases/tag/v0.29.0