### PR TITLE
Flexible subgraph deployment name resolution

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -27,7 +27,7 @@ import {
   SubgraphIdentifierType,
   evaluateDeployments,
   AllocationDecision,
-  formatDeploymentName,
+  resolveSubgraphDeploymentName,
 } from '@graphprotocol/indexer-common'
 import { Indexer } from './indexer'
 import { AgentConfig } from './types'
@@ -689,13 +689,14 @@ class Agent {
     // Index all new deployments worth indexing
     await queue.addAll(
       deploy.map(deployment => async () => {
-        const subgraphDeployment =
-          await this.networkMonitor.requireSubgraphDeployment(
-            deployment.ipfsHash,
-          )
-        const name = formatDeploymentName(subgraphDeployment)
+        const name = await resolveSubgraphDeploymentName(
+          deployment,
+          this.networkMonitor,
+          this.logger,
+        )
         this.logger.info(`Index subgraph deployment`, {
           name,
+
           deployment: deployment.display,
         })
 

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -16,7 +16,7 @@ import {
   CloseAllocationResult,
   CreateAllocationResult,
   fetchIndexingRules,
-  formatDeploymentName,
+  resolveSubgraphDeploymentName,
   indexerError,
   IndexerError,
   IndexerErrorCode,
@@ -332,15 +332,17 @@ export class AllocationManager {
       )
     }
 
-    const subgraphDeployment = await this.networkMonitor.requireSubgraphDeployment(
-      deployment.ipfsHash,
+    const deploymentName = await resolveSubgraphDeploymentName(
+      deployment,
+      this.networkMonitor,
+      logger,
     )
 
     // Ensure subgraph is deployed before allocating
     await this.subgraphManager.ensure(
       logger,
       this.models,
-      formatDeploymentName(subgraphDeployment),
+      deploymentName,
       deployment,
       indexNode,
     )

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -1,7 +1,7 @@
 import {
   NetworkMonitor,
   epochElapsedBlocks,
-  formatDeploymentName,
+  resolveSubgraphDeploymentName,
 } from '@graphprotocol/indexer-common'
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/ban-types */
@@ -352,8 +352,8 @@ async function resolvePOI(
           }
           throw indexerError(
             IndexerErrorCode.IE068,
-            `User provided POI does not match reference fetched from the graph-node. Use '--force' to bypass this POI accuracy check. 
-            POI: ${poi}, 
+            `User provided POI does not match reference fetched from the graph-node. Use '--force' to bypass this POI accuracy check.
+            POI: ${poi},
             referencePOI: ${generatedPOI}`,
           )
       }
@@ -479,15 +479,17 @@ export default {
         )
       }
 
-      const subgraphDeployment = await networkMonitor.requireSubgraphDeployment(
-        subgraphDeploymentID.ipfsHash,
+      const deploymentName = await resolveSubgraphDeploymentName(
+        subgraphDeploymentID,
+        networkMonitor,
+        logger,
       )
 
       // Ensure subgraph is deployed before allocating
       await subgraphManager.ensure(
         logger,
         models,
-        formatDeploymentName(subgraphDeployment),
+        deploymentName,
         subgraphDeploymentID,
         indexNode,
       )

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -127,7 +127,7 @@ export async function resolveSubgraphDeploymentName(
   } catch (err) {
     logger.debug(
       `Failed to resolve subgraph deployment name for ${deploymentId.ipfsHash} because it was not found in the Network Subgraph. \
-      Using a simplifiled name.`,
+      Using a simplified name.`,
       err,
     )
     return `unknownSubgraph/${deploymentId.ipfsHash}/unknownCreator`

--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -1,5 +1,6 @@
-import { Address, SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { Address, Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
 import { BigNumber, providers } from 'ethers'
+import { NetworkMonitor } from './indexer-management'
 
 export enum AllocationManagementMode {
   AUTO = 'auto',
@@ -110,6 +111,27 @@ export function cleanDeploymentName(subgraphName: undefined | string): string {
   }
 
   return cleaned
+}
+
+// Helper function to handle deployment names for Subgraphs potentially not listed in the Network Subgraph.
+export async function resolveSubgraphDeploymentName(
+  deploymentId: SubgraphDeploymentID,
+  networkMonitor: NetworkMonitor,
+  logger: Logger,
+): Promise<string> {
+  try {
+    const subgraphDeployment = await networkMonitor.requireSubgraphDeployment(
+      deploymentId.ipfsHash,
+    )
+    return formatDeploymentName(subgraphDeployment)
+  } catch (err) {
+    logger.debug(
+      `Failed to resolve subgraph deployment name for ${deploymentId.ipfsHash} because it was not found in the Network Subgraph. \
+      Using a simplifiled name.`,
+      err,
+    )
+    return `unknownSubgraph/${deploymentId.ipfsHash}/unknownCreator`
+  }
 }
 
 export enum TransactionType {


### PR DESCRIPTION
PR #615 inadvertently caused the indexer Agent to only handle subgraphs registered in the Network Subgraph, as it can no longer name a subgraph deployment if it's not registered there.

This PR reintroduces a simpler naming scheme based only on the IPFS hash,  similar to the previous naming convention, to handle the case of such subgraphs.
