### PR TITLE
common, docs: fix ActionInput schema

### DIFF
--- a/docs/action-queue.md
+++ b/docs/action-queue.md
@@ -130,8 +130,8 @@ input ActionInput {
     poi: String
     force: Boolean
     source: String!
-    reason: String
-    priority: Int
+    reason: String!
+    priority: Int!
 }
 
 input ActionUpdateInput {

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -655,24 +655,24 @@ describe('Actions', () => {
   })
 
   test('Reject empty action input', async () => {
+    const expectedFieldNamesAndTypes: [string, string][] = [
+      ['status', 'ActionStatus'],
+      ['type', 'ActionType'],
+      ['source', 'String'],
+      ['reason', 'String'],
+      ['priority', 'Int'],
+    ]
+    const graphQLErrors = expectedFieldNamesAndTypes.map(
+      ([fieldName, fieldType]) =>
+        new GraphQLError(
+          `Variable "$actions" got invalid value {} at "actions[0]"; Field "${fieldName}" of required type "${fieldType}!" was not provided.`,
+        ),
+    )
+    const expected = new CombinedError({ graphQLErrors })
+
     await expect(
       client.mutation(QUEUE_ACTIONS_MUTATION, { actions: [{}] }).toPromise(),
-    ).resolves.toHaveProperty(
-      'error',
-      new CombinedError({
-        graphQLErrors: [
-          new GraphQLError(
-            'Variable "$actions" got invalid value {} at "actions[0]"; Field "status" of required type "ActionStatus!" was not provided.',
-          ),
-          new GraphQLError(
-            'Variable "$actions" got invalid value {} at "actions[0]"; Field "type" of required type "ActionType!" was not provided.',
-          ),
-          new GraphQLError(
-            'Variable "$actions" got invalid value {} at "actions[0]"; Field "source" of required type "String!" was not provided.',
-          ),
-        ],
-      }),
-    )
+    ).resolves.toHaveProperty('error', expected)
   })
 
   test('Reject action with invalid params for action type', async () => {

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -167,8 +167,8 @@ const SCHEMA_SDL = gql`
     poi: String
     force: Boolean
     source: String!
-    reason: String
-    priority: Int
+    reason: String!
+    priority: Int!
   }
 
   input ActionUpdateInput {


### PR DESCRIPTION
Marks `reason` and `priority` fields as mandatory.

Fixes #617.