### PR TITLE
Forward graph-attestable header for free queries

### DIFF
--- a/packages/indexer-service/src/queries.ts
+++ b/packages/indexer-service/src/queries.ts
@@ -108,6 +108,7 @@ export class QueryProcessor implements QueryProcessorInterface {
       status: 200,
       result: {
         graphQLResponse: response.data,
+        attestable: response.headers['graph-attestable'] === 'true',
       },
     }
   }

--- a/packages/indexer-service/src/server/index.ts
+++ b/packages/indexer-service/src/server/index.ts
@@ -331,7 +331,8 @@ export const createApp = async ({
             res
               .status(response.status || 200)
               .contentType('application/json')
-              .send(response.result)
+              .setHeader('graph-attestable', response.result.attestable.toString())
+              .send({ graphQLResponse: response.result.graphQLResponse })
           } catch (error) {
             const err = indexerError(IndexerErrorCode.IE033, error)
             logger.error(`Failed to handle free query`, { err })

--- a/packages/indexer-service/src/types.ts
+++ b/packages/indexer-service/src/types.ts
@@ -15,6 +15,7 @@ export interface QueryResult {
 
 export interface UnattestedQueryResult {
   graphQLResponse: string
+  attestable: boolean
 }
 
 export type Response<T> = {


### PR DESCRIPTION
Automated fishermen may be relying on free queries to check against untrusted indexer responses. For this purpose, they require the signal that the response is expected to be attestable.