### PR TITLE
Updated feature support matrix to support indexing rewards for substreams 

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -1,38 +1,48 @@
 # Feature support matrix
 
-As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xbdd884654a393620a7e8665b4289201b7542c3ee62becfad133e951b0c408444), this defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration.
+As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xbdd884654a393620a7e8665b4289201b7542c3ee62becfad133e951b0c408444), the Feature support matrix defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration.
 
-Each deployment of The Graph Network has its own specific Feature support matrix, as features will be introduced to testnet & mainnet at different stages of the development and testing lifecycle.
+The matrix below reflects the canonical Council-ratified version. As outlined in GIP-00008, Council ratification is currently required for each update, which may happen at different stages of feature development and testing lifecycle.
 
-An example:
 
-| Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-|--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
-| **Core Features**        |         |             |              |                   |                      |                  |
-| Full-text Search         |         | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors         |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                 |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**    |         |             |              |                   |                      |                  |
-| eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
-| eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100               | gnosis  | Yes         | No           | Yes               | Yes                  | Yes              |
-| near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
-| cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
-| arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161             | arbitrum-one  | Yes   | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220             | celo    | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114             | avalanche | Yes       | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features** |         |             |              |                   |                      |                  |
-| ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
-| ENS                      |         | Yes         | Yes          | No                | No                   | No               |
-| File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
+| Subgraph Feature         | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
+| ------------------------ | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- |
+| **Core Features**        |               |             |              |                   |                      |                  |
+| Full-text Search         |               | Yes         | No           | No                | Yes                  | Yes              |
+| Non-Fatal Errors         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Grafting                 |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Types**    |               |             |              |                   |                      |                  |
+| eip155:*                 | *             | Yes         | No           | No                | No                   | No               |
+| eip155:1                 | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100               | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| near:*                   | *             | Yes         | Yes          | No                | No                   | No               |
+| cosmos:*                 | *             | Yes         | Yes          | No                | No                   | No               |
+| arweave:*                | *             | Yes         | Yes          | No                | No                   | No               |
+| eip155:42161             | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:42220             | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:43114             | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:250               | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:137               | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Features** |               |             |              |                   |                      |                  |
+| ipfs.cat in mappings     |               | Yes         | Yes          | No                | No                   | No               |
+| ENS                      |               | Yes         | Yes          | No                | No                   | No               |
+| File data sources: IPFS  |               | Yes         | Yes          | No                | Yes                  | Yes              |
+| Substreams data sources  | mainnet       | Yes         | Yes          | Yes               | Yes                  | Yes              | 
 
-The accepted `graph-node` version range is also specificied; it always comprises of the latest available version and the one immediately preceding it. Here's an example of a version range which includes both 0.30.X and 0.31.X:
+The accepted `graph-node` version range must always be specificied; it always comprises of the latest available version and the one immediately preceding it. 
+The latest for the feature matrix above:
 
 ```
-graph-node: >=0.30 <0.32
+graph-node: >=0.31 <0.32
 ```
 
+### Latest Council snapshot
+[GGP-0026: Updated Feature Matrix Support (Graph Node v0.31.0)
+](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x80c55bb8697d16fedb71ccdce40704f24e931cc28f289a029e0717f3b729e6a8)
+
+
+### Other notes
+- Currently, one single matrix is used to reflect protocol behaviour for both Ethereum mainnet and Arbitrum One. 
 - Aliases can be used in subgraph manifest files to refer to specific networks.
 - Experimental features are generally not fully supported for indexing rewards and arbitration, and usage of experimental features will be considered during any arbitration that does occur.
 - Query fees apply to all queries, regardless of the underlying features used by a subgraph.

--- a/docs/networks.md
+++ b/docs/networks.md
@@ -11,3 +11,5 @@
 [Arbitrum Goerli configuration](./networks/arbitrum-goerli.md)
 
 [Testnet setup instructions](./testnet-setup.md)
+
+[Feature Support Matrix (Ethereum & Arbitrum One)](./feature-support-matrix.md)

--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -77,34 +77,3 @@ option can be used.
 | -------------------- | ---------------- | ----------------------------------- |
 | `ethereum`           | `--ethereum-rpc` | `mainnet:<ethereum-json-rpc-url>`   |
 | `ipfs`               | `--ipfs`         | `https://ipfs.network.thegraph.com` |
-
-## Feature support
-
-> This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
-
-```
-graph-node: >=0.30 <0.32
-```
-
-| Subgraph Feature         | Aliases | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-|--------------------------|---------|-------------|--------------|-------------------|----------------------|------------------|
-| **Core Features**        |         |             |              |                   |                      |                  |
-| Full-text Search         |         | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors         |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                 |         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**    |         |             |              |                   |                      |                  |
-| eip155:*                 | *       | Yes         | No           | No                | No                   | No               |
-| eip155:1                 | mainnet | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100               | gnosis  | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| near:*                   | *       | Yes         | Yes          | No                | No                   | No               |
-| cosmos:*                 | *       | Yes         | Yes          | No                | No                   | No               |
-| arweave:*                | *       | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161             | arbitrum-one  | Yes   | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220             | celo    | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114             | avalanche | Yes       | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features** |         |             |              |                   |                      |                  |
-| ipfs.cat in mappings     |         | Yes         | Yes          | No                | No                   | No               |
-| ENS                      |         | Yes         | Yes          | No                | No                   | No               |
-| File data sources: IPFS  |         | Yes         | Yes          | No                | Yes                  | Yes              |
-
-[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x80c55bb8697d16fedb71ccdce40704f24e931cc28f289a029e0717f3b729e6a8)

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -77,35 +77,3 @@ option can be used.
 | `ethereum`           | `--ethereum-rpc` | `mainnet:<ethereum-json-rpc-url>`   |
 | `ipfs`               | `--ipfs`         | `https://ipfs.network.thegraph.com` |
 
-## Feature support
-
-> This defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration ([read more](../feature-support-matrix.md)).
-
-```
-graph-node: >=0.30 <0.32
-```
-
-| Subgraph Feature         | Aliases      | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-|--------------------------|--------------|-------------|--------------|-------------------|----------------------|------------------|
-| **Core Features**        |              |             |              |                   |                      |                  |
-| Full-text Search         |              | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors         |              | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                 |              | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**    |              |             |              |                   |                      |                  |
-| eip155:*                 | *            | Yes         | No           | No                | No                   | No               |
-| eip155:1                 | mainnet      | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100               | gnosis       | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| near:*                   | *            | Yes         | Yes          | No                | No                   | No               |
-| cosmos:*                 | *            | Yes         | Yes          | No                | No                   | No               |
-| arweave:*                | *            | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161             | arbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220             | celo         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114             | avalanche    | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:250               | fantom       | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:137               | matic        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features** |              |             |              |                   |                      |                  |
-| ipfs.cat in mappings     |              | Yes         | Yes          | No                | No                   | No               |
-| ENS                      |              | Yes         | Yes          | No                | No                   | No               |
-| File data sources: IPFS  |              | Yes         | Yes          | No                | Yes                  | Yes              |
-
-[Council snapshot](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x80c55bb8697d16fedb71ccdce40704f24e931cc28f289a029e0717f3b729e6a8)


### PR DESCRIPTION
I also removed the feature support matrix from Ethereum mainnet & Arbitrum One environments, as we've agreed it should be the same on environments.

Another GGP will be created in https://snapshot.org/#/council.graphprotocol.eth referencing the latest feature support matrix. After Council approval, this PR should be merged.