### PR TITLE
indexer-agent,indexer-service: Startup argument parsing updates and cleanup

### DIFF
--- a/packages/indexer-agent/config.yaml
+++ b/packages/indexer-agent/config.yaml
@@ -1,1 +1,1 @@
-ethereum-network: "mainnet"
+log-level: "debug"

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { Argv } from 'yargs'
 import { parse as yaml_parse } from 'yaml'
 import { SequelizeStorage, Umzug } from 'umzug'
+
 import {
   connectContracts,
   connectDatabase,
@@ -368,34 +369,6 @@ export default {
           return 'Invalid --rebate-claim-max-batch-size provided. Must be > 0 and an integer.'
         }
         return true
-      })
-      .option('vector-node', {
-        description: 'URL of a vector node',
-        type: 'string',
-        group: 'Query Fees',
-      })
-      .option('vector-router', {
-        description: 'Public identifier of the vector router',
-        type: 'string',
-        group: 'Query Fees',
-      })
-      .option('vector-transfer-definition', {
-        description: 'Address of the Graph transfer definition contract',
-        type: 'string',
-        default: 'auto',
-        group: 'Query Fees',
-      })
-      .option('vector-event-server', {
-        description: 'External URL of the vector event server of the agent',
-        type: 'string',
-        group: 'Query Fees',
-      })
-      .option('vector-event-server-port', {
-        description: 'Port to serve the vector event server at',
-        type: 'number',
-        required: false,
-        default: 8001,
-        group: 'Query Fees',
       })
       .option('allocation-exchange-contract', {
         description: 'Address of the contract to submit query fee vouchers to',

--- a/packages/indexer-service/config.yaml
+++ b/packages/indexer-service/config.yaml
@@ -1,0 +1,1 @@
+log-level: "debug"

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import readPackage from 'read-pkg'
 import { Argv } from 'yargs'
 import { BigNumber, Wallet } from 'ethers'
+import fs from 'fs'
+import { parse as yaml_parse } from 'yaml'
 
 import {
   connectContracts,
@@ -38,13 +40,6 @@ export default {
         description: 'Ethereum node or provider URL',
         type: 'string',
         required: true,
-        group: 'Ethereum',
-      })
-      .option('ethereum-network', {
-        description: 'Ethereum network',
-        type: 'string',
-        required: false,
-        default: 'any',
         group: 'Ethereum',
       })
       .option('ethereum-polling-interval', {
@@ -130,6 +125,11 @@ export default {
         required: true,
         group: 'Postgres',
       })
+      .option('network-subgraph-deployment', {
+        description: 'Network subgraph deployment',
+        type: 'string',
+        group: 'Network Subgraph',
+      })
       .option('network-subgraph-endpoint', {
         description: 'Endpoint to query the network subgraph from',
         type: 'string',
@@ -162,24 +162,6 @@ export default {
         required: false,
         group: 'Indexer Infrastructure',
       })
-      .option('vector-node', {
-        description: 'URL of a vector node',
-        type: 'string',
-        required: false,
-        group: 'Query Fees',
-      })
-      .option('vector-router', {
-        description: 'Public identifier of the vector router',
-        type: 'string',
-        required: false,
-        group: 'Query Fees',
-      })
-      .option('vector-transfer-definition', {
-        description: 'Address of the Graph transfer definition contract',
-        type: 'string',
-        default: 'auto',
-        group: 'Query Fees',
-      })
       .option('allocation-syncing-interval', {
         description: 'Interval (in ms) for syncing indexer allocations from the network',
         type: 'number',
@@ -190,6 +172,19 @@ export default {
         description: 'Address that signs query fee receipts from a known client',
         type: 'string',
         required: false,
+      })
+      .check(argv => {
+        if (!argv['network-subgraph-endpoint'] && !argv['network-subgraph-deployment']) {
+          return `At least one of --network-subgraph-endpoint and --network-subgraph-deployment must be provided`
+        }
+        return true
+      })
+      .config({
+        key: 'config-file',
+        description: 'Indexer service configuration file (YAML format)',
+        parseFn: function (cfgFilePath: string) {
+          return yaml_parse(fs.readFileSync(cfgFilePath, 'utf-8'))
+        },
       })
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
#### indexer-service:
- Parse --config-file and load parameters as startup arguments, include a simple default config file
- Remove deprecated yargs option: ethereum-network, vector-*
- Add network-subgraph-deployment yargs option (bug fix)
- Include network-subgraph args requirements check

#### indexer-agent:
- Update default config yaml, was setting a now deprecated param
- Remove vector related yargs options