### PR TITLE
indexer-agent: remove input allocation-exchange-contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,6 @@ Query Fees
                                   agent                                 [string]
   --vector-event-server-port      Port to serve the vector event server at
                                                         [number] [default: 8001]
-  --allocation-exchange-contract  Address of the contract to submit query fee
-                                  vouchers to         [string] [default: "auto"]
   --collect-receipts-endpoint     Client endpoint for collecting receipts
                                                                         [string]
 

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -370,14 +370,6 @@ export default {
         }
         return true
       })
-      .option('allocation-exchange-contract', {
-        description: 'Address of the contract to submit query fee vouchers to',
-        type: 'string',
-        required: false,
-        default: 'auto',
-        implies: ['collect-receipts-endpoint'],
-        group: 'Query Fees',
-      })
       .option('collect-receipts-endpoint', {
         description: 'Client endpoint for collecting receipts',
         type: 'string',


### PR DESCRIPTION
Simply remove `allocation-exchange-contract` from the indexer agent start command, update README.md.

Can also remove other unused variables such as `vector-node`, `vector-event-server`, ... as they are not used as well

Resolves #594 