### PR TITLE
Update feature support matrix to include Fantom and Polygon

### DIFF
--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -103,7 +103,7 @@ upgrade window: 795
 | eip155:42220             | celo         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:43114             | avalanche    | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:250               | fantom       | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:137               | polygon      | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:137               | matic        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features** |              |             |              |                   |                      |                  |
 | ipfs.cat in mappings     |              | Yes         | Yes          | No                | No                   | No               |
 | ENS                      |              | Yes         | Yes          | No                | No                   | No               |

--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -86,25 +86,27 @@ valid from: 787
 upgrade window: 795
 ```
 
-| Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-|--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
-| **Core Features**        |         |             |              |                   |                      |                  |
-| Full-text Search         |         | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors         |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                 |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**    |         |             |              |                   |                      |                  |
-| eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
-| eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100               | gnosis  | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
-| cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
-| arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161             | arbitrum-one  | Yes   | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220             | celo    | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114             | avalanche | Yes       | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features** |         |             |              |                   |                      |                  |
-| ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
-| ENS                      |         | Yes         | Yes          | No                | No                   | No               |
-| File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
+| Subgraph Feature         | Aliases      | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
+|--------------------------|--------------|-------------|--------------|-------------------|----------------------|------------------|
+| **Core Features**        |              |             |              |                   |                      |                  |
+| Full-text Search         |              | Yes         | No           | No                | Yes                  | Yes              |
+| Non-Fatal Errors         |              | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Grafting                 |              | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Types**    |              |             |              |                   |                      |                  |
+| eip155:*                 | *            | Yes         | No           | No                | No                   | No               |
+| eip155:1                 | mainnet      | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100               | gnosis       | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| near:*                   | *            | Yes         | Yes          | No                | No                   | No               |
+| cosmos:*                 | *            | Yes         | Yes          | No                | No                   | No               |
+| arweave:*                | *            | Yes         | Yes          | No                | No                   | No               |
+| eip155:42161             | arbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:42220             | celo         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:43114             | avalanche    | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:250               | fantom       | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:137               | polygon      | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Features** |              |             |              |                   |                      |                  |
+| ipfs.cat in mappings     |              | Yes         | Yes          | No                | No                   | No               |
+| ENS                      |              | Yes         | Yes          | No                | No                   | No               |
+| File data sources: IPFS  |              | Yes         | Yes          | No                | Yes                  | Yes              |
 
 [Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4fa76f9ae541bf883e547407270866ffeb8448f3b3fca90bb9c5bc46e31499c2)


### PR DESCRIPTION
Proposing adding support for Fantom and Polygon to the feature support matrix. This PR will be included in the GGP (Graph Governance Proposal) to be created here https://snapshot.org/#/council.graphprotocol.eth.

This PR should be merged after Council approval. Afterward, the reference to the canonical GGP-ratified feature support matrix (end of the .md) will be updated.