### PR TITLE
indexer-common: Fix blockHashFromNumber usage

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -682,7 +682,7 @@ export default {
     await receiptCollector.queuePendingReceiptsFromDatabase()
 
     const networkMonitor = new NetworkMonitor(
-      resolveChainId(networkMeta.chainId),
+      await resolveChainId(networkMeta.chainId),
       contracts,
       toAddress(indexerAddress),
       logger.child({ component: 'NetworkMonitor' }),

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -313,19 +313,14 @@ const setup = async () => {
     voucherRedemptionMaxBatchSize: 100,
   })
 
-  const epochSubgraph = await EpochSubgraph.create(
-    'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli',
-  )
-
   const networkMonitor = new NetworkMonitor(
-    resolveChainId('goerli'),
+    await resolveChainId('goerli'),
     contracts,
     toAddress('0xc61127cdfb5380df4214b0200b9a07c7c49d34f9'),
     logger,
     indexingStatusResolver,
     networkSubgraph,
     ethereum,
-    epochSubgraph,
   )
 
   client = await createIndexerManagementClient({

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -573,7 +573,7 @@ export class NetworkMonitor {
   }
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {
-    const networkAlias = resolveChainAlias(networkID)
+    const networkAlias = await resolveChainAlias(networkID)
     if (!this.epochSubgraph) {
       if (networkID == this.networkCAIPID) {
         return await this.networkCurrentEpoch()
@@ -685,15 +685,15 @@ export class NetworkMonitor {
         !deploymentIndexingStatuses[0].chains[0].network
       ) {
         this.logger.error(
-          `Failed to query indexing status for ${allocation.subgraphDeployment.id.ipfsHash}`,
+          `No indexing status data found for ${allocation.subgraphDeployment.id.ipfsHash}`,
         )
         throw indexerError(
-          IndexerErrorCode.IE020,
-          `Failed to query indexing status for ${allocation.subgraphDeployment.id.ipfsHash}`,
+          IndexerErrorCode.IE018,
+          `No indexing status data found for ${allocation.subgraphDeployment.id.ipfsHash}`,
         )
       }
       const deploymentNetworkAlias = deploymentIndexingStatuses[0].chains[0].network
-      const deploymentNetworkCAIPID = resolveChainId(deploymentNetworkAlias)
+      const deploymentNetworkCAIPID = await resolveChainId(deploymentNetworkAlias)
       const currentEpoch = await this.currentEpoch(deploymentNetworkCAIPID)
 
       this.logger.trace(`Fetched block pointer to use in resolving POI`, {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -17,6 +17,7 @@ import {
   EpochSubgraph,
   BlockPointer,
   resolveChainId,
+  resolveChainAlias,
 } from '@graphprotocol/indexer-common'
 import {
   Address,
@@ -572,6 +573,7 @@ export class NetworkMonitor {
   }
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {
+    const networkAlias = resolveChainAlias(networkID)
     if (!this.epochSubgraph) {
       if (networkID == this.networkCAIPID) {
         return await this.networkCurrentEpoch()
@@ -631,7 +633,7 @@ export class NetworkMonitor {
           ? result.data.network.latestValidBlockNumber
           : result.data.network.latestValidBlockNumber.previousBlockNumber
       const startBlockHash = await this.indexingStatusResolver.blockHashFromNumber(
-        networkID,
+        networkAlias,
         +validBlock.blockNumber,
       )
 
@@ -649,7 +651,8 @@ export class NetworkMonitor {
         maxTimeout: 10000,
         onFailedAttempt: (err) => {
           this.logger.warn(`Epoch subgraph could not be queried`, {
-            networkName: networkID,
+            networkID,
+            networkAlias,
             attempt: err.attemptNumber,
             retriesLeft: err.retriesLeft,
             err: err.message,
@@ -663,7 +666,8 @@ export class NetworkMonitor {
         this.logger.error(`Failed to query latest epoch number`, {
           err,
           msg: err.message,
-          networkName: networkID,
+          networkID,
+          networkAlias,
         })
         throw indexerError(IndexerErrorCode.IE069, err)
       }

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -179,3 +179,13 @@ export function resolveChainId(key: number | string): string {
   }
   throw new Error(`Failed to resolve CAIP2 ID from the provided network alias: ${key}`)
 }
+
+export function resolveChainAlias(id: string): string {
+  try {
+    return Object.keys(Caip2ByChainAlias).filter(
+      (name) => Caip2ByChainAlias[name] == id,
+    )[0]
+  } catch (error) {
+    throw new Error(`Failed to match chain ids to a network alias`)
+  }
+}

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -163,7 +163,7 @@ const Caip2ByChainId: { [key: number]: string } = {
 
 /// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)
 /// or chain ids (numbers).
-export function resolveChainId(key: number | string): string {
+export async function resolveChainId(key: number | string): Promise<string> {
   if (typeof key === 'number' || !isNaN(+key)) {
     // If key is a number, then it must be a `chainId`
     const chainId = Caip2ByChainId[+key]
@@ -180,12 +180,19 @@ export function resolveChainId(key: number | string): string {
   throw new Error(`Failed to resolve CAIP2 ID from the provided network alias: ${key}`)
 }
 
-export function resolveChainAlias(id: string): string {
-  try {
-    return Object.keys(Caip2ByChainAlias).filter(
-      (name) => Caip2ByChainAlias[name] == id,
-    )[0]
-  } catch (error) {
-    throw new Error(`Failed to match chain ids to a network alias`)
+export async function resolveChainAlias(id: string): Promise<string> {
+  const aliasMatches = Object.keys(Caip2ByChainAlias).filter(
+    (name) => Caip2ByChainAlias[name] == id,
+  )
+  if (aliasMatches.length === 1) {
+    return aliasMatches[0]
+  } else if (aliasMatches.length === 0) {
+    throw new Error(
+      `Failed to match chain id, '${id}', to a network alias in Caip2ByChainAlias`,
+    )
+  } else {
+    throw new Error(
+      `Something has gone wrong, chain id, '${id}', matched more than one network alias in Caip2ByChainAlias`,
+    )
   }
 }

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -209,10 +209,10 @@ export class IndexingStatusResolver {
   }
 
   public async blockHashFromNumber(
-    network: string,
+    networkAlias: string,
     blockNumber: number,
   ): Promise<string> {
-    this.logger.trace(`Querying blockHashFromNumber`, { network, blockNumber })
+    this.logger.trace(`Querying blockHashFromNumber`, { networkAlias, blockNumber })
     try {
       return await pRetry(
         async (attempt) => {
@@ -224,7 +224,7 @@ export class IndexingStatusResolver {
                 }
               `,
               {
-                network,
+                network: networkAlias,
                 blockNumber,
               },
             )
@@ -235,7 +235,7 @@ export class IndexingStatusResolver {
           }
 
           this.logger.trace('Resolved block hash', {
-            network,
+            networkAlias,
             blockNumber,
             blockHash: result.data.blockHashFromNumber,
             attempt,
@@ -248,6 +248,8 @@ export class IndexingStatusResolver {
           maxTimeout: 10000,
           onFailedAttempt: (err) => {
             this.logger.warn(`Block hash could not be queried`, {
+              networkAlias,
+              blockNumber,
               attempt: err.attemptNumber,
               retriesLeft: err.retriesLeft,
               err: err.message,
@@ -258,7 +260,7 @@ export class IndexingStatusResolver {
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE070, error)
       this.logger.error(`Failed to query block hash`, {
-        network,
+        networkAlias,
         blockNumber,
         error: error.message,
       })

--- a/packages/indexer-common/src/indexing-status.ts
+++ b/packages/indexer-common/src/indexing-status.ts
@@ -231,7 +231,11 @@ export class IndexingStatusResolver {
             .toPromise()
 
           if (!result.data || !result.data.blockHashFromNumber || result.error) {
-            throw new Error(`Failed to query graph node for blockHashFromNumber`)
+            throw new Error(
+              `Failed to query graph node for blockHashFromNumber: ${
+                result.error ?? 'no data returned'
+              }`,
+            )
           }
 
           this.logger.trace('Resolved block hash', {


### PR DESCRIPTION
- Update usage of `blockHashFromNumber()`; it expects a network alias string value for the `network` parameter.
- Update naming to improve clarity between network identifier formats (alias and id). 