### PR TITLE
fix: WIP on porting to Neon NAPI backend and 0.10

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.20.18"
+  "version": "0.20.19"
 }

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-agent",
-  "version": "0.20.18",
+  "version": "0.20.19",
   "description": "Indexer agent",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-cli",
-  "version": "0.20.18",
+  "version": "0.20.19",
   "description": "Indexer CLI for The Graph Network",
   "main": "./dist/cli.js",
   "files": [

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-common",
-  "version": "0.20.18",
+  "version": "0.20.19",
   "description": "Common library for Graph Protocol indexer components",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/indexer-native/jest.config.js
+++ b/packages/indexer-native/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-    forceExit: true,
     collectCoverage: true,
     testEnvironment: 'node',
     testPathIgnorePatterns: ['/node_modules/', '/dist/', '.yalc']

--- a/packages/indexer-native/lib/index.js
+++ b/packages/indexer-native/lib/index.js
@@ -15,11 +15,11 @@ function promisify(f) {
 class NativeSignatureVerifier {
   constructor(address) {
     this.address = address;
-    this._native = new addon.NativeSignatureVerifier(address);
+    this._native = addon.create_signature_verifier(address);
   }
 
   async verify(message, signature) {
-    return await promisify((cb) => this._native.verify(cb, message, signature));
+    return await promisify((cb) => addon.verify_signature(this._native, cb, message, signature));
   }
 }
 
@@ -30,7 +30,7 @@ class NativeAttestationSigner {
     privateKey,
     subgraphDeploymentId
   ) {
-    this._native = new addon.NativeAttestationSigner(
+    this._native = new addon.create_attestation_signer(
       chainId,
       disputeManagerAddress,
       privateKey,
@@ -39,7 +39,7 @@ class NativeAttestationSigner {
   }
   async createAttestation(request, response) {
     return await promisify((cb) =>
-      this._native.createAttestation(cb, request, response)
+      addon.create_attestation(this._native, cb, request, response)
     );
   }
 }

--- a/packages/indexer-native/native/Cargo.toml
+++ b/packages/indexer-native/native/Cargo.toml
@@ -3,7 +3,6 @@ name = "indexer-native"
 version = "0.1.0"
 authors = ["Zac Burns <That3Percent@gmail.com>"]
 license = "MIT"
-build = "build.rs"
 edition = "2018"
 exclude = ["artifacts.json", "index.node"]
 
@@ -11,12 +10,8 @@ exclude = ["artifacts.json", "index.node"]
 name = "indexer_native"
 crate-type = ["cdylib"]
 
-[build-dependencies]
-neon-build = "0.9.1"
-
 [dependencies]
-neon = "0.9"
-neon-utils = { git = "https://github.com/edgeandnode/neon-utils", rev = "2507d4f" }
+neon-utils = { git = "https://github.com/edgeandnode/neon-utils", rev = "484d139" }
 secp256k1 = { version = "0.20", features = ["recovery"] }
 never = "0.1"
 keccak-hash = "0.5.1"
@@ -25,3 +20,8 @@ arc-swap = "1.2"
 eip-712-derive = { git = "https://github.com/graphprotocol/eip-712-derive" }
 hex = "0.4.2"
 primitive-types = "0.8"
+
+[dependencies.neon]
+version = "0.10.1"
+default-features = false
+features = ["napi-6"]

--- a/packages/indexer-native/native/build.rs
+++ b/packages/indexer-native/native/build.rs
@@ -1,7 +1,0 @@
-extern crate neon_build;
-
-fn main() {
-    neon_build::setup(); // must be called in build.rs
-
-    // add project-specific build logic here...
-}

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-native",
-  "version": "0.20.18",
+  "version": "0.20.11",
   "description": "Performance sensitive indexer code",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -41,7 +41,7 @@
     "lint": "eslint .",
     "prepare": "yarn format && yarn lint",
     "install": "yarn pull-or-build",
-    "test": "jest --colors --verbose",
+    "test": "jest --colors --verbose --forceExit",
     "test:ci": "jest --verbose --ci",
     "clean": "rm -rf ./node_modules ./binary ./build ./coverage ./native/target ./native/artifacts.json ./native/index.node"
   },

--- a/packages/indexer-service/CHANGELOG.md
+++ b/packages/indexer-service/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.19] - 2023-08-12
+## Changed
+- Revert indexer-native to 0.20.11 (newer builds are broken)
+
+## [0.20.18] - 2023-08-11
+## Changed
+- Changes to support the multi-network changes from indexer-common
+
 ## [0.20.17] - 2023-06-19
 ### Changed
 - Use new partial-vouchers encoding, json

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/indexer-service",
-  "version": "0.20.18",
+  "version": "0.20.19",
   "description": "Indexer service",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@google-cloud/profiler": "4.1.7",
     "@graphprotocol/common-ts": "2.0.1",
-    "@graphprotocol/indexer-common": "^0.20.18",
-    "@graphprotocol/indexer-native": "^0.20.18",
+    "@graphprotocol/indexer-common": "^0.20.19",
+    "@graphprotocol/indexer-native": "^0.20.11",
     "@graphql-tools/load": "7.5.8",
     "@graphql-tools/url-loader": "7.9.11",
     "@graphql-tools/wrap": "8.4.13",

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -34,7 +34,7 @@
     "@google-cloud/profiler": "4.1.7",
     "@graphprotocol/common-ts": "2.0.1",
     "@graphprotocol/indexer-common": "^0.20.19",
-    "@graphprotocol/indexer-native": "^0.20.11",
+    "@graphprotocol/indexer-native": "0.20.11",
     "@graphql-tools/load": "7.5.8",
     "@graphql-tools/url-loader": "7.9.11",
     "@graphql-tools/wrap": "8.4.13",


### PR DESCRIPTION
Early WIP, not even close to working yet. The NAPI backend removes the declare_types way to create classes, and removes the tasks API in favor of a new channels API, so this requires a relatively big refactor.

This will require finishing https://github.com/edgeandnode/neon-utils/pull/10