### PR TITLE
indexer-service: Add 'yaml' dependency

### DIFF
--- a/packages/indexer-service/CHANGELOG.md
+++ b/packages/indexer-service/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Include yaml package as dependency
 
 ## [0.20.9] - 2023-01-24
 ### Added

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -61,6 +61,7 @@
     "p-queue": "6.6.2",
     "p-retry": "4.6.1",
     "read-pkg": "5.2.0",
+    "yaml": "^2.0.0-10",
     "yargs": "17.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The `yaml` dependency was included in another package but not in indexer-service, so local builds were working but the indexer-service container did not have the necessary dependencies. This PR resolves by adding `yaml` to indexer-service dependency list. 