### PR TITLE
Indexer-Service: save `allocation_summary` within transaction

### DIFF
--- a/packages/indexer-common/src/allocations/query-fees.ts
+++ b/packages/indexer-common/src/allocations/query-fees.ts
@@ -146,7 +146,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
               transaction,
               this.protocolNetwork,
             )
-            await summary.save()
+            await summary.save({ transaction })
           }
         },
       )
@@ -581,7 +581,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
             summary.withdrawnFees = BigNumber.from(summary.withdrawnFees)
               .add(voucher.amount)
               .toString()
-            await summary.save()
+            await summary.save({ transaction })
           }
         },
       )

--- a/packages/indexer-service/src/query-fees/allocations.ts
+++ b/packages/indexer-service/src/query-fees/allocations.ts
@@ -154,7 +154,7 @@ export class AllocationReceiptManager implements ReceiptManager {
               this.protocolNetwork,
             )
             if (isNewSummary) {
-              await summary.save()
+              await summary.save({ transaction })
             }
 
             const [state, isNew] =


### PR DESCRIPTION
The `allocation_summary` row is saved without a reference to the current `transaction` object.

Since the transaction's isolation level is set to [`REPEATABLE_READ`](https://www.postgresql.org/docs/current/transaction-iso.html#XACT-REPEATABLE-READ), it is possible that the new allocation summary is not visible to the subsequent insertion into `allocation_summaries`, which is scoped to the ongoing transaction.
