### PR TITLE
feat: update network params, deployment hash and contracts version

### DIFF
--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -6,7 +6,7 @@ Network information can be found at https://thegraph.com/explorer/network. The G
 
 | Component       | Release                                                                    |
 | --------------- | -------------------------------------------------------------------------- |
-| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
+| contracts       | [2.3.0](https://github.com/graphprotocol/contracts/releases/tag/v2.3.0)    |
 | indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
 | indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
@@ -16,7 +16,7 @@ Network information can be found at https://thegraph.com/explorer/network. The G
 
 | Parameter                   | Value                 |
 | --------------------------- | --------------------  |
-| Epoch length                | ~ 24h (6646 blocks)   |
+| Epoch length                | ~ 24h (7200 blocks)   |
 | Maximum allocation lifetime | ~28 days (28 epochs)  |
 
 ## Contracts & accounts
@@ -41,8 +41,8 @@ Other network contracts can be found in [graphprotocol/contracts](https://github
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                     |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure       |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                  |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u`        |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`                  |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmVzvwKWRPGvghBvYpqLzzmcKvKqy3LGpN93USiATBypfr`        |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network` or `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet` |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (USDC)     |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts` |
 | `INDEXER_AGENT_GAS_PRICE_MAX`               | `--gas-price-max`               | `50`                                                    |
@@ -65,8 +65,8 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                        |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer              |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator           |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u` |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`           |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmVzvwKWRPGvghBvYpqLzzmcKvKqy3LGpN93USiATBypfr` |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network` or `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet`       |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0x982D10c56b8BBbD6e09048F5c5f01b43C65D5aE0`     |
 
 ### Graph Node

--- a/docs/networks/testnet.md
+++ b/docs/networks/testnet.md
@@ -6,7 +6,7 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 
 | Component       | Release                                                                         |
 | --------------- | ------------------------------------------------------------------------------- |
-| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)       |
+| contracts       | [2.3.0](https://github.com/graphprotocol/contracts/releases/tag/v2.3.0)         |
 | indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
 | indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
 | indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
@@ -47,7 +47,7 @@ testnet (for now) are Mainnet subgraphs. This means:
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                               |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of testnet indexer infrastructure                                 |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                            |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                  |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmZdoqtHDkrvwXG3zNrmwcU8p7nmcPzUpQ1ncDdF5wJR1b`                                  |
 | `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli`      |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0x9e7e607afd22906f7da6f1ec8f432d6f244278be` (GDAI)                               |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.testnet.thegraph.com/collect-receipts`                           |
@@ -71,7 +71,7 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `goerli`                                                                        |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                             |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                          |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmZdoqtHDkrvwXG3zNrmwcU8p7nmcPzUpQ1ncDdF5wJR1b`                                |
 | `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli`    |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xe1EC4339019eC9628438F8755f847e3023e4ff9c`                                    |
 


### PR DESCRIPTION
Updated the contracts version to the latest available (support for L2, updated contracts addresses, etc).
Updated subgraph deployments to the latest non-ipfs codebase deployed ([Mainnet](https://thegraph.com/hosted-service/subgraph/juanmardefago/no-ipfs-network-mainnet?version=pending), [Goerli](https://thegraph.com/hosted-service/subgraph/juanmardefago/no-ipfs-network-goerli?version=pending))
Updated network params for mainnet (epoch block length)
Added another fallback API for the graph-network subgraph on mainnet