### PR TITLE
Update ci ubuntu OS version

### DIFF
--- a/.github/workflows/publish-native-binaries.yml
+++ b/.github/workflows/publish-native-binaries.yml
@@ -21,7 +21,7 @@ jobs:
         system:
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
         include:
           - node_version: 18

--- a/.github/workflows/publish-native-binaries.yml
+++ b/.github/workflows/publish-native-binaries.yml
@@ -4,9 +4,11 @@
 name: "Publish binaries"
 
 on:
+  workflow_dispatch:
   release:
     types:
       - created
+      - published
 
 jobs:
   publish-github:


### PR DESCRIPTION
github runners no longer support v18.04 ubuntu LTS, the oldest release is 20.04 LTS