### PR TITLE
Display supported networks in indexer-cli usage text

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/actions/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/get.ts
@@ -22,7 +22,7 @@ ${chalk.bold('graph indexer actions get')} [options]
 ${chalk.dim('Options:')}
 
   -h, --help                                                        Show usage information
-  -n, --network                                                     Filter by protocol network
+  -n, --network                                                     Filter by protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
       --type    allocate|unallocate|reallocate|collect              Filter by type
       --status  queued|approved|pending|success|failed|canceled     Filter by status
       --source <source>                                             Fetch only actions queued by a specific source

--- a/packages/indexer-cli/src/commands/indexer/actions/queue.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/queue.ts
@@ -29,7 +29,7 @@ ${chalk.bold(
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage informatio
-  -n, --network <STRING>        [REQUIRED] The protocol network for this action
+  -n, --network <STRING>        [Required] The protocol network for this action (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
   -s, --source <STRING>         Specify the source of the action decision
   -r, --reason <STRING>         Specify the reason for the action to be taken

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -15,6 +15,9 @@ ${chalk.dim('Options:')}
   -h, --help                    Show usage information
   -f, --force                   Bypass POIaccuracy checks and submit transaction with provided data
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
+
+${chalk.dim('Networks:')}
+  mainnet, arbitrum-one, goerli or arbitrum goerli
 `
 
 module.exports = {

--- a/packages/indexer-cli/src/commands/indexer/allocations/create.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/create.ts
@@ -22,6 +22,9 @@ ${chalk.dim('Options:')}
   -h, --help                    Show usage information
   -f, --force                   Bypass POI accuracy checks and submit transaction with provided data
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
+
+${chalk.dim('Networks:')}
+  mainnet, arbitrum-one, goerli or arbitrum goerli
 `
 
 module.exports = {

--- a/packages/indexer-cli/src/commands/indexer/allocations/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/get.ts
@@ -18,7 +18,7 @@ ${chalk.bold('graph indexer allocations get')} [options] all
 ${chalk.dim('Options:')}
 
   -h, --help                                Show usage information
-  -n, --network                             Filter allocations by their protocol network
+  -n, --network                             Filter allocations by their protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
       --status active|closed|claimable      Filter by status
       --deployment <id>                     Fetch only allocations for a specific subgraph deployment
   -o, --output table|json|yaml              Choose the output format: table (default), JSON, or YAML

--- a/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
@@ -16,6 +16,9 @@ ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
   -f, --force                   Bypass POI accuracy checks and submit transaction with provided data
+
+${chalk.dim('Networks:')}
+  mainnet, arbitrum-one, goerli or arbitrum goerli
 `
 
 module.exports = {

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -13,7 +13,7 @@ ${chalk.bold(
 
 ${chalk.dim('Options:')}
 
-  -n, --network                 Filter by protocol network
+  -n, --network                 Filter by protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli) 
   -h, --help                    Show usage information
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `

--- a/packages/indexer-cli/src/commands/indexer/rules/clear.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/clear.ts
@@ -21,7 +21,7 @@ ${chalk.bold('graph indexer rules reset')} [options] <subgraph-identifier> [<key
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 
 ${chalk.dim('Hints:')}

--- a/packages/indexer-cli/src/commands/indexer/rules/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/delete.ts
@@ -19,7 +19,7 @@ ${chalk.bold('graph indexer rules delete')} [options] <deployment-id>
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/commands/indexer/rules/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/get.ts
@@ -19,7 +19,7 @@ ${chalk.bold('graph indexer rules get')} [options] <deployment-id> [<key1> ...]
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 Filter by the rule's protocol network
+  -n, --network                 Filter by the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
       --merged                  Shows the deployment rules and global rules merged
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `

--- a/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/maybe.ts
@@ -18,7 +18,7 @@ ${chalk.bold('graph indexer rules maybe')} [options] <deployment-id>
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/commands/indexer/rules/set.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/set.ts
@@ -26,7 +26,7 @@ ${chalk.bold('graph indexer rules set')} [options] <deployment-id> <key1> <value
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/commands/indexer/rules/start.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/start.ts
@@ -20,7 +20,7 @@ ${chalk.bold('graph indexer rules always')} [options] <deployment-id>
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/commands/indexer/rules/stop.ts
+++ b/packages/indexer-cli/src/commands/indexer/rules/stop.ts
@@ -20,7 +20,7 @@ ${chalk.bold('graph indexer rules never')} [options] <deployment-id>
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
 

--- a/packages/indexer-cli/src/commands/indexer/status.ts
+++ b/packages/indexer-cli/src/commands/indexer/status.ts
@@ -21,7 +21,7 @@ ${chalk.bold('graph indexer status')}
 ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
-  -n, --network                 [Required] the rule's protocol network
+  -n, --network                 [Required] the rule's protocol network (mainnet, arbitrum-one, goerli, arbitrum-goerli)
 `
 
 interface Endpoint {


### PR DESCRIPTION
Adds the supported network names in `indexer-cli` command's usage texts.

When `--network` is passed as an option:

```shellsession
$ ./graph-indexer indexer actions queue --help

💁
graph indexer actions queue [options] <ActionType> <targetDeployment> <param1> <param2> <param3> <param4>
graph indexer actions queue [options] allocate <deploymentID> <amount>
graph indexer actions queue [options] unallocate <deploymentID> <allocationID> <poi> <force>
graph indexer actions queue [options] reallocate <deploymentID> <allocationID> <amount> <poi> <force>

Options:

  -h, --help                    Show usage informatio
  -n, --network <STRING>        [Required] The protocol network for this action (mainnet, arbitrum-one, goerli, arbitrum-goerli)
  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
  -s, --source <STRING>         Specify the source of the action decision
  -r, --reason <STRING>         Specify the reason for the action to be taken
  -p, --priority <INT>          Define a priority order for the action
```

When `network` is passed as a positional argument:

```shellsession
$ ./graph-indexer indexer allocations reallocate --help

💁
graph indexer allocations reallocate [options] <network> <id> <amount> <poi>

Options:

  -h, --help                    Show usage information
  -f, --force                   Bypass POI accuracy checks and submit transaction with provided data

Networks:
  mainnet, arbitrum-one, goerli or arbitrum goerli
```