### PR TITLE
fix indexer-cli v0.20.11

### DIFF
--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -31,6 +31,7 @@
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.74",
     "@urql/core": "2.4.4",
+    "axios": "^1.3.1",
     "chalk": "4.1.2",
     "env-paths": "2.2.1",
     "ethers": "5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,6 +3642,15 @@ axios@^1.0.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.1.tgz#80bf6c8dbb46e6db1fa8fe9ab114c1ca7405c2ee"
+  integrity sha512-78pWJsQTceInlyaeBQeYZ/QgZeWS8hGeKiIJiDKQe3hEyBb7sEMq0K4gjx+Va6WHTYO4zI/RRl8qGRzn0YMadA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz#a1bf8d61928edfefd21da27eb86a695bfd691444"


### PR DESCRIPTION
Running graph indexer status with 0.20.11 causes an error due to the absence of the axios module.
We will therefore fix this with this request.

Fixes #595 