### PR TITLE
fix: properly skip reconciling allocations on a network in manual mode

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -1231,10 +1231,7 @@ export class Agent {
                   .map(decision => decision.deployment.ipfsHash),
               },
             )
-            allocationDecisions.forEach(
-              allocation => (allocation.toAllocate = false),
-            )
-            return allocationDecisions
+            return [] as AllocationDecision[]
           }
           const networkSubgraphDeployment = network.networkSubgraph.deployment
           if (


### PR DESCRIPTION
Setting allocation decisions to false would try to close allocations when on manual mode. It wouldn't actually go through because actions won't really be queued on manual, thankfully.
This PR changes it so that we use an empty array of allocation decisions for the network that is in manual mode, making the reconcile step a noop instead of an attempt to close all allocations.