### PR TITLE
indexer-agent,-common: query fee metrics for Prometheus

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -642,6 +642,7 @@ export default {
 
     const receiptCollector = new AllocationReceiptCollector({
       logger,
+      metrics,
       transactionManager: network.transactionManager,
       models: queryFeeModels,
       allocationExchange: network.contracts.allocationExchange,

--- a/packages/indexer-common/CHANGELOG.md
+++ b/packages/indexer-common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `ReceiptMetrics` metric for allocation receipt collector
 
 ## [0.20.11] - 2023-02-01
 ### Changed

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -7,7 +7,9 @@ import {
   connectContracts,
   connectDatabase,
   createLogger,
+  createMetrics,
   Logger,
+  Metrics,
   mutable,
   NetworkContracts,
   parseGRT,
@@ -264,6 +266,7 @@ let networkMonitor: NetworkMonitor
 let receiptCollector: AllocationReceiptCollector
 let mockedSubgraphManager: SubgraphManager
 let allocationManager: AllocationManager
+let metrics: Metrics
 
 // Make global Jest variables available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -313,8 +316,10 @@ const setup = async () => {
     'https://api.thegraph.com/subgraphs/name/graphprotocol/goerli-epoch-block-oracle',
   )
 
+  metrics = createMetrics()
   receiptCollector = new AllocationReceiptCollector({
     logger,
+    metrics,
     transactionManager: transactionManager,
     models: queryFeeModels,
     allocationExchange: contracts.allocationExchange,
@@ -384,6 +389,7 @@ const teardownEach = async () => {
 }
 
 const teardownAll = async () => {
+  metrics.registry.clear()
   await sequelize.drop({})
 }
 


### PR DESCRIPTION
To keep track of query fee metrics, add property `metrics: Metrics` to the receipt collector `AllocationReceiptCollector`, which batch receipts to collect as vouchers (exchanged through partial vouchers if needed), and redeem batched vouchers. 

Added a customized `ReceiptMetrics` property keeps track the count, success rate, and duration for basic query fee collection performances.

```
interface ReceiptMetrics {
	receiptsToCollect: Gauge<'allocation'> 			// Individual receipts to collect
	failedReceipts: Counter<'allocation'> 			// Failed to queue receipts to collect
	partialVouchersToExchange: Gauge<'allocation'> 		// Individual partial vouchers to exchange
	receiptsCollectDuration: Histogram<'allocation'> 	// Duration of processing and exchanging receipts to voucher
	vouchers: Counter<'allocation'> 			// Individual vouchers to redeem
	successVoucherRedeems: Counter<'allocation'> 		// Successfully redeemed vouchers
	invalidVoucherRedeems: Counter<'allocation'> 		// Invalid vouchers redeems - tx paused or unauthorized
	failedVoucherRedeems: Counter<'allocation'> 		// Failed redeems for vouchers
	vouchersRedeemDuration: Histogram<'allocation'> 	// Duration of redeeming vouchers
	vouchersBatchRedeemSize: Gauge<never> 			// Size of redeeming batched vouchers
	vouchersCollectedFees: Gauge<'allocation'> 		// Amount of query fees collected for a voucher'
}
```

Open questions:
- Is it better to track metrics by subgraph deployment id? Tracking by allocation was the easiest but metrics across allocations on the same subgraph deployment could be valuable to track.
- Maybe VouchersCollectedFees gauge can be split into 2, one above the redeem threshold, and one below the redeem threshold.
- ReceiptToCollectDuration currently includes both single shot collection and collection through partial vouchers. Considering that partial vouchers are not used super often I kept them together, but maybe it could become outliers and influence the metrics negatively?
