### PR TITLE
Add CAIP-2 entry for chain 1337

### DIFF
--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -153,12 +153,14 @@ const Caip2ByChainAlias: { [key: string]: string } = {
   mainnet: 'eip155:1',
   goerli: 'eip155:5',
   gnosis: 'eip155:100',
+  hardhat: 'eip155:1337',
 }
 
 const Caip2ByChainId: { [key: number]: string } = {
   1: 'eip155:1',
   5: 'eip155:5',
   100: 'eip155:100',
+  1337: 'eip155:1337',
 }
 
 /// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)


### PR DESCRIPTION
This seems necessary to run the indexer-agent against a local hardhat chain.