### PR TITLE
Introduce a configurable JSON RPC provider for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,4 @@ jobs:
           POSTGRES_TEST_USERNAME: testuser
           POSTGRES_TEST_PASSWORD: testpass
           NODE_OPTIONS: '--dns-result-order=ipv4first'
+          INDEXER_TEST_JRPC_PROVIDER_URL: ${{ secrets.TESTS_RPC_PROVIDER }}

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.ts
@@ -30,6 +30,7 @@ import {
   resolveChainAlias,
   resolveChainId,
   SubgraphDeployment,
+  getTestProvider,
 } from '@graphprotocol/indexer-common'
 import { BigNumber, ethers, utils } from 'ethers'
 
@@ -66,7 +67,7 @@ const setupMonitor = async () => {
     async: false,
     level: __LOG_LEVEL__ ?? 'error',
   })
-  ethereum = ethers.getDefaultProvider('goerli')
+  ethereum = getTestProvider('goerli')
   contracts = await connectContracts(ethereum, 5)
   networkSubgraph = await NetworkSubgraph.create({
     logger,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -43,6 +43,7 @@ import {
   resolveChainId,
   AllocationManager,
   SubgraphManager,
+  getTestProvider,
 } from '@graphprotocol/indexer-common'
 import { CombinedError } from '@urql/core'
 import { GraphQLError } from 'graphql'
@@ -283,7 +284,7 @@ const setup = async () => {
   queryFeeModels = defineQueryFeeModels(sequelize)
   managementModels = defineIndexerManagementModels(sequelize)
   sequelize = await sequelize.sync({ force: true })
-  ethereum = ethers.getDefaultProvider('goerli')
+  ethereum = getTestProvider('goerli')
   wallet = Wallet.createRandom()
   contracts = await connectContracts(ethereum, 5)
   logger = createLogger({

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
@@ -18,7 +18,11 @@ import {
 import { defineIndexerManagementModels, IndexerManagementModels } from '../../models'
 import { CombinedError } from '@urql/core'
 import { GraphQLError } from 'graphql'
-import { IndexingStatusResolver, NetworkSubgraph } from '@graphprotocol/indexer-common'
+import {
+  IndexingStatusResolver,
+  NetworkSubgraph,
+  getTestProvider,
+} from '@graphprotocol/indexer-common'
 
 // Make global Jest variable available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -98,7 +102,7 @@ const setupAll = async () => {
   sequelize = await connectDatabase(__DATABASE__)
   models = defineIndexerManagementModels(sequelize)
   address = '0xtest'
-  contracts = await connectContracts(ethers.getDefaultProvider('goerli'), 5)
+  contracts = await connectContracts(getTestProvider('goerli'), 5)
   sequelize = await sequelize.sync({ force: true })
   logger = createLogger({
     name: 'Indexer API Client',

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
@@ -25,6 +25,7 @@ import {
   IndexingStatusResolver,
   NetworkSubgraph,
   SubgraphIdentifierType,
+  getTestProvider,
 } from '@graphprotocol/indexer-common'
 
 // Make global Jest variable available
@@ -134,7 +135,7 @@ const setupAll = async () => {
   sequelize = await connectDatabase(__DATABASE__)
   models = defineIndexerManagementModels(sequelize)
   address = '0xtest'
-  contracts = await connectContracts(ethers.getDefaultProvider('goerli'), 5)
+  contracts = await connectContracts(getTestProvider('goerli'), 5)
   await sequelize.sync({ force: true })
   logger = createLogger({
     name: 'Indexer API Client',

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
@@ -20,7 +20,11 @@ import {
   IndexerManagementModels,
   POIDisputeAttributes,
 } from '../../models'
-import { IndexingStatusResolver, NetworkSubgraph } from '@graphprotocol/indexer-common'
+import {
+  IndexingStatusResolver,
+  NetworkSubgraph,
+  getTestProvider,
+} from '@graphprotocol/indexer-common'
 
 // Make global Jest variable available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -192,7 +196,7 @@ const setupAll = async () => {
   sequelize = await connectDatabase(__DATABASE__)
   models = defineIndexerManagementModels(sequelize)
   address = '0xtest'
-  contracts = await connectContracts(ethers.getDefaultProvider('goerli'), 5)
+  contracts = await connectContracts(getTestProvider('goerli'), 5)
   await sequelize.sync({ force: true })
   logger = createLogger({
     name: 'POI dispute tests',

--- a/packages/indexer-common/src/utils.ts
+++ b/packages/indexer-common/src/utils.ts
@@ -1,3 +1,9 @@
+import {
+  BaseProvider,
+  JsonRpcProvider,
+  getDefaultProvider,
+} from '@ethersproject/providers'
+
 export const parseBoolean = (
   val: string | boolean | number | undefined | null,
 ): boolean => {
@@ -7,4 +13,13 @@ export const parseBoolean = (
 
 export function nullPassThrough<T, U>(fn: (x: T) => U): (x: T | null) => U | null {
   return (x: T | null) => (x === null ? null : fn(x))
+}
+
+export function getTestProvider(network: string): BaseProvider {
+  const testJsonRpcProviderUrl = process.env.INDEXER_TEST_JRPC_PROVIDER_URL
+  if (testJsonRpcProviderUrl) {
+    return new JsonRpcProvider(testJsonRpcProviderUrl)
+  } else {
+    return getDefaultProvider(network)
+  }
 }

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -31,6 +31,7 @@ import {
   IndexingStatusResolver,
   NetworkSubgraph,
   QueryFeeModels,
+  getTestProvider,
 } from '@graphprotocol/indexer-common'
 
 // Make global Jest variable available
@@ -60,7 +61,7 @@ const setup = async () => {
   queryFeeModels = defineQueryFeeModels(sequelize)
   models = defineIndexerManagementModels(sequelize)
   address = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
-  contracts = await connectContracts(ethers.getDefaultProvider('goerli'), 5)
+  contracts = await connectContracts(getTestProvider('goerli'), 5)
   await sequelize.sync({ force: true })
   const statusEndpoint = 'http://localhost:8030/graphql'
   indexingStatusResolver = new IndexingStatusResolver({


### PR DESCRIPTION
Resolves #626 

TODO:
- [x] Create GH Secret with our test RPC provider URL
- [x] Update our [CI script](https://github.com/graphprotocol/indexer/blob/6a9e7efa87a4523b8c42faa3d381c0a06aa71788/.github/workflows/ci.yml) to use that secret.