### PR TITLE
update networks docs

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -2,8 +2,12 @@
 
 > This content has been moved
  
-[Mainnet configuration](./networks/mainnet.md)
+[Ethereum Mainnet configuration](./networks/ethereum-mainnet.md)
 
-[Testnet configuration](./networks/testnet.md)
+[Arbitrum One configuration](./networks/arbitrum-one.md)
+
+[Ethereum Goerli configuration](./networks/ethereum-goerli.md)
+
+[Arbitrum Goerli configuration](./networks/arbitrum-goerli.md)
 
 [Testnet setup instructions](./testnet-setup.md)

--- a/docs/networks/arbitrum-goerli.md
+++ b/docs/networks/arbitrum-goerli.md
@@ -47,7 +47,7 @@ testnet (for now) are Mainnet subgraphs. This means:
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                                         |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of testnet indexer infrastructure                                           |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                                      |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                            |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPrYRfx7XEk81GgjKe7uEmnBicPMxmBwCgVTWQW4t6hJZ`                                            |
 | `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum-goerli`       |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | TBD                                                                                         |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway-testnet-arbitrum.network.thegraph.com/collect-receipts`                    |
@@ -72,7 +72,7 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `goerli`                                                                                 |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                                      |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                                   |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                       |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPrYRfx7XEk81GgjKe7uEmnBicPMxmBwCgVTWQW4t6hJZ`                                         |
 | `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum-goerli`    |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xac01B0b3B2Dc5D8E0D484c02c4d077C15C96a7b4`                                             |
 

--- a/docs/networks/arbitrum-goerli.md
+++ b/docs/networks/arbitrum-goerli.md
@@ -1,0 +1,109 @@
+# Testnet Configuration
+
+The Graph Network's testnet is on Goerli. Goerli network information can be found at https://testnet.thegraph.com/explorer?chain=arbitrum-goerli.
+
+## Latest Releases
+
+| Component       | Release                                                                              |
+| --------------- | ------------------------------------------------------------------------------------ |
+| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)            |
+| indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
+| indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
+| indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
+| graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
+
+## Network Parameters
+
+| Parameter                   | Value             |
+| --------------------------- | ----------------- |
+| Epoch length                | ~ 2h (554 blocks) |
+| Maximum allocation lifetime | ~ 9h (4 epochs)   |
+
+## Contracts & accounts
+
+| Name               | Address                                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Graph Token (GRT ) | [`0x18C924BD5E8b83b47EFaDD632b7178E2Fd36073D`](https://goerli.arbiscan.io/address/0x18C924BD5E8b83b47EFaDD632b7178E2Fd36073D) |
+| Staking            | [`0xcd549d0C43d915aEB21d3a331dEaB9B7aF186D26`](https://goerli.arbiscan.io/address/0xcd549d0C43d915aEB21d3a331dEaB9B7aF186D26) |
+| Data Edge          | [``](https://goerli.arbiscan.io/address/) |
+| Block Oracle Owner | [``](https://goerli.arbiscan.io/address/) |
+
+Other network contracts can be found in [graphprotocol/contracts](https://github.com/graphprotocol/contracts/blob/dev/addresses.json#L971).
+
+## Configuration
+
+The Graph testnet contracts live on Goerli, but many of the subgraphs used in the
+testnet (for now) are Mainnet subgraphs. This means:
+
+- Indexer Agent and Indexer Service must connect to Goerli
+- Graph Node must connect to at least one Mainnet Ethereum node/provider
+
+### Indexer Agent
+
+| Environment Variable                        | CLI Argument                    | Value                                                                                       |
+| ------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------- |
+| `INDEXER_AGENT_ETHEREUM`                    | `--ethereum`                    | An Ethereum Goerli node/provider                                                            |
+| `INDEXER_AGENT_ETHEREUM_NETWORK`            | `--ethereum-network`            | `goerli`                                                                                    |
+| `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                                         |
+| `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of testnet indexer infrastructure                                           |
+| `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                                      |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                            |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum-goerli`       |
+| `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | TBD                                                                                         |
+| `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway-testnet-arbitrum.network.thegraph.com/collect-receipts`                    |
+| `INDEXER_AGENT_GAS_PRICE_MAX`               | `--gas-price-max`               | `50`                                                                                        |
+| `INDEXER_AGENT_EPOCH_SUBGRAPH_ENDPOINT`     | `--epoch-subgraph-endpoint`     | `https://api.thegraph.com/subgraphs/name/graphprotocol/arb-goerli-epoch-block-oracle`       |
+
+In order to avoid collecting or claiming query fees below a certain threshold
+(e.g. below the cost of the two transactions), the following configuration
+option can be used.
+
+| Environment Variable                         | CLI Argument                      | Value                                                                                     |
+| -------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `INDEXER_AGENT_REBATE_CLAIM_THRESHOLD`       | `--rebate-claim-threshold`        | Minimum rebate (in GRT) received for an allocation to claim (Default: 200)                |
+| `INDEXER_AGENT_REBATE_CLAIM_BATCH_THRESHOLD` | `--rebate-claim-batch-threshold`  | Minimum total rebates (in GRT) before a batched claim is processed (Default: 2000)        |
+| `INDEXER_AGENT_VOUCHER_EXPIRATION`           | `--voucher-expiration`            | Time (in seconds) to permanently delete vouchers with too few query fees  (Default: 2160) |
+
+### Indexer Service
+
+| Environment Variable                          | CLI Argument                    | Value                                                                                    |
+| --------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `INDEXER_SERVICE_ETHEREUM`                    | `--ethereum`                    | An Ethereum Goerli node/provider                                                         |
+| `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `goerli`                                                                                 |
+| `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                                      |
+| `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                                   |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                       |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum-goerli`    |
+| `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xac01B0b3B2Dc5D8E0D484c02c4d077C15C96a7b4`                                             |
+
+### Graph Node
+
+| Environment Variable | CLI Argument     | Value                               |
+| -------------------- | ---------------- | ----------------------------------- |
+| `ethereum`           | `--ethereum-rpc` | `mainnet:...`                       |
+| `ipfs`               | `--ipfs`         | `https://ipfs.network.thegraph.com` |
+
+## Feature support
+
+> This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
+
+| Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
+|--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
+| **Core Features**        |         |             |              |                   |                      |                  |
+| Full-text Search         |         | Yes         | No           | No                | Yes                  | Yes              |
+| Non-Fatal Errors         |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Grafting                 |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Types**    |         |             |              |                   |                      |                  |
+| eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
+| eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100               | gnosis  | Yes         | No           | Yes               | Yes                  | Yes              |
+| near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
+| cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
+| arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |
+| eip155:42161             | arbitrum-one  | Yes   | Yes          | Yes               | Yes                  | Yes              |
+| eip155:42220             | celo    | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:43114             | avalanche | Yes       | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Features** |         |             |              |                   |                      |                  |
+| ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
+| ENS                      |         | Yes         | Yes          | No                | No                   | No               |
+| File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |

--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -1,15 +1,15 @@
-# Mainnet Configuration
+# Arbitrum One Configuration
 
-Network information can be found at https://thegraph.com/explorer/network. The Graph Network mainnet is open for everyone to participate in as an indexer. The only requirement is a minimum stake of 100k GRT.
+Network information can be found at https://thegraph.com/explorer?chain=arbitrum-one. The Graph Network mainnet is open for everyone to participate in as an indexer. The only requirement is a minimum stake of 100k GRT.
 
 ## Latest Releases
 
 | Component       | Release                                                                    |
 | --------------- | -------------------------------------------------------------------------- |
 | contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
-| indexer-agent   | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| indexer-cli     | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
-| indexer-service | [0.18.6](https://github.com/graphprotocol/indexer/releases/tag/v0.18.6)    |
+| indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
+| indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
+| indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | graph-node      | [0.30.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0) |
 
 ## Network Parameters
@@ -23,29 +23,31 @@ Network information can be found at https://thegraph.com/explorer/network. The G
 
 | Name               | Address                                                                                                                 |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Graph Token (GRT)  | [`0xc944E90C64B2c07662A292be6244BDf05Cda44a7`](https://etherscan.io/address/0xc944e90c64b2c07662a292be6244bdf05cda44a7) |
-| Staking            | [`0xF55041E37E12cD407ad00CE2910B8269B01263b9`](https://etherscan.io/address/0xF55041E37E12cD407ad00CE2910B8269B01263b9) |
-| Data Edge          | [`0xADE906194C923b28F03F48BC5D9D987AAE21fFab`](https://etherscan.io/address/0xADE906194C923b28F03F48BC5D9D987AAE21fFab) |
-| Block Oracle Owner | [`0xeb4ad97a099defc85c900a60adfd2405c455b2c0`](https://etherscan.io/address/0xeb4ad97a099defc85c900a60adfd2405c455b2c0) |
+| Graph Token (GRT)  | [`0x9623063377AD1B27544C965cCd7342f7EA7e88C7`](https://arbiscan.io/address/0x9623063377AD1B27544C965cCd7342f7EA7e88C7) |
+| Staking            | [`0x00669A4CF01450B64E8A2A20E9b1FCB71E61eF03`](https://arbiscan.io/address/0x00669A4CF01450B64E8A2A20E9b1FCB71E61eF03) |
+| Data Edge          | [``](https://arbiscan.io/address/) |
+| Block Oracle Owner | [``](https://arbiscan.io/address/) |
 
-Other network contracts can be found in [graphprotocol/contracts](https://github.com/graphprotocol/contracts/blob/dev/addresses.json).
+Other network contracts can be found in [graphprotocol/contracts](https://github.com/graphprotocol/contracts/blob/dev/addresses.json#L752).
 
 ## Configuration
 
 ### Indexer Agent
 
-| Environment Variable                        | CLI Argument                    | Value                                                   |
-| ------------------------------------------- | ------------------------------- | ------------------------------------------------------- |
-| `INDEXER_AGENT_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                       |
-| `INDEXER_AGENT_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                               |
-| `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                     |
-| `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure       |
-| `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                  |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u`        |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`                  |
-| `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (USDC)     |
-| `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts` |
-| `INDEXER_AGENT_GAS_PRICE_MAX`               | `--gas-price-max`               | `50`                                                    |
+| Environment Variable                        | CLI Argument                    | Value                                                                               |
+| ------------------------------------------- | ------------------------------- | --------------------------------------------------------------------------------    |
+| `INDEXER_AGENT_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                                                   |
+| `INDEXER_AGENT_ETHEREUM_NETWORK`            | `--ethereum-network`            | `arbitrum`                                                                          |
+| `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                 |
+| `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure                                   |
+| `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                              |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                  |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum`      |
+| `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | TBD                                                                                 |
+| `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts`                             |
+| `INDEXER_AGENT_GAS_PRICE_MAX`               | `--gas-price-max`               | `50`                                                                                |
+| `INDEXER_AGENT_EPOCH_SUBGRAPH_ENDPOINT`     | `--epoch-subgraph-endpoint`     | `https://api.thegraph.com/subgraphs/name/graphprotocol/arbitrum-epoch-block-oracle` |
+
 
 In order to avoid collecting or claiming query fees below a certain threshold
 (e.g. below the cost of the two transactions), the following configuration
@@ -59,15 +61,15 @@ option can be used.
 
 ### Indexer Service
 
-| Environment Variable                          | CLI Argument                    | Value                                            |
-| --------------------------------------------- | ------------------------------- | ------------------------------------------------ |
-| `INDEXER_SERVICE_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                |
-| `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                        |
-| `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer              |
-| `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator           |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u` |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`           |
-| `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0x982D10c56b8BBbD6e09048F5c5f01b43C65D5aE0`     |
+| Environment Variable                          | CLI Argument                    | Value                                                                                    |
+| --------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `INDEXER_SERVICE_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                                                        |
+| `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `arbitrum`                                                                               |
+| `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                      |
+| `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                                   |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                       |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum`           |
+| `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xc483960d4D58eabc434Dc88a620AdFd883D6Dd4e`                                             |
 
 ### Graph Node
 

--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -41,7 +41,7 @@ Other network contracts can be found in [graphprotocol/contracts](https://github
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                 |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure                                   |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                              |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                  |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmTM95FDj31cw2E9vLtboVUiH31X3ddhkd7xgeVzqBRafA`                                    |
 | `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum`      |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | TBD                                                                                 |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts`                             |
@@ -67,7 +67,7 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `arbitrum`                                                                               |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                      |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                                   |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | ``                                                                                       |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmTM95FDj31cw2E9vLtboVUiH31X3ddhkd7xgeVzqBRafA`                                         |
 | `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum`           |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xc483960d4D58eabc434Dc88a620AdFd883D6Dd4e`                                             |
 

--- a/docs/networks/ethereum-goerli.md
+++ b/docs/networks/ethereum-goerli.md
@@ -1,15 +1,15 @@
 # Testnet Configuration
 
-The Graph Network's testnet is on Goerli. Goerli network information can be found at https://testnet.thegraph.com/explorer/network.
+The Graph Network's testnet is on Goerli. Goerli network information can be found at https://testnet.thegraph.com/explorer?chain=goerli.
 
 ## Latest Releases
 
 | Component       | Release                                                                              |
 | --------------- | ------------------------------------------------------------------------------------ |
 | contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)            |
-| indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
-| indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
-| indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
+| indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
+| indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
 | graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
 
 ## Network Parameters

--- a/docs/networks/ethereum-goerli.md
+++ b/docs/networks/ethereum-goerli.md
@@ -47,7 +47,7 @@ testnet (for now) are Mainnet subgraphs. This means:
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                               |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of testnet indexer infrastructure                                 |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                            |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                  |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmeoyAr2soK1xE32Pxh1ZNXoQq75ZJwHJ7nzms3MogJUvK`                                  |
 | `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli`      |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0x9e7e607afd22906f7da6f1ec8f432d6f244278be` (GDAI)                               |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.testnet.thegraph.com/collect-receipts`                           |
@@ -71,7 +71,7 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `goerli`                                                                        |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of testnet indexer                                             |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for testnet operator                                          |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmPVz18RFwK6hE5rZFWERk23LgrTBz2FCkZzgPSrFxFWN4`                                |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmeoyAr2soK1xE32Pxh1ZNXoQq75ZJwHJ7nzms3MogJUvK`                                |
 | `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli`    |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0xe1EC4339019eC9628438F8755f847e3023e4ff9c`                                    |
 

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -1,0 +1,111 @@
+# Mainnet Configuration
+
+Network information can be found at https://thegraph.com/explorer?chain=mainnet. The Graph Network mainnet is open for everyone to participate in as an indexer. The only requirement is a minimum stake of 100k GRT.
+
+## Latest Releases
+
+| Component       | Release                                                                    |
+| --------------- | -------------------------------------------------------------------------- |
+| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
+| indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
+| indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
+| indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
+| graph-node      | [0.30.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0) |
+
+## Network Parameters
+
+| Parameter                   | Value                 |
+| --------------------------- | --------------------  |
+| Epoch length                | ~ 24h (6646 blocks)   |
+| Maximum allocation lifetime | ~28 days (28 epochs)  |
+
+## Contracts & accounts
+
+| Name               | Address                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Graph Token (GRT)  | [`0xc944E90C64B2c07662A292be6244BDf05Cda44a7`](https://etherscan.io/address/0xc944e90c64b2c07662a292be6244bdf05cda44a7) |
+| Staking            | [`0xF55041E37E12cD407ad00CE2910B8269B01263b9`](https://etherscan.io/address/0xF55041E37E12cD407ad00CE2910B8269B01263b9) |
+| Data Edge          | [`0xADE906194C923b28F03F48BC5D9D987AAE21fFab`](https://etherscan.io/address/0xADE906194C923b28F03F48BC5D9D987AAE21fFab) |
+| Block Oracle Owner | [`0xeb4ad97a099defc85c900a60adfd2405c455b2c0`](https://etherscan.io/address/0xeb4ad97a099defc85c900a60adfd2405c455b2c0) |
+
+Other network contracts can be found in [graphprotocol/contracts](https://github.com/graphprotocol/contracts/blob/dev/addresses.json).
+
+## Configuration
+
+### Indexer Agent
+
+| Environment Variable                        | CLI Argument                    | Value                                                                              |
+| ------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------- |
+| `INDEXER_AGENT_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                                                  |
+| `INDEXER_AGENT_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                                                          |
+| `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                |
+| `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure                                  |
+| `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                             |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u`                                   |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`                                             |
+| `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (USDC)                                |
+| `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts`                            |
+| `INDEXER_AGENT_GAS_PRICE_MAX`               | `--gas-price-max`               | `50`                                                                               |
+| `INDEXER_AGENT_EPOCH_SUBGRAPH_ENDPOINT`     | `--epoch-subgraph-endpoint`     | `https://api.thegraph.com/subgraphs/name/graphprotocol/mainnet-epoch-block-oracle` |
+
+In order to avoid collecting or claiming query fees below a certain threshold
+(e.g. below the cost of the two transactions), the following configuration
+option can be used.
+
+| Environment Variable                         | CLI Argument                      | Value                                                                                     |
+| -------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `INDEXER_AGENT_REBATE_CLAIM_THRESHOLD`       | `--rebate-claim-threshold`        | Minimum rebate (in GRT) received for an allocation to claim (Default: 200)                |
+| `INDEXER_AGENT_REBATE_CLAIM_BATCH_THRESHOLD` | `--rebate-claim-batch-threshold`  | Minimum total rebates (in GRT) before a batched claim is processed (Default: 2000)        |
+| `INDEXER_AGENT_VOUCHER_EXPIRATION`           | `--voucher-expiration`            | Time (in seconds) to permanently delete vouchers with too few query fees  (Default: 2160) |            
+
+### Indexer Service
+
+| Environment Variable                          | CLI Argument                    | Value                                            |
+| --------------------------------------------- | ------------------------------- | ------------------------------------------------ |
+| `INDEXER_SERVICE_ETHEREUM`                    | `--ethereum`                    | An Ethereum mainnet node/provider                |
+| `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                        |
+| `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer              |
+| `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator           |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u` |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`           |
+| `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0x982D10c56b8BBbD6e09048F5c5f01b43C65D5aE0`     |
+
+### Graph Node
+
+| Environment Variable | CLI Argument     | Value                               |
+| -------------------- | ---------------- | ----------------------------------- |
+| `ethereum`           | `--ethereum-rpc` | `mainnet:<ethereum-json-rpc-url>`   |
+| `ipfs`               | `--ipfs`         | `https://ipfs.network.thegraph.com` |
+
+## Feature support
+
+> This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
+
+```
+graph-node: ≥0.30.0 <0.31.0
+valid from: 787
+upgrade window: 795
+```
+
+| Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
+|--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
+| **Core Features**        |         |             |              |                   |                      |                  |
+| Full-text Search         |         | Yes         | No           | No                | Yes                  | Yes              |
+| Non-Fatal Errors         |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Grafting                 |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Types**    |         |             |              |                   |                      |                  |
+| eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
+| eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100               | gnosis  | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
+| cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
+| arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |
+| eip155:42161             | arbitrum-one  | Yes   | Yes          | Yes               | Yes                  | Yes              |
+| eip155:42220             | celo    | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:43114             | avalanche | Yes       | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Features** |         |             |              |                   |                      |                  |
+| ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
+| ENS                      |         | Yes         | Yes          | No                | No                   | No               |
+| File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
+
+[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4fa76f9ae541bf883e547407270866ffeb8448f3b3fca90bb9c5bc46e31499c2)

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -41,7 +41,7 @@ Other network contracts can be found in [graphprotocol/contracts](https://github
 | `INDEXER_AGENT_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer                                                |
 | `INDEXER_AGENT_INDEXER_GEO_COORDINATES`     | `--indexer-geo-coordinates`     | Geo coordinates of mainnet indexer infrastructure                                  |
 | `INDEXER_AGENT_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator                                             |
-| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u`                                   |
+| `INDEXER_AGENT_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP`                                   |
 | `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`                                             |
 | `INDEXER_AGENT_DAI_CONTRACT`                | `--dai-contract`                | `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (USDC)                                |
 | `INDEXER_AGENT_COLLECT_RECEIPTS_ENDPOINT`   | `--collect-receipts-endpoint`   | `https://gateway.network.thegraph.com/collect-receipts`                            |
@@ -66,7 +66,7 @@ option can be used.
 | `INDEXER_SERVICE_ETHEREUM_NETWORK`            | `--ethereum-network`            | `mainnet`                                        |
 | `INDEXER_SERVICE_INDEXER_ADDRESS`             | `--indexer-address`             | Ethereum address of mainnet indexer              |
 | `INDEXER_SERVICE_MNEMONIC`                    | `--mnemonic`                    | Ethereum mnemonic for mainnet operator           |
-| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmV614UpBCpuusv5MsismmPYu4KqLtdeNMKpiNrX56kw6u` |
+| `INDEXER_SERVICE_NETWORK_SUBGRAPH_DEPLOYMENT` | `--network-subgraph-deployment` | `QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP` |
 | `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT`   | `--network-subgraph-endpoint`   | `https://gateway.thegraph.com/network`           |
 | `INDEXER_SERVICE_CLIENT_SIGNER_ADDRESS`       | `--client-signer-address`       | `0x982D10c56b8BBbD6e09048F5c5f01b43C65D5aE0`     |
 

--- a/docs/networks/testnet.md
+++ b/docs/networks/testnet.md
@@ -4,13 +4,13 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 
 ## Latest Releases
 
-| Component       | Release                                                                         |
-| --------------- | ------------------------------------------------------------------------------- |
-| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)       |
-| indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)       |
-| graph-node      | [0.30.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0-rc.0)       |
+| Component       | Release                                                                              |
+| --------------- | ------------------------------------------------------------------------------------ |
+| contracts       | [1.13.0](https://github.com/graphprotocol/contracts/releases/tag/v1.13.0)            |
+| indexer-agent   | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| indexer-cli     | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| indexer-service | [0.20.12](https://github.com/graphprotocol/indexer/releases/tag/v0.20.12)            |
+| graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
 
 ## Network Parameters
 


### PR DESCRIPTION
**What changed:**
- renamed mainnet.md -> ethereum-mainnet.md
- renamed testnet.md -> ethereum-goerli.md
- bumped indexer stack versions
- use hosted service urls for the network subgraphs

**What's been added:**
- added arbitrum-one.md
- added arbitrum-goerli.md

**What's missing:**
- arbitrum one and goerli network subgraph IPFS hash
- arbitrum one and goerli Data Edge and Block Oracle Owner contract addresses
- arbitrum one and goerli DAI contract address