### PR TITLE
Include `action` and `allocation` IDs on logs for IE053

### DIFF
--- a/packages/indexer-common/src/allocations/query-fees.ts
+++ b/packages/indexer-common/src/allocations/query-fees.ts
@@ -160,7 +160,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
     })
 
     try {
-      logger.debug(`Queue allocation receipts for collecting`)
+      logger.debug(`Queue allocation receipts for collecting`, { actionID, allocation })
 
       const now = new Date()
 
@@ -191,7 +191,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         receipts.length,
       )
       if (receipts.length <= 0) {
-        logger.debug(`No receipts to collect for allocation`)
+        logger.debug(`No receipts to collect for allocation`, { actionID, allocation })
         return false
       }
 
@@ -205,6 +205,8 @@ export class AllocationReceiptCollector implements ReceiptCollector {
       logger.info(`Successfully queued allocation receipts for collecting`, {
         receipts: receipts.length,
         timeout: new Date(timeout).toLocaleString(),
+        actionID,
+        allocation,
       })
       return true
     } catch (err) {
@@ -212,6 +214,8 @@ export class AllocationReceiptCollector implements ReceiptCollector {
       this.metrics.failedReceipts.inc({ allocation: allocation.id })
       this.logger.error(`Failed to queue allocation receipts for collecting`, {
         error,
+        actionID,
+        allocation,
       })
       throw error
     }


### PR DESCRIPTION
This PR adds a bit more context around [IE053](https://github.com/graphprotocol/indexer/blob/main/docs/errors.md#ie053) by including the action and the allocation IDs in the log message, so users can determine which action has failed.

The need for this PR arose from indexers needing clarification due to an action appearing to work despite this error being logged. Putting the `actionID` in the error context will ease investigations about such behavior, particularly in distinguishing between successful and failed actions, possibly indicating a retry.