### PR TITLE
Release `v0.31.0-rc.0` to testnet

### DIFF
--- a/docs/networks/testnet.md
+++ b/docs/networks/testnet.md
@@ -4,13 +4,13 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 
 ## Latest Releases
 
-| Component       | Release                                                                         |
-| --------------- | ------------------------------------------------------------------------------- |
-| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)       |
-| indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| graph-node      | [0.30.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0-rc.0)       |
+| Component       | Release                                                                              |
+| --------------- | ------------------------------------------------------------------------------------ |
+| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)            |
+| indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
 
 ## Network Parameters
 


### PR DESCRIPTION
Tag: https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0