### PR TITLE
indexer-agent: Remove networkCurrentEpoch() from critical path

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -172,19 +172,6 @@ class Agent {
       },
     )
 
-    const networkLatestEpoch = timer(600_000).tryMap(
-      async () => await this.networkMonitor.networkCurrentEpoch(),
-      {
-        onError: error =>
-          this.logger.warn(
-            `Failed to obtain protocol chain's latest valid epoch`,
-            {
-              error,
-            },
-          ),
-      },
-    )
-
     const channelDisputeEpochs = timer(600_000).tryMap(
       () => this.network.contracts.staking.channelDisputeEpochs(),
       {
@@ -399,7 +386,6 @@ class Agent {
       recentlyClosedAllocations,
       claimableAllocations,
       disputableAllocations,
-      networkLatestEpoch,
     }).pipe(
       async ({
         paused,
@@ -413,10 +399,9 @@ class Agent {
         recentlyClosedAllocations,
         claimableAllocations,
         disputableAllocations,
-        networkLatestEpoch,
       }) => {
         this.logger.info(`Reconcile with the network`, {
-          networkLatestEpoch,
+          currentEpochNumber,
         })
 
         // Do nothing else if the network is paused


### PR DESCRIPTION
The networkCurrentEpoch() function requires that the protocol chain be registered with the Epoch Block Oracle as an index chain. There may be cases where the protocol chain is not registered as an index chain; we don't want to block the indexer-agent reconciliation loop. 