### PR TITLE
Fix: Throw errors on specific graphql error messages

### DIFF
--- a/packages/indexer-service/src/queries.ts
+++ b/packages/indexer-service/src/queries.ts
@@ -98,9 +98,10 @@ export class QueryProcessor implements QueryProcessorInterface {
   validateResponse(query: String, response: AxiosResponse, ipfsHash: String): void {
     // Check response for specific graphql errors
     const throwableErrors = [
-      'Failed to decode `block.hash` value: `no block with that hash found`',
+      'Failed to decode `block.hash` value:',
       'Store error: database unavailable',
-      'Store error: store error: Fulltext search is not yet deterministic'
+      'Store error: store error: Fulltext search is not yet deterministic',
+      'Failed to decode `block.number` value:'
     ]
 
     // Optimization: Parse only if the message is small enough, presume there are no critical errors otherwise
@@ -116,7 +117,10 @@ export class QueryProcessor implements QueryProcessorInterface {
         query,
       })
       for (const graphqlError of responseData.errors) {
-        if (throwableErrors.includes(graphqlError.message)) {
+        const isThrowableError = throwableErrors.some((errorString) =>
+            graphqlError.message.startsWith(errorString)
+        );
+        if (isThrowableError) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const error = Error(graphqlError.message) as any
           error.status = 500;


### PR DESCRIPTION
Indexer-service presently does not validate the responses from graph-node and forwards them directly to the gateways. The gateway will run its own validation and may find errors in the response and consider the query response incorrect. These conditions are not visible to indexer operator.

This PR logs at the WARN level graph-node responses that contain `errors` messages. If one of these messages contain one of the throwableErrors defined, a throw happens, which will ensure that the failed query will be logged at a higher level, and reported in the monitoring metrics.

To avoid putting too much strain on the CPU and affecting the performance, only small graphql responses are parsed and analyzed, assuming that larger responses indicate a successful query.

fixes #629