### PR TITLE
More helpful error messages for address validation

### DIFF
--- a/packages/indexer-common/src/__tests__/network-specification-files/invalid-address.yml
+++ b/packages/indexer-common/src/__tests__/network-specification-files/invalid-address.yml
@@ -1,0 +1,34 @@
+networkIdentifier: mainnet
+gateway:
+  url: http://gateway
+indexerOptions:
+  address: "0x4e8a4C63Df58bf59Fef513aB67a76319a9faf448"
+  mnemonic: word ivory whale diesel slab pelican voyage oxygen chat find tobacco sport
+  url: http://indexer
+  geoCoordinates: [25.1, -71.2]
+  restakeRewards: true
+  rebateClaimThreshold: 400
+  rebateClaimBatchThreshold: 5000
+  rebateClaimMaxBatchSize: 10
+  poiDisputeMonitoring: false
+  poiDisputableEpochs: 5
+  defaultAllocationAmount: 0.05
+  voucherRedemptionThreshold: 2
+  voucherRedemptionBatchThreshold: 2000
+  voucherRedemptionMaxBatchSize: 15
+  allocationManagementMode: "auto"
+  autoAllocationMinBatchSize: 20
+transactionMonitoring:
+  gasIncreaseTimeout: 10
+  gasIncreaseFactor: 10
+  baseFeePerGasMax: 10
+  maxTransactionAttempts: 10
+subgraphs:
+  networkSubgraph:
+    deployment: QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB
+  epochSubgraph:
+    url: http://subgraph
+networkProvider:
+  url: http://provider
+dai:
+  contractAddress: "0x4e8a4C63Df58bf59Fef513aB67a76319a9faf448 "

--- a/packages/indexer-common/src/__tests__/network-specification.test.ts
+++ b/packages/indexer-common/src/__tests__/network-specification.test.ts
@@ -65,6 +65,11 @@ describe('Failed deserialization', () => {
       path: ['subgraphs', 'networkSubgraph', 'deployment'],
       message: 'Invalid IPFS hash',
     },
+    {
+      file: 'invalid-address.yml',
+      path: ['dai', 'contractAddress'],
+      message: 'Invalid contract address',
+    },
   ]
 
   test.each(failedTests)(

--- a/packages/indexer-common/src/network-specification.ts
+++ b/packages/indexer-common/src/network-specification.ts
@@ -3,6 +3,7 @@ import { BigNumber } from 'ethers'
 import { validateNetworkIdentifier, validateIpfsHash } from './parsers'
 import { AllocationManagementMode } from './types'
 import { z } from 'zod'
+import { utils } from 'ethers'
 
 // TODO: make sure those values are always in sync with the AllocationManagementMode enum. Can we do this in compile time?
 const ALLOCATION_MANAGEMENT_MODE = ['auto', 'manual', 'oversight'] as const
@@ -30,7 +31,12 @@ export type Gateway = z.infer<typeof Gateway>
 // Indexer identification and network behavior options
 export const IndexerOptions = z
   .object({
-    address: z.string().transform(toAddress),
+    address: z
+      .string()
+      .refine((val) => utils.isAddress(val), {
+        message: 'Invalid contract address',
+      })
+      .transform(toAddress),
     mnemonic: z.string(),
     url: z.string().url(),
     geoCoordinates: z.number().array().length(2).default([31.780715, -41.179504]),
@@ -116,6 +122,9 @@ export const Dai = z
     contractAddress: z
       .string()
       .default('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+      .refine((val) => utils.isAddress(val), {
+        message: 'Invalid contract address',
+      })
       .transform(toAddress),
     inject: z.boolean().default(true),
   })


### PR DESCRIPTION
Our input validation framework does not catch errors when converting values to the `Address` type. This PR adds a check to ensure that the provided value is a valid `Address` before attempting the conversion.