### PR TITLE
Auto-detect `ethereum-network`

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- The `ethereum-network` command line argument is no longer required.
 
 ## [0.20.4] - 2022-09-29
 ### Added

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -49,13 +49,6 @@ export default {
         required: true,
         group: 'Ethereum',
       })
-      .option('ethereum-network', {
-        description: 'Ethereum network',
-        type: 'string',
-        required: false,
-        default: 'any',
-        group: 'Ethereum',
-      })
       .option('ethereum-polling-interval', {
         description: 'Polling interval for the Ethereum provider (ms)',
         type: 'number',
@@ -571,7 +564,6 @@ export default {
     const networkProvider = await Network.provider(
       logger,
       metrics,
-      argv.ethereumNetwork,
       argv.ethereum,
       argv.ethereumPollingInterval,
     )

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -29,7 +29,7 @@ import {
   AllocationManagementMode,
   NetworkMonitor,
   EpochSubgraph,
-  CAIPIds,
+  resolveChainId,
 } from '@graphprotocol/indexer-common'
 import { startAgent } from '../agent'
 import { Indexer } from '../indexer'
@@ -677,7 +677,7 @@ export default {
     await receiptCollector.queuePendingReceiptsFromDatabase()
 
     const networkMonitor = new NetworkMonitor(
-      CAIPIds[argv.ethereumNetwork],
+      resolveChainId(networkMeta.chainId),
       contracts,
       toAddress(indexerAddress),
       logger.child({ component: 'NetworkMonitor' }),

--- a/packages/indexer-common/CHANGELOG.md
+++ b/packages/indexer-common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `ethereum-network` is now inferred from provider's `chainId`
 
 ## [0.20.4] - 2022-09-29
 ### Fixed

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -38,7 +38,7 @@ import {
   TransactionManager,
   NetworkMonitor,
   EpochSubgraph,
-  CAIPIds,
+  resolveChainId,
 } from '@graphprotocol/indexer-common'
 import { CombinedError } from '@urql/core'
 import { GraphQLError } from 'graphql'
@@ -296,7 +296,7 @@ const setup = async () => {
   )
 
   const networkMonitor = new NetworkMonitor(
-    CAIPIds['goerli'],
+    resolveChainId('goerli'),
     contracts,
     toAddress('0xc61127cdfb5380df4214b0200b9a07c7c49d34f9'),
     logger,

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -572,17 +572,16 @@ export class NetworkMonitor {
   }
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {
-    const networkAlias = alias(networkID)
     if (!this.epochSubgraph) {
       if (networkID == this.networkCAIPID) {
         return await this.networkCurrentEpoch()
       }
       this.logger.error(`Epoch start block not available for the network`, {
-        networkName: networkAlias,
+        networkName: networkID,
       })
       throw indexerError(
         IndexerErrorCode.IE071,
-        `Epoch start block not available for network: ${networkAlias}`,
+        `Epoch start block not available for network: ${networkID}`,
       )
     }
 
@@ -621,7 +620,7 @@ export class NetworkMonitor {
 
       if (!result.data.network || !result.data.network.latestValidBlockNumber) {
         throw new Error(
-          `Failed to query EBO for ${networkAlias}'s latest valid epoch number`,
+          `Failed to query EBO for ${networkID}'s latest valid epoch number`,
         )
       }
 
@@ -632,7 +631,7 @@ export class NetworkMonitor {
           ? result.data.network.latestValidBlockNumber
           : result.data.network.latestValidBlockNumber.previousBlockNumber
       const startBlockHash = await this.indexingStatusResolver.blockHashFromNumber(
-        networkAlias,
+        networkID,
         +validBlock.blockNumber,
       )
 
@@ -650,7 +649,7 @@ export class NetworkMonitor {
         maxTimeout: 10000,
         onFailedAttempt: (err) => {
           this.logger.warn(`Epoch subgraph could not be queried`, {
-            networkName: networkAlias,
+            networkName: networkID,
             attempt: err.attemptNumber,
             retriesLeft: err.retriesLeft,
             err: err.message,
@@ -664,7 +663,7 @@ export class NetworkMonitor {
         this.logger.error(`Failed to query latest epoch number`, {
           err,
           msg: err.message,
-          networkName: networkAlias,
+          networkName: networkID,
         })
         throw indexerError(IndexerErrorCode.IE069, err)
       }

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -13,11 +13,10 @@ import {
   Subgraph,
   SubgraphDeployment,
   SubgraphVersion,
-  CAIPIds,
   NetworkEpoch,
   EpochSubgraph,
   BlockPointer,
-  alias,
+  resolveChainId,
 } from '@graphprotocol/indexer-common'
 import {
   Address,
@@ -691,7 +690,7 @@ export class NetworkMonitor {
         )
       }
       const deploymentNetworkAlias = deploymentIndexingStatuses[0].chains[0].network
-      const deploymentNetworkCAIPID = CAIPIds[deploymentNetworkAlias]
+      const deploymentNetworkCAIPID = resolveChainId(deploymentNetworkAlias)
       const currentEpoch = await this.currentEpoch(deploymentNetworkCAIPID)
 
       this.logger.trace(`Fetched block pointer to use in resolving POI`, {

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -161,7 +161,7 @@ const Caip2ByChainId: { [key: number]: string } = {
   100: 'eip155:100',
 }
 
-/// Unified entryfpoint to resolve CAIP ID based either on chain aliases (strings)
+/// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)
 /// or chain ids (numbers).
 export function resolveChainId(key: number | string): string {
   if (typeof key === 'number') {

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -149,16 +149,31 @@ export interface NetworkEpoch {
   startBlockHash: string
 }
 
-export const CAIPIds: { [key: string]: string } = {
+const Caip2ByChainAlias: { [key: string]: string } = {
   mainnet: 'eip155:1',
   goerli: 'eip155:5',
   gnosis: 'eip155:100',
 }
 
-export const alias = (identifier: string): string => {
-  try {
-    return Object.keys(CAIPIds).filter((name) => CAIPIds[name] == identifier)[0]
-  } catch (error) {
-    throw new Error(`Failed to match chain ids to a network alias`)
+const Caip2ByChainId: { [key: number]: string } = {
+  1: 'eip155:1',
+  5: 'eip155:5',
+  100: 'eip155:100',
+}
+
+/// Unified entryfpoint to resolve CAIP ID based either on chain aliases (strings)
+/// or chain ids (numbers).
+export function resolveChainId(key: number | string): string {
+  if (typeof key === 'number') {
+    const chainId = Caip2ByChainId[key]
+    if (chainId !== undefined) {
+      return chainId
+    }
+  } else {
+    const chainId = Caip2ByChainAlias[key]
+    if (chainId !== undefined) {
+      return chainId
+    }
   }
+  throw new Error(`Failed to resolve CAIP2 ID from the provided network alias: ${key}`)
 }

--- a/packages/indexer-common/src/network.ts
+++ b/packages/indexer-common/src/network.ts
@@ -158,7 +158,6 @@ export class Network {
   static async provider(
     logger: Logger,
     metrics: Metrics,
-    networkName: string,
     networkURL: string,
     pollingInterval: number,
   ): Promise<providers.StaticJsonRpcProvider> {
@@ -202,15 +201,12 @@ export class Network {
       password = providerUrl.password
     }
 
-    const networkProvider = new providers.StaticJsonRpcProvider(
-      {
-        url: providerUrl.toString(),
-        user: username,
-        password: password,
-        allowInsecureAuthentication: true,
-      },
-      networkName,
-    )
+    const networkProvider = new providers.StaticJsonRpcProvider({
+      url: providerUrl.toString(),
+      user: username,
+      password: password,
+      allowInsecureAuthentication: true,
+    })
     networkProvider.pollingInterval = pollingInterval
 
     networkProvider.on('debug', (info) => {

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -298,7 +298,6 @@ export default {
     const networkProvider = await Network.provider(
       logger,
       metrics,
-      argv.ethereumNetwork,
       argv.ethereum,
       argv.ethereumPollingInterval,
     )


### PR DESCRIPTION
- Rely on chainID from ethereum provider instead of `argv.ethereumNetwork`.
- Remove `--ethereum-network` from `indexer-agent`.

