### PR TITLE
Validate Network Subgraph `chainId`

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -556,7 +556,7 @@ export default {
     const epochSubgraph = await EpochSubgraph.create(argv.epochSubgraphEndpoint)
 
     const networkMonitor = new NetworkMonitor(
-      await resolveChainId(networkMeta.chainId),
+      resolveChainId(networkMeta.chainId),
       contracts,
       toAddress(indexerAddress),
       logger.child({ component: 'NetworkMonitor' }),
@@ -795,8 +795,8 @@ async function validateNetworkId(
     throw new Error(errorMsg)
   }
 
-  const providerChainId = await resolveChainId(providerNetwork.chainId)
-  const networkSubgraphChainId = await resolveChainId(subgraphNetworkChainName)
+  const providerChainId = resolveChainId(providerNetwork.chainId)
+  const networkSubgraphChainId = resolveChainId(subgraphNetworkChainName)
   if (providerChainId !== networkSubgraphChainId) {
     const errorMsg =
       'The configured provider and the Network Subgraph have different CAIP-2 chain IDs. ' +

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -613,7 +613,6 @@ export default {
         err: indexerError(IndexerErrorCode.IE001, err),
       })
       process.exit(1)
-      return
     }
     logger.info(`Successfully ran database migrations`)
 

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -83,6 +83,7 @@ export enum IndexerErrorCode {
   IE070 = 'IE070',
   IE071 = 'IE071',
   IE072 = 'IE072',
+  IE073 = 'IE073',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -159,6 +160,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE070: 'Failed to query latest valid epoch and block hash',
   IE071: 'Add Epoch subgraph support for non-protocol chains',
   IE072: 'Failed to execute batch tx (contract: staking)',
+  IE073: 'Failed to query subgraph features from indexing statuses endpoint',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.ts
@@ -82,7 +82,7 @@ const setupMonitor = async () => {
     statusEndpoint,
   })
   networkMonitor = new NetworkMonitor(
-    await resolveChainId('goerli'),
+    resolveChainId('goerli'),
     contracts,
     toAddress('0xc61127cdfb5380df4214b0200b9a07c7c49d34f9'),
     logger,
@@ -243,27 +243,27 @@ describe('Actions', () => {
   })
 })
 describe('Types', () => {
-  test('Fail to resolve chain id', async () => {
-    await expect(resolveChainId('arbitrum')).rejects.toThrow(
+  test('Fail to resolve chain id', () => {
+    expect(() => resolveChainId('arbitrum')).toThrow(
       'Failed to resolve CAIP2 ID from the provided network alias: arbitrum',
     )
   })
 
-  test('Resolve chain id: `mainnet`', async () => {
-    await expect(resolveChainId('mainnet')).resolves.toBe('eip155:1')
+  test('Resolve chain id: `mainnet`', () => {
+    expect(resolveChainId('mainnet')).toBe('eip155:1')
   })
 
-  test('Resolve chain id: `5`', async () => {
-    await expect(resolveChainId('5')).resolves.toBe('eip155:5')
+  test('Resolve chain id: `5`', () => {
+    expect(resolveChainId('5')).toBe('eip155:5')
   })
 
-  test('Resolve chain alias: `eip155:1`', async () => {
-    await expect(resolveChainAlias('eip155:1')).resolves.toBe('mainnet')
+  test('Resolve chain alias: `eip155:1`', () => {
+    expect(resolveChainAlias('eip155:1')).toBe('mainnet')
   })
 
-  test('Fail to Resolve chain alias: `eip155:666`', async () => {
-    await expect(resolveChainAlias('eip155:666')).rejects.toThrow(
-      "Failed to match chain id, 'eip155:666', to a network alias",
+  test('Fail to Resolve chain alias: `eip155:666`', () => {
+    expect(() => resolveChainAlias('eip155:666')).toThrow(
+      "Failed to match chain id, 'eip155:666', to a network alias in Caip2ByChainAlias",
     )
   })
 })
@@ -275,7 +275,7 @@ describe.skip('Monitor', () => {
 
   test('Fetch currentEpoch for `goerli`', async () => {
     await expect(
-      networkMonitor.currentEpoch(await resolveChainId('goerli')),
+      networkMonitor.currentEpoch(resolveChainId('goerli')),
     ).resolves.toHaveProperty('networkID', 'eip155:5')
   }, 10000)
 

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -331,7 +331,7 @@ const setup = async () => {
   })
 
   networkMonitor = new NetworkMonitor(
-    await resolveChainId('goerli'),
+    resolveChainId('goerli'),
     contracts,
     toAddress('0xc61127cdfb5380df4214b0200b9a07c7c49d34f9'),
     logger,

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -588,7 +588,7 @@ export class NetworkMonitor {
   }
 
   async currentEpoch(networkID: string): Promise<NetworkEpoch> {
-    const networkAlias = await resolveChainAlias(networkID)
+    const networkAlias = resolveChainAlias(networkID)
 
     const queryEpochSubgraph = async () => {
       // We know it is non-null because of the check above for a null case that will end execution of fn if true
@@ -758,7 +758,7 @@ Please submit an issue at https://github.com/graphprotocol/block-oracle/issues/n
         )
       }
       const deploymentNetworkAlias = deploymentIndexingStatuses[0].chains[0].network
-      const deploymentNetworkCAIPID = await resolveChainId(deploymentNetworkAlias)
+      const deploymentNetworkCAIPID = resolveChainId(deploymentNetworkAlias)
       const currentEpoch = await this.currentEpoch(deploymentNetworkCAIPID)
 
       this.logger.trace(`Fetched block pointer to use in resolving POI`, {

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -184,7 +184,7 @@ const Caip2ByChainId: { [key: number]: string } = {
 
 /// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)
 /// or chain ids (numbers).
-export async function resolveChainId(key: number | string): Promise<string> {
+export function resolveChainId(key: number | string): string {
   if (typeof key === 'number' || !isNaN(+key)) {
     // If key is a number, then it must be a `chainId`
     const chainId = Caip2ByChainId[+key]
@@ -201,7 +201,7 @@ export async function resolveChainId(key: number | string): Promise<string> {
   throw new Error(`Failed to resolve CAIP2 ID from the provided network alias: ${key}`)
 }
 
-export async function resolveChainAlias(id: string): Promise<string> {
+export function resolveChainAlias(id: string): string {
   const aliasMatches = Object.keys(Caip2ByChainAlias).filter(
     (name) => Caip2ByChainAlias[name] == id,
   )


### PR DESCRIPTION
Resolves #555 

TODO:
- [x] validate `chainId` when the indexer syncs the Network Subgraph
- [ ] validate `chainId` when the indexer does not syncs the Network Subgraph