### PR TITLE
update action statuses and indexing rules

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -618,6 +618,18 @@ export class AllocationManager {
       indexingRewards: rewardsAssigned,
     })
 
+    // Upsert a rule so the agent keeps the deployment synced but doesn't allocate to it
+    logger.debug(
+      `Updating indexing rules so indexer-agent keeps the deployment synced but doesn't reallocate to it`,
+    )
+    const offchainIndexingRule = {
+      identifier: subgraphDeploymentID.ipfsHash,
+      identifierType: SubgraphIdentifierType.DEPLOYMENT,
+      decisionBasis: IndexingDecisionBasis.OFFCHAIN,
+    } as Partial<IndexingRuleAttributes>
+
+    await upsertIndexingRule(logger, this.models, offchainIndexingRule)
+
     logger.info('Identifying receipts worth collecting', {
       allocation: closeAllocationEventLogs.allocationID,
     })
@@ -627,19 +639,6 @@ export class AllocationManager {
       actionID,
       allocation,
     )
-
-    // Upsert a rule so the agent keeps the deployment synced but doesn't allocate to it
-    logger.debug(
-      `Updating indexing rules so indexer-agent keeps the deployment synced but doesn't reallocate to it`,
-    )
-    const offchainIndexingRule = {
-      identifier: allocation.subgraphDeployment.id.ipfsHash,
-      protocolNetwork: this.network.specification.networkIdentifier,
-      identifierType: SubgraphIdentifierType.DEPLOYMENT,
-      decisionBasis: IndexingDecisionBasis.OFFCHAIN,
-    } as Partial<IndexingRuleAttributes>
-
-    await upsertIndexingRule(logger, this.models, offchainIndexingRule)
 
     return {
       actionID,


### PR DESCRIPTION
As reported in issue #575, we observed cases in which the agent allocate to a subgraph deployment right after unallocate actions. The two possible causes are
- allocation was closed successfully but failed to confirm due to IE053 when identifying the receipts, thus exited with error early without updating the indexing rules
  - moved update indexing rules to right after closing allocation, and before identifying receipts to collect. Regardless of the result for query fee collection, the indexing rules should be updated promptly
- transaction to update action statuses did not include all the approved actions, might be due to agent creating allocate actions too early from indexing rules
  - added an additional step to update actions not included, and added debug logging

