### PR TITLE
Fix string interpolation in migration file

### DIFF
--- a/packages/indexer-agent/src/db/migrations/11-add-protocol-network-field.ts
+++ b/packages/indexer-agent/src/db/migrations/11-add-protocol-network-field.ts
@@ -380,7 +380,7 @@ WHERE
       this.logger.debug(
         `Restoring foreing key between tables '${dependent.table}' and '${target.table}'`,
       )
-      const constraintName = '${dependent.table}_${target.table}_fkey'
+      const constraintName = `${dependent.table}_${target.table}_fkey`
 
       const createConstraintSql = `
       ALTER TABLE "${dependent.table}"


### PR DESCRIPTION
Constraint name was being created as a literal string.
No data is in risk, but the constraint name must be corrected.