### PR TITLE
Clean and validate `Action.amount` 

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -1055,7 +1055,7 @@ describe('Allocation Manager', () => {
   }
   const reallocateAction = {
     ...invalidReallocateAction,
-    amount: 10_000,
+    amount: '10000',
     allocationID,
   }
 
@@ -1065,9 +1065,9 @@ describe('Allocation Manager', () => {
     const mapper = (x: Action) => allocationManager.resolveActionDelta(x)
     const balances = await Promise.all(actions.map(mapper))
 
-    expect(balances[0].balance).toStrictEqual(BigNumber.from(10_000)) // (allocate)
-    expect(balances[1].balance).toStrictEqual(BigNumber.from('-0x054b40b1f852bda00000')) // -25*10**21 (unallocate)
-    expect(balances[2].balance).toStrictEqual(BigNumber.from('-0x054b40b1f852bd9fd8f0')) // -25*10**21 + 10,000 (reallocate)
+    expect(balances[0].balance).toStrictEqual(parseGRT('10000')) // (allocate)
+    expect(balances[1].balance).toStrictEqual(parseGRT('-25000')) // (unallocate)
+    expect(balances[2].balance).toStrictEqual(parseGRT('-15000')) // (reallocate)
   })
 
   test('validateActionBatchFeasibility() validates and correctly sorts actions based on net token balance', async () => {

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -10,7 +10,6 @@ import {
   Action,
   ActionFailure,
   ActionType,
-  Allocation,
   allocationIdProof,
   AllocationResult,
   AllocationStatus,
@@ -1125,7 +1124,12 @@ export class AllocationManager {
     let unallocates = BigNumber.from(0)
 
     // Handle allocations
-    const allocates = BigNumber.from(action.amount ?? 0)
+    let allocates
+    if (action.amount) {
+      allocates = parseGRT(action.amount)
+    } else {
+      allocates = BigNumber.from(0)
+    }
 
     // Handle unallocations
     if (action.type === ActionType.UNALLOCATE || action.type === ActionType.REALLOCATE) {


### PR DESCRIPTION
Fixes parsing of `Action.amount` during batch stake feasibility validation in the AllocationManager context.

Fixes #589 