### PR TITLE
Update publish build binaries action strategies matrix

### DIFF
--- a/.github/workflows/publish-native-binaries.yml
+++ b/.github/workflows/publish-native-binaries.yml
@@ -15,12 +15,21 @@ jobs:
       # (https://github.com/bchr02/node-pre-gyp-github/issues/42)
       fail-fast: false
       matrix:
-        node_version: [14, 15, 16, 17, 18]
+        node_version: [14, 16, 17]
         system:
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
+        include:
+          - node_version: 18
+            system:
+              os: ubuntu-22.04
+              target: x86_64-unknown-linux-gnu
+          - node_version: 18
+            system:
+              os: macos-latest
+              target: x86_64-apple-darwin
     runs-on: ${{ matrix.system.os }}
     steps:
       - name: Checkout the repo
@@ -29,6 +38,10 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ matrix.node_version }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -47,8 +47,9 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "2.0.1",
-    "@mapbox/node-pre-gyp": "1.0.9",
-    "cargo-cp-artifact": "0.1.6"
+    "@mapbox/node-pre-gyp": "1.0.10",
+    "node-pre-gyp-github": "1.4.4",
+    "cargo-cp-artifact": "0.1.7"
   },
   "devDependencies": {
     "bs58": "5.0.0",
@@ -56,7 +57,6 @@
     "eslint-config-prettier": "8.5.0",
     "ethers": "5.7.0",
     "jest": "27.5.1",
-    "node-pre-gyp-github": "1.4.4",
     "prettier": "2.6.2"
   },
   "binary": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,6 +1883,21 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
+"@mapbox/node-pre-gyp@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz#8e6735ccebbb1581e5a7e652244cadc8a844d03c"
+  integrity sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==
+  dependencies:
+    detect-libc "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.7"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@mapbox/node-pre-gyp@1.0.9", "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz"
@@ -4054,6 +4069,11 @@ cargo-cp-artifact@0.1.6:
   version "0.1.6"
   resolved "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz"
   integrity sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==
+
+cargo-cp-artifact@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.7.tgz#1181b9d6e71f00f17c068c05e3cd1b0864783341"
+  integrity sha512-pxEV9p1on8vu3BOKstVisF9TwMyGKCBRvzaVpQHuU2sLULCKrn3MJWx/4XlNzmG6xNCTPf78DJ7WCGgr2mOzjg==
 
 chalk@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
- Remove node v15 builds (not compatible with `lerna@6.1.0`)
- Use `actions/setup-python@v4` to specify Python version, for
compatibility with node-gyp
- Use `Ubuntu-22.04` runner for Node v18 builds
- Upgrade node-pre-gyp dependency -> `1.0.10`