### PR TITLE
Refactor: Auto L2 Transfer Support

### DIFF
--- a/packages/indexer-common/src/types.ts
+++ b/packages/indexer-common/src/types.ts
@@ -61,11 +61,20 @@ export interface SubgraphDeployment {
   protocolNetwork: string
 }
 
+// L1 Network Subgraph will always return `null` for the
+// `transferredToL2*` set of fields
 export interface TransferredSubgraphDeployment {
-  transferredToL2: boolean
-  transferredToL2At: BigNumber
-  transferredToL2AtTx: string
-  transferredToL2AtBlockNumber: BigNumber
+  id: string
+  idOnL1: string
+  idOnL2: string
+  startedTransferToL2L: boolean
+  startedTransferToL2At: BigNumber
+  startedTransferToL2AtBlockNumber: BigNumber
+  startedTransferToL2AtTx: string
+  transferredToL2: boolean | null
+  transferredToL2At: BigNumber | null
+  transferredToL2AtTx: string | null
+  transferredToL2AtBlockNumber: BigNumber | null
   ipfsHash: string
   protocolNetwork: string
   ready: boolean | null


### PR DESCRIPTION
Major changes:
- Refactor NetworkSubgraph query for transferred subgraphs, considering some fields will always be `null` on L1.
- For synced subgraph deployments and during the first 48 hours after the transfer started: 
  - On **L1**: Keep allocations open
  - On **L2**: Open allocations and create a `decisionBasis=always` indexing rule. *(Indexers are expected to manually update this rule afterwards)*

This means transfers older than 48h will be ignored by this feature.

Minor changes:
- auto-formatting 
- use of `networkIsL1` and `networkIsL2` helper functions
  