### PR TITLE
Release `graph-node` `v0.29.0` on mainnet

### DIFF
--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -10,7 +10,7 @@ Network information can be found at https://thegraph.com/explorer/network. The G
 | indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| graph-node      | [0.28.2](https://github.com/graphprotocol/graph-node/releases/tag/v0.28.2) |
+| graph-node      | [0.29.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.29.0) |
 
 ## Network Parameters
 
@@ -80,6 +80,12 @@ option can be used.
 
 > This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
 
+```
+graph-node: ≥0.29.0 <0.30.0
+valid from: 708
+upgrade window: 720
+```
+
 | Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
 |--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
 | **Core Features**        |         |             |              |                   |                      |                  |
@@ -89,6 +95,7 @@ option can be used.
 | **Data Source Types**    |         |             |              |                   |                      |                  |
 | eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
 | eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100               | gnosis  | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
 | cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
 | arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |

--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -103,4 +103,4 @@ upgrade window: 720
 | ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
 | ENS                      |         | Yes         | Yes          | No                | No                   | No               |
 
-[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xbdd884654a393620a7e8665b4289201b7542c3ee62becfad133e951b0c408444)
+[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4fa76f9ae541bf883e547407270866ffeb8448f3b3fca90bb9c5bc46e31499c2)


### PR DESCRIPTION
We're releasing `graph-node` `v0.29.0` to mainnet. Link to the release: https://github.com/graphprotocol/graph-node/releases/tag/v0.29.0.

Blockers that must be addressed before merging this PR:
- [x] Get Council's approval.
- [x] Add a commit linking to the GGP in `mainnet.md`.
- [x] Backstop indexers upgrade and resyncing of subgraphs affected by determinism fixes.
- [x] In case https://github.com/graphprotocol/indexer/pull/553 hasn't been merged yet, merge it.

The dependencies between these steps are not necessarily linear, and we might make progress on these fronts in parallel to save time.

cc @PedroMD @fordN 