### PR TITLE
indexer-common: Include entire action batch in stake feasibility calculation

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.ts
@@ -1073,10 +1073,10 @@ describe('Allocation Manager', () => {
 
   const actions = [queuedAllocateAction, unallocateAction, reallocateAction] as Action[]
 
-  test('resolveActionDelta() correctly calculates token balances for array of actions', async () => {
-    const mapper = (x: Action) => allocationManager.resolveActionDelta(x)
-    const balances = await Promise.all(actions.map(mapper))
-
+  test('stakeUsageSummary() correctly calculates token balances for array of actions', async () => {
+    const balances = await Promise.all(
+      actions.map((action) => allocationManager.stakeUsageSummary(action)),
+    )
     const allocate = balances[0]
     const unallocate = balances[1]
     const reallocate = balances[2]

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize'
 import gql from 'graphql-tag'
-import { ethers } from 'ethers'
 import {
   connectDatabase,
   connectContracts,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize'
 import gql from 'graphql-tag'
-import { ethers } from 'ethers'
 import {
   connectDatabase,
   connectContracts,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize'
 import gql from 'graphql-tag'
-import { ethers } from 'ethers'
 import {
   connectDatabase,
   connectContracts,

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -144,7 +144,7 @@ export class AllocationManager {
   ): Promise<AllocationResult[]> {
     return pMap(
       actions,
-      async (action) => {
+      async (action: Action) => {
         try {
           return await this.confirmActionExecution(receipt, action)
         } catch (error) {
@@ -215,9 +215,13 @@ export class AllocationManager {
   }
 
   async prepareTransactions(actions: Action[]): Promise<PopulateTransactionResult[]> {
-    return await pMap(actions, async (action) => await this.prepareTransaction(action), {
-      stopOnError: false,
-    })
+    return await pMap(
+      actions,
+      async (action: Action) => await this.prepareTransaction(action),
+      {
+        stopOnError: false,
+      },
+    )
   }
   async prepareTransaction(action: Action): Promise<PopulateTransactionResult> {
     const logger = this.logger.child({ action: action.id })


### PR DESCRIPTION
Remove individual action stake feasibility check in favor of the batch level check.

I've also included a few small type safety and formatting improvements suggested by my IDE.