### PR TITLE
Use `EpochSubgraph` to fetch block numbers instead of `EpochManager`

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `--epoch-subgraph-endpoint` is now a required parameter to start the Agent
 
 ## [0.20.7] - 2022-12-20
 ### Changed

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -175,14 +175,10 @@ class Agent {
 
     const currentEpochStartBlock = currentEpochNumber.tryMap(
       async () => {
-        const startBlockNumber =
-          await this.network.contracts.epochManager.currentEpochBlock()
-        const startBlock = await this.network.ethereum.getBlock(
-          startBlockNumber.toNumber(),
-        )
+        const currentEpoch = await this.networkMonitor.networkCurrentEpoch()
         return {
-          number: startBlock.number,
-          hash: startBlock.hash,
+          number: currentEpoch.startBlockNumber,
+          hash: currentEpoch.startBlockHash,
         } as BlockPointer
       },
       {

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -162,7 +162,7 @@ export default {
       .option('epoch-subgraph-endpoint', {
         description: 'Endpoint to query the epoch block oracle subgraph from',
         type: 'string',
-        required: false,
+        required: true,
         group: 'Protocol',
       })
       .option('index-node-ids', {
@@ -612,9 +612,7 @@ export default {
         : undefined,
     })
 
-    const epochSubgraph = argv.epochSubgraphEndpoint
-      ? await EpochSubgraph.create(argv.epochSubgraphEndpoint)
-      : undefined
+    const epochSubgraph = await EpochSubgraph.create(argv.epochSubgraphEndpoint)
 
     logger.info('Connect to network')
     const maxGasFee = argv.baseFeeGasMax || argv.gasPriceMax

--- a/packages/indexer-common/CHANGELOG.md
+++ b/packages/indexer-common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Epoch block tracking is now handled by the Epoch Subgraph instead of the Epoch Manager contract
 
 ## [0.20.8] - 2022-12-21
 ### Fixed

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -257,6 +257,7 @@ let networkSubgraph: NetworkSubgraph
 let client: IndexerManagementClient
 let transactionManager: TransactionManager
 let wallet: Wallet
+let epochSubgraph: EpochSubgraph
 
 // Make global Jest variables available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -302,6 +303,10 @@ const setup = async () => {
     0,
   )
 
+  epochSubgraph = await EpochSubgraph.create(
+    'https://api.thegraph.com/subgraphs/name/graphprotocol/goerli-epoch-block-oracle',
+  )
+
   const receiptCollector = new AllocationReceiptCollector({
     logger,
     transactionManager: transactionManager,
@@ -321,6 +326,7 @@ const setup = async () => {
     indexingStatusResolver,
     networkSubgraph,
     ethereum,
+    epochSubgraph,
   )
 
   client = await createIndexerManagementClient({

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -559,17 +559,7 @@ export class NetworkMonitor {
   }
 
   async networkCurrentEpoch(): Promise<NetworkEpoch> {
-    const epochNumber = await this.currentEpochNumber()
-    const startBlockNumber = (
-      await this.contracts.epochManager.currentEpochBlock()
-    ).toNumber()
-    const startBlockHash = (await this.ethereum.getBlock(startBlockNumber)).hash
-    return {
-      networkID: this.networkCAIPID,
-      epochNumber,
-      startBlockNumber,
-      startBlockHash,
-    }
+    return this.currentEpoch(this.networkCAIPID)
   }
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -599,6 +599,11 @@ export class NetworkMonitor {
                 }
               }
             }
+            _meta {
+              block {
+                number
+              }
+            }
           }
         `,
         {
@@ -626,12 +631,14 @@ export class NetworkMonitor {
         networkAlias,
         +validBlock.blockNumber,
       )
+      const latestBlock = result.data._meta.block.number
 
       return {
         networkID,
         epochNumber: +validBlock.epochNumber,
         startBlockNumber: +validBlock.blockNumber,
         startBlockHash,
+        latestBlock,
       }
     }
 

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -774,7 +774,7 @@ export class NetworkMonitor {
             throw indexerError(
               IndexerErrorCode.IE068,
               `User provided POI does not match reference fetched from the graph-node. Use '--force' to bypass this POI accuracy check.
-              POI: ${poi}, 
+              POI: ${poi},
               referencePOI: ${generatedPOI}`,
             )
         }

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -43,7 +43,7 @@ export class NetworkMonitor {
     private indexingStatusResolver: IndexingStatusResolver,
     private networkSubgraph: NetworkSubgraph,
     private ethereum: providers.BaseProvider,
-    private epochSubgraph?: EpochSubgraph,
+    private epochSubgraph: EpochSubgraph,
   ) {}
 
   async currentEpochNumber(): Promise<number> {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -564,18 +564,6 @@ export class NetworkMonitor {
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {
     const networkAlias = await resolveChainAlias(networkID)
-    if (!this.epochSubgraph) {
-      if (networkID == this.networkCAIPID) {
-        return await this.networkCurrentEpoch()
-      }
-      this.logger.error(`Epoch start block not available for the network`, {
-        networkName: networkID,
-      })
-      throw indexerError(
-        IndexerErrorCode.IE071,
-        `Epoch start block not available for network: ${networkID}`,
-      )
-    }
 
     const queryEpochSubgraph = async () => {
       // We know it is non-null because of the check above for a null case that will end execution of fn if true

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -150,6 +150,10 @@ export interface NetworkEpoch {
   latestBlock: number
 }
 
+export function epochElapsedBlocks(networkEpoch: NetworkEpoch): number {
+  return networkEpoch.startBlockNumber - networkEpoch.latestBlock
+}
+
 const Caip2ByChainAlias: { [key: string]: string } = {
   mainnet: 'eip155:1',
   goerli: 'eip155:5',

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -147,6 +147,7 @@ export interface NetworkEpoch {
   epochNumber: number
   startBlockNumber: number
   startBlockHash: string
+  latestBlock: number
 }
 
 const Caip2ByChainAlias: { [key: string]: string } = {


### PR DESCRIPTION
Tested on Goerli
https://testnet.thegraph.com/explorer/profile/0xa54f5494242a0c11094d76045dc01e2e544d873d?view=Indexing