### PR TITLE
Release Graph Node `v0.31.0` on mainnet

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -27,7 +27,7 @@ An example:
 | ENS                      |         | Yes         | Yes          | No                | No                   | No               |
 | File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
 
-The accepted `graph-node` version range is also specificied, with an "upgrade window" from the previous version.
+The accepted `graph-node` version range is also specificied, with an "upgrade window" from the previous version. Here's an example:
 
 ```
 graph-node: ≥0.30.0 <0.31.0

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -27,14 +27,11 @@ An example:
 | ENS                      |         | Yes         | Yes          | No                | No                   | No               |
 | File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
 
-The accepted `graph-node` version range is also specificied, with an "upgrade window" from the previous version. Here's an example:
+The accepted `graph-node` version range is also specificied; it always comprises of the latest available version and the one immediately preceding it. Here's an example of a version range which includes both 0.30.X and 0.31.X:
 
 ```
-graph-node: ≥0.30.0 <0.31.0
-valid from: 787
-upgrade window: 795
+graph-node: >=0.30 <0.32
 ```
-
 
 - Aliases can be used in subgraph manifest files to refer to specific networks.
 - Experimental features are generally not fully supported for indexing rewards and arbitration, and usage of experimental features will be considered during any arbitration that does occur.

--- a/docs/networks/arbitrum-goerli.md
+++ b/docs/networks/arbitrum-goerli.md
@@ -10,7 +10,7 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
-| graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
+| graph-node      | [0.31.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0)           |
 
 ## Network Parameters
 

--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -83,9 +83,7 @@ option can be used.
 > This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
 
 ```
-graph-node: ≥0.31.0 <0.32.0
-valid from: 891
-upgrade window: 914
+graph-node: >=0.30 <0.32
 ```
 
 | Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |

--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -4,13 +4,13 @@ Network information can be found at https://thegraph.com/explorer?chain=arbitrum
 
 ## Latest Releases
 
-| Component       | Release                                                                    |
-| --------------- | -------------------------------------------------------------------------- |
-| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
+| Component       | Release                                                                      |
+| --------------- | ---------------------------------------------------------------------------- |
+| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)    |
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
-| graph-node      | [0.30.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0) |
+| graph-node      | [0.31.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0)   |
 
 ## Network Parameters
 
@@ -83,9 +83,9 @@ option can be used.
 > This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
 
 ```
-graph-node: ≥0.30.0 <0.31.0
-valid from: 787
-upgrade window: 795
+graph-node: ≥0.31.0 <0.32.0
+valid from: 891
+upgrade window: 914
 ```
 
 | Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
@@ -109,4 +109,4 @@ upgrade window: 795
 | ENS                      |         | Yes         | Yes          | No                | No                   | No               |
 | File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
 
-[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4fa76f9ae541bf883e547407270866ffeb8448f3b3fca90bb9c5bc46e31499c2)
+[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x80c55bb8697d16fedb71ccdce40704f24e931cc28f289a029e0717f3b729e6a8)

--- a/docs/networks/ethereum-goerli.md
+++ b/docs/networks/ethereum-goerli.md
@@ -10,7 +10,7 @@ The Graph Network's testnet is on Goerli. Goerli network information can be foun
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)            |
-| graph-node      | [0.31.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0-rc.0) |
+| graph-node      | [0.31.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0)           |
 
 ## Network Parameters
 

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -4,13 +4,13 @@ Network information can be found at https://thegraph.com/explorer?chain=mainnet.
 
 ## Latest Releases
 
-| Component       | Release                                                                    |
-| --------------- | -------------------------------------------------------------------------- |
-| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)  |
+| Component       | Release                                                                      |
+| --------------- | ---------------------------------------------------------------------------- |
+| contracts       | [1.11.1](https://github.com/graphprotocol/contracts/releases/tag/v1.11.1)    |
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
-| graph-node      | [0.30.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.30.0) |
+| graph-node      | [0.31.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.31.0)   |
 
 ## Network Parameters
 
@@ -82,9 +82,9 @@ option can be used.
 > This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
 
 ```
-graph-node: ≥0.30.0 <0.31.0
-valid from: 787
-upgrade window: 795
+graph-node: ≥0.31.0 <0.32.0
+valid from: 891
+upgrade window: 914
 ```
 
 | Subgraph Feature         | Aliases      | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
@@ -110,4 +110,4 @@ upgrade window: 795
 | ENS                      |              | Yes         | Yes          | No                | No                   | No               |
 | File data sources: IPFS  |              | Yes         | Yes          | No                | Yes                  | Yes              |
 
-[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4fa76f9ae541bf883e547407270866ffeb8448f3b3fca90bb9c5bc46e31499c2)
+[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x80c55bb8697d16fedb71ccdce40704f24e931cc28f289a029e0717f3b729e6a8)

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -82,9 +82,7 @@ option can be used.
 > This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
 
 ```
-graph-node: ≥0.31.0 <0.32.0
-valid from: 891
-upgrade window: 914
+graph-node: >=0.30 <0.32
 ```
 
 | Subgraph Feature         | Aliases      | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |


### PR DESCRIPTION
Still a draft PR because we're waiting for GGP approval.

EDIT 2023-06-23: now ready for review.