### PR TITLE
Detailed subgraph deployment names

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Subgraph deployment names are now format as: `<SUBGRAPH_NAME>/<IPFS_HASH>/<OWNER_ADDRESSS>`
 
 ## [0.20.12] - 2023-02-19
 ### Changed

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -27,6 +27,7 @@ import {
   SubgraphIdentifierType,
   evaluateDeployments,
   AllocationDecision,
+  formatDeploymentName,
 } from '@graphprotocol/indexer-common'
 import { Indexer } from './indexer'
 import { AgentConfig } from './types'
@@ -688,8 +689,11 @@ class Agent {
     // Index all new deployments worth indexing
     await queue.addAll(
       deploy.map(deployment => async () => {
-        const name = `indexer-agent/${deployment.ipfsHash.slice(-10)}`
-
+        const subgraphDeployment =
+          await this.networkMonitor.requireSubgraphDeployment(
+            deployment.ipfsHash,
+          )
+        const name = formatDeploymentName(subgraphDeployment)
         this.logger.info(`Index subgraph deployment`, {
           name,
           deployment: deployment.display,

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -702,14 +702,17 @@ export default {
       indexerAddress,
       allocationManagementMode,
     )
-    const networkSubgraphDeployment = argv.networkSubgraphDeployment
+    const networkSubgraphDeploymentId = argv.networkSubgraphDeployment
       ? new SubgraphDeploymentID(argv.networkSubgraphDeployment)
       : undefined
-    if (networkSubgraphDeployment !== undefined) {
+    if (networkSubgraphDeploymentId !== undefined) {
       // Make sure the network subgraph is being indexed
+      //
+      // TODO: once the Network Subgraph is published to the Network, we can use the
+      // `formatDeploymentName` function instead of using a hardcoded deployment name.
       await indexer.ensure(
-        `indexer-agent/${networkSubgraphDeployment.ipfsHash.slice(-10)}`,
-        networkSubgraphDeployment,
+        `graphprotocol/network-subgraph/${networkSubgraphDeploymentId.ipfsHash}`,
+        networkSubgraphDeploymentId,
       )
     }
 

--- a/packages/indexer-agent/src/db/migrations/11-update-deployment-names.ts
+++ b/packages/indexer-agent/src/db/migrations/11-update-deployment-names.ts
@@ -1,0 +1,120 @@
+import { Logger } from '@graphprotocol/common-ts'
+import {
+  formatDeploymentName,
+  indexerError,
+  IndexerErrorCode,
+  IndexingStatusResolver,
+  NetworkMonitor,
+  SubgraphDeploymentAssignment,
+} from '@graphprotocol/indexer-common'
+import { Client } from 'jayson/promise'
+import pMap from 'p-map'
+
+interface MigrationContext {
+  logger: Logger
+  indexingStatusResolver: IndexingStatusResolver
+  graphNodeAdminEndpoint: string
+  networkMonitor: NetworkMonitor
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+interface SubgraphRedeployment {
+  newName: string
+  ipfsHash: string
+  nodeId: string
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { logger, networkMonitor: networkMonitor } = context
+
+  const clientConstructor = context.graphNodeAdminEndpoint.startsWith('https')
+    ? Client.https
+    : Client.http
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rpc = clientConstructor(context.graphNodeAdminEndpoint as any)
+
+  // Fetch active deployments.
+  const subgraphDeploymentAssignments =
+    await context.indexingStatusResolver.subgraphDeploymentsAssignments()
+
+  // Maps assignments to redeployments
+  const mapper = async (assignment: SubgraphDeploymentAssignment) =>
+    await processAssignment(assignment, networkMonitor, logger)
+
+  // Produces the Redeployments.
+  const subgraphRedeployments: SubgraphRedeployment[] = (
+    await pMap(subgraphDeploymentAssignments, mapper)
+  ).filter((item): item is SubgraphRedeployment => Boolean(item))
+
+  // Execute Redeployments over Graph-Node's RPC endpoint
+  await pMap(subgraphRedeployments, async subgraphRedeployment =>
+    redeploy(rpc, subgraphRedeployment, logger),
+  )
+}
+
+export async function down(): Promise<void> {
+  // Nothing to do here. The old subgraph names should still exist in Graph Node's database.
+}
+
+// Performs redeployment in Graph-Node
+async function redeploy(
+  client: Client,
+  subgraphRedeployment: SubgraphRedeployment,
+  logger: Logger,
+): Promise<void> {
+  logger = logger.child({
+    ...subgraphRedeployment,
+  })
+  try {
+    logger.info(`Redeploying subgraph with adjusted name`)
+    logger.debug(`Sending subgraph_create request`)
+    const create_response = await client.request('subgraph_create', {
+      name: subgraphRedeployment.newName,
+    })
+    if (create_response.error) {
+      throw create_response.error
+    }
+    logger.debug(`Sending subgraph_deploy request`)
+    const deploy_response = await client.request('subgraph_deploy', {
+      name: subgraphRedeployment.newName,
+      ipfs_hash: subgraphRedeployment.ipfsHash,
+      node_id: subgraphRedeployment.nodeId,
+    })
+    if (deploy_response.error) {
+      throw deploy_response.error
+    }
+    logger.info(`Successfully redeployed subgraph with a fixed name`)
+  } catch (error) {
+    const err = indexerError(IndexerErrorCode.IE026, error)
+    logger.error(`Failed to redeploy subgraph with a fixed name`, { err })
+    throw err
+  }
+}
+
+// Tentatively converts a `SubgraphDeploymentAssignment` into a `SubgraphRedeployment`
+async function processAssignment(
+  assignment: SubgraphDeploymentAssignment,
+  networkMonitor: NetworkMonitor,
+  logger: Logger,
+): Promise<SubgraphRedeployment | undefined> {
+  logger.debug(
+    `Querying the Network Subgraph for more details on subgraph deployment ${assignment.id}`,
+  )
+  const deployment = await networkMonitor.subgraphDeployment(
+    assignment.id.ipfsHash,
+  )
+  if (!deployment) {
+    logger.info(
+      `Subgraph deployment ${assignment.id} was not found in Network Subgraph. Skipping its redeployment`,
+    )
+    return undefined
+  }
+  return {
+    newName: formatDeploymentName(deployment),
+    ipfsHash: assignment.id.ipfsHash,
+    nodeId: assignment.node,
+  }
+}

--- a/packages/indexer-agent/src/indexer.ts
+++ b/packages/indexer-agent/src/indexer.ts
@@ -131,36 +131,7 @@ export class Indexer {
   }
 
   async subgraphDeployments(): Promise<SubgraphDeploymentID[]> {
-    try {
-      const result = await this.statusResolver.statuses
-        .query(
-          gql`
-            {
-              indexingStatuses {
-                subgraphDeployment: subgraph
-                node
-              }
-            }
-          `,
-        )
-        .toPromise()
-
-      if (result.error) {
-        throw result.error
-      }
-
-      return result.data.indexingStatuses
-        .filter((status: { subgraphDeployment: string; node: string }) => {
-          return status.node && status.node !== 'removed'
-        })
-        .map((status: { subgraphDeployment: string; node: string }) => {
-          return new SubgraphDeploymentID(status.subgraphDeployment)
-        })
-    } catch (error) {
-      const err = indexerError(IndexerErrorCode.IE018, error)
-      this.logger.error(`Failed to query indexing status API`, { err })
-      throw err
-    }
+    return await this.statusResolver.subgraphDeployments()
   }
 
   async indexNodes(): Promise<indexNode[]> {

--- a/packages/indexer-common/src/__tests__/subgraphs.ts
+++ b/packages/indexer-common/src/__tests__/subgraphs.ts
@@ -1,0 +1,88 @@
+import { formatDeploymentName, cleanDeploymentName } from '../types'
+import { BigNumber } from 'ethers'
+import { SubgraphDeploymentID, toAddress } from '@graphprotocol/common-ts'
+
+describe('formatDeploymentName function tests', () => {
+  const creatorAddress = toAddress('0x6d2e03b7EfFEae98BD302A9F836D0d6Ab0002766')
+  const name = 'testSubgraphName'
+  const ipfsHash = 'Qmadj8x9km1YEyKmRnJ6EkC2zpJZFCfTyTZpuqC3j6e1QH'
+  const base = {
+    id: new SubgraphDeploymentID(ipfsHash),
+    deniedAt: 0,
+    stakedTokenns: BigNumber.from(0),
+    signalledTokens: BigNumber.from(0),
+    queryFeesAmount: BigNumber.from(0),
+    stakedTokens: BigNumber.from(0),
+    activeAllocations: 0,
+  }
+
+  test('formatDeploymentName can handle existing subgraph and owner information', async () => {
+    const nameAndOwner = {
+      name,
+      creatorAddress,
+      ...base,
+    }
+    expect(formatDeploymentName(nameAndOwner)).toBe(
+      `${name}/${ipfsHash}/${creatorAddress}`,
+    )
+  })
+
+  test('formatDeploymentName can handle missing owner name', async () => {
+    const noOwner = {
+      name,
+      ...base,
+    }
+    expect(formatDeploymentName(noOwner)).toBe(`${name}/${ipfsHash}/unknownCreator`)
+  })
+
+  test('formatDeploymentName can handle missing subgraph name', async () => {
+    const noName = {
+      creatorAddress,
+      ...base,
+    }
+    expect(formatDeploymentName(noName)).toBe(
+      `unknownSubgraph/${ipfsHash}/${creatorAddress}`,
+    )
+  })
+
+  test('formatDeploymentName can handle missing subgraph and owner names', async () => {
+    expect(formatDeploymentName(base)).toBe(`unknownSubgraph/${ipfsHash}/unknownCreator`)
+  })
+})
+
+describe('cleanDeploymentName function tests', () => {
+  test('can handle null input', () => {
+    expect(cleanDeploymentName(undefined)).toBe('unknownSubgraph')
+  })
+  test('can remove invalid characters', () => {
+    expect(cleanDeploymentName('abc!@"#$%^&*()-def_123')).toBe('abc-def_123')
+  })
+  test('can strip invalid charecters from start', () => {
+    expect(cleanDeploymentName('_abc')).toBe('abc')
+    expect(cleanDeploymentName('-abc')).toBe('abc')
+  })
+  test('can strip invalid charecters from the end', () => {
+    expect(cleanDeploymentName('abc_')).toBe('abc')
+    expect(cleanDeploymentName('abc-')).toBe('abc')
+  })
+  test('can strip invalid charecters from both ends', () => {
+    expect(cleanDeploymentName('_abc_')).toBe('abc')
+    expect(cleanDeploymentName('-abc-')).toBe('abc')
+  })
+  test('can clean empty strings', () => {
+    expect(cleanDeploymentName('')).toBe('unknownSubgraph')
+    expect(cleanDeploymentName('--')).toBe('unknownSubgraph')
+    expect(cleanDeploymentName('_')).toBe('unknownSubgraph')
+  })
+  test('can clean the special name "graphql"', () => {
+    expect(cleanDeploymentName('graphql')).toBe('graphql-subgraph')
+    expect(cleanDeploymentName('-graphql-')).toBe('graphql-subgraph')
+    expect(cleanDeploymentName('_graphql')).toBe('graphql-subgraph')
+    expect(cleanDeploymentName('graphql_')).toBe('graphql-subgraph')
+  })
+  test('can chop the subgraph name to the adequate size', () => {
+    const reallyLongName = // 200 chars
+      'y2feiw6y0eihrau5m5my0g0wvg6e2qbf79k91wzhcoep40hrend3re36jaejomss0goyaxx6yph5rrwieg3gkrvys699riza6kfak1tx9uy46onxt4fs3tp95e05v3xcf0jdldsz5ukqozsefo53wxl2m5rh5cdx8dkxq1fktr'
+    expect(cleanDeploymentName(reallyLongName)).toHaveLength(165)
+  })
+})

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -16,6 +16,7 @@ import {
   CloseAllocationResult,
   CreateAllocationResult,
   fetchIndexingRules,
+  formatDeploymentName,
   indexerError,
   IndexerError,
   IndexerErrorCode,
@@ -330,11 +331,15 @@ export class AllocationManager {
       )
     }
 
+    const subgraphDeployment = await this.networkMonitor.requireSubgraphDeployment(
+      deployment.ipfsHash,
+    )
+
     // Ensure subgraph is deployed before allocating
     await this.subgraphManager.ensure(
       logger,
       this.models,
-      `indexer-agent/${deployment.ipfsHash.slice(-10)}`,
+      formatDeploymentName(subgraphDeployment),
       deployment,
       indexNode,
     )

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -440,6 +440,12 @@ export class NetworkMonitor {
                   id
                 }
               }
+              versions(first: 1, orderBy: version, orderDirection: desc) {
+                subgraph {
+                  displayName
+                  creatorAddress
+                }
+              }
             }
           }
         `,
@@ -477,6 +483,18 @@ export class NetworkMonitor {
     }
   }
 
+  // Wrapper function over this.subgraphDeployment that will throw an
+  // error on missing subgraph deployments
+  async requireSubgraphDeployment(ipfsHash: string): Promise<SubgraphDeployment> {
+    const subgraphDeployment = await this.subgraphDeployment(ipfsHash)
+    if (!subgraphDeployment) {
+      const errorMessage = `Failed to locate subgraph deployment with id ${ipfsHash} in the Network Subgraph`
+      this.logger.error(errorMessage, { ipfsHash })
+      throw indexerError(IndexerErrorCode.IE020, errorMessage)
+    }
+    return subgraphDeployment
+  }
+
   async subgraphDeployments(): Promise<SubgraphDeployment[]> {
     const deployments = []
     const queryProgress = {
@@ -511,6 +529,12 @@ export class NetworkMonitor {
                 indexerAllocations {
                   indexer {
                     id
+                  }
+                }
+                versions(first: 1, orderBy: version, orderDirection: desc) {
+                  subgraph {
+                    displayName
+                    creatorAddress
                   }
                 }
               }

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -59,6 +59,8 @@ export const parseGraphQLSubgraphDeployment = (
   signalledTokens: BigNumber.from(subgraphDeployment.signalledTokens),
   queryFeesAmount: BigNumber.from(subgraphDeployment.queryFeesAmount),
   activeAllocations: subgraphDeployment.indexerAllocations.length,
+  name: subgraphDeployment.versions[0].subgraph.displayName,
+  creatorAddress: toAddress(subgraphDeployment.versions[0].subgraph.creatorAddress),
 })
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -1,4 +1,4 @@
-import { SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { Address, SubgraphDeploymentID } from '@graphprotocol/common-ts'
 import { BigNumber, providers } from 'ethers'
 
 export enum AllocationManagementMode {
@@ -59,6 +59,57 @@ export interface SubgraphDeployment {
   signalledTokens: BigNumber
   queryFeesAmount: BigNumber
   activeAllocations: number
+  name?: string
+  creatorAddress?: Address
+}
+
+export function formatDeploymentName(subgraphDeployment: SubgraphDeployment): string {
+  const creatorAddress = subgraphDeployment.creatorAddress || 'unknownCreator'
+  const cleanedName = cleanDeploymentName(subgraphDeployment.name)
+  return `${cleanedName}/${subgraphDeployment.id.ipfsHash}/${creatorAddress}`
+}
+
+export function cleanDeploymentName(subgraphName: undefined | string): string {
+  const unknownSubgraph = 'unknownSubgraph'
+
+  if (!subgraphName) {
+    return unknownSubgraph
+  }
+
+  /* Strip everything out of the string except for ASCII alphanumeric characters, dashes and
+   underscores.
+
+   We must also limit the name size, as Graph Node enforces a maximum deployment name lenght of 255
+   characters. Considering the other parts of the deployment name have fixed sizes (see table
+   below), we must limit the subgraph name to 165 characters.
+
+   ------------------+-----
+    Subgraph Name    | 165  <--- Size Limit
+    Slash            |   1
+    IPFS Qm-Hash     |  46
+    Slash            |   1
+    Owner Address    |  42
+   ------------------+-----
+    Total Characters | 255
+   ------------------+----- */
+  let cleaned = subgraphName.replace(/[^\w\d_-]+/g, '').slice(0, 165)
+
+  // 1. Should not start or end with a special character.
+  const first = cleaned.match(/^[-_]/) ? 1 : undefined
+  const last = cleaned.slice(-1).match(/[-_]$/) ? cleaned.length - 1 : undefined
+  cleaned = cleaned.slice(first, last)
+
+  // 2. Must be non-empty.
+  if (cleaned === '') {
+    return unknownSubgraph
+  }
+
+  // 3. To keep URLs unambiguous, reserve the token "graphql".
+  if (cleaned == 'graphql') {
+    return 'graphql-subgraph'
+  }
+
+  return cleaned
 }
 
 export enum TransactionType {


### PR DESCRIPTION
When defining a deployment name, queries the Network Subgraph for the subgraph and owner names and creates a string in the form: `{subgraph}/{owner}/{ipfsHash}`.

Includes a migration that will redeploy all active subgraphs with the new name.

Fixes #574 