### PR TITLE
Fix error handling for recently executed actions

### DIFF
--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -160,7 +160,7 @@ export class ActionManager {
             networkLogger.debug('Batch ready, preparing to execute', {
               paused,
               isOperator,
-              protocolNetwork: network.specification.networkIdentifier
+              protocolNetwork: network.specification.networkIdentifier,
             })
             // Do nothing else if the network is paused
             if (paused) {

--- a/packages/indexer-common/src/operator.ts
+++ b/packages/indexer-common/src/operator.ts
@@ -303,10 +303,7 @@ export class Operator {
       .toPromise()
 
     if (actionResult.error) {
-      if (
-        actionResult.error instanceof CombinedError &&
-        actionResult.error.message.includes('Duplicate')
-      ) {
+      if (actionResult.error instanceof CombinedError) {
         if (actionResult.error.message.includes('Duplicate')) {
           this.logger.warn(
             `Action not queued: Already a queued action targeting ${actionInput.deploymentID} from another source`,


### PR DESCRIPTION
The second expression of the conditional was blocking the error handling.