### PR TITLE
fix(indexer-native): abandon neon-utils in favor of napi-6

### DIFF
--- a/packages/indexer-native/lib/index.js
+++ b/packages/indexer-native/lib/index.js
@@ -1,25 +1,13 @@
-var addon = require("../binary");
-
-function promisify(f) {
-  return new Promise((resolve, reject) =>
-    f((err, result) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(result);
-      }
-    }),
-  );
-}
+var addon = require("../binary/index.node");
 
 class NativeSignatureVerifier {
   constructor(address) {
     this.address = address;
-    this._native = new addon.NativeSignatureVerifier(address);
+    this._native = addon.signature_verifier_new(address);
   }
 
-  async verify(message, signature) {
-    return await promisify((cb) => this._native.verify(cb, message, signature));
+  verify(message, signature) {
+    return addon.signature_verifier_verify(this._native, message, signature);
   }
 }
 
@@ -30,16 +18,19 @@ class NativeAttestationSigner {
     privateKey,
     subgraphDeploymentId,
   ) {
-    this._native = new addon.NativeAttestationSigner(
+    this._native = addon.attestation_signer_new(
       chainId,
       disputeManagerAddress,
       privateKey,
       subgraphDeploymentId,
     );
   }
-  async createAttestation(request, response) {
-    return await promisify((cb) =>
-      this._native.createAttestation(cb, request, response),
+
+  createAttestation(request, response) {
+    return addon.attestation_signer_create_attestation(
+      this._native,
+      request,
+      response,
     );
   }
 }

--- a/packages/indexer-native/lib/index.test.js
+++ b/packages/indexer-native/lib/index.test.js
@@ -3,16 +3,16 @@ const { utils, Wallet } = require("ethers");
 const bs58 = require("bs58");
 
 describe("Native Functions", () => {
-  test("Signatures", async () => {
+  test("Signatures", () => {
     let address = "0xc61127cdfb5380df4214b0200b9a07c7c49d34f9";
     let native = new NativeSignatureVerifier(address);
 
     // Taken from the indexer-service code matching
     // the Scalar format.
-    let verifyReceipt = async (receipt) => {
+    let verifyReceipt = (receipt) => {
       const message = receipt.slice(64, 136);
       const signature = receipt.slice(136, 266);
-      return await native.verify(message, signature);
+      return native.verify(message, signature);
     };
 
     // Testing multiple true/false values in this order on the same NativeSignatureVerifier
@@ -33,15 +33,15 @@ describe("Native Functions", () => {
       "640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090000000259d1189ce128a2a3b4786035aed37cca0968c638c67e73ed1496a50fbda043d5553a7702bb8b0f71409dd0199533161e322b17826a91236cfb22504a093d0a451c";
     // The awaits give time for each previous task to resolve, ensuring that the
     // fast path is taken for subsequent runs.
-    await expect(verifyReceipt(receipt0Tampered)).resolves.toEqual(false);
-    await expect(verifyReceipt(receipt0________)).resolves.toEqual(true);
-    await expect(verifyReceipt(receipt1________)).resolves.toEqual(true);
-    await expect(verifyReceipt(receipt1Tampered)).resolves.toEqual(false);
+    expect(verifyReceipt(receipt0Tampered)).toEqual(false);
+    expect(verifyReceipt(receipt0________)).toEqual(true);
+    expect(verifyReceipt(receipt1________)).toEqual(true);
+    expect(verifyReceipt(receipt1Tampered)).toEqual(false);
     // When running the tests locally with some debug information, to ensure
     // that the fast path was transitioned to it only printed 3/4 messages.
     // Adding this redundant test printed 4/5 messages. Assuming the problem
     // is just flushing output.
-    await expect(verifyReceipt(receipt1Tampered)).resolves.toEqual(false);
+    expect(verifyReceipt(receipt1Tampered)).toEqual(false);
   });
 
   test("Create attestation", async () => {
@@ -75,9 +75,9 @@ describe("Native Functions", () => {
       r: "0x702af3e8dec0aab1b29e5663b7ba6843689a55c2c178a26dcce3bc1eeb3a1de9",
       s: "0x7b24b529fcf92c9426179146bb7bfed6540043e2c30132e59d994a3cc718f2be",
     };
-    await expect(
-      signer.createAttestation("request", "response"),
-    ).resolves.toEqual(expected);
+    await expect(signer.createAttestation("request", "response")).toEqual(
+      expected,
+    );
   });
 
   test("Fail to initialize signer", async () => {

--- a/packages/indexer-native/native/Cargo.lock
+++ b/packages/indexer-native/native/Cargo.lock
@@ -3,12 +3,33 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.4"
+name = "alloy-primitives"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "66f73f11dcfbf8bb763d88fb1d082fe7cca0a00d3227d9921bdbd52ce5e013e2"
 dependencies = [
- "memchr",
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "proptest",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f938f00332d63a5b0ac687bd6f46d03884638948921d9f8b50c59563d421ae25"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "smol_str",
 ]
 
 [[package]]
@@ -30,10 +51,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "atomic-take"
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -42,16 +63,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
+ "bit-vec",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -63,22 +99,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cc"
-version = "1.0.82"
+name = "bytes"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -97,6 +133,24 @@ checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "const-hex"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca268df6cd88e646b564e6aff1a016834e5f42077c736ef6b6789c31ef9ec5dc"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "serde",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
@@ -124,6 +178,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,25 +211,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
+name = "errno"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "faster-hex"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9042d281a5eec0f2387f8c3ea6c4514e2cf2732c90a85aaf383b761ee3b290d"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
- "serde",
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
-name = "firestorm"
-version = "0.5.1"
+name = "errno-dragonfly"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f6c2c942da57e2aaaa84b8a521489486f14e75e7fa91dab70aba913975f98"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixed-hash"
@@ -170,17 +243,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
  "static_assertions",
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
@@ -204,16 +274,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -237,51 +307,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "indexer-native"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "arc-swap",
  "eip-712-derive",
- "hex",
  "keccak-hash",
  "lazy_static",
  "neon",
- "neon-build",
- "neon-utils",
- "never",
- "primitive-types",
  "secp256k1",
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.0.0"
+name = "itoa"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "keccak-hash"
@@ -304,6 +346,22 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsecp256k1"
@@ -354,10 +412,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
+name = "linux-raw-sys"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "neon"
@@ -366,8 +424,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e15415261d880aed48122e917a45e87bb82cf0260bb6db48bbab44b7464373"
 dependencies = [
  "neon-build",
+ "neon-macros",
  "neon-runtime",
- "semver",
+ "semver 0.9.0",
  "smallvec",
 ]
 
@@ -376,8 +435,16 @@ name = "neon-build"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bac98a702e71804af3dacfde41edde4a16076a7bbe889ae61e56e18c5b1c811"
+
+[[package]]
+name = "neon-macros"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7288eac8b54af7913c60e0eb0e2a7683020dffa342ab3fd15e28f035ba897cf"
 dependencies = [
- "neon-sys",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
 ]
 
 [[package]]
@@ -387,79 +454,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676720fa8bb32c64c3d9f49c47a47289239ec46b4bdb66d0913cc512cb0daca"
 dependencies = [
  "cfg-if",
- "neon-sys",
+ "libloading",
  "smallvec",
 ]
 
 [[package]]
-name = "neon-sys"
-version = "0.10.1"
+name = "num-traits"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ebc923308ac557184455b4aaa749470554cbac70eb4daa8b18cdc16bef7df6"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
- "cc",
- "regex",
+ "autocfg",
+ "libm",
 ]
-
-[[package]]
-name = "neon-utils"
-version = "1.1.0"
-source = "git+https://github.com/edgeandnode/neon-utils?rev=b757548#b757548c3b36854e7ce7554a815a5d074278f51c"
-dependencies = [
- "atomic-take",
- "faster-hex",
- "firestorm",
- "neon",
- "neon-build",
- "never",
- "primitive-types",
- "rustc-hex",
- "secp256k1",
-]
-
-[[package]]
-name = "never"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
-dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -474,18 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
- "impl-codec",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
 ]
 
 [[package]]
@@ -498,19 +500,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.32"
+name = "proptest"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
- "proc-macro2",
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -543,39 +565,82 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.3"
+name = "rand_xorshift"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "rand_core",
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.3.6"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rustc-hex"
-version = "2.1.0"
+name = "ruint"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+dependencies = [
+ "proptest",
+ "rand",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.18",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "secp256k1"
@@ -605,6 +670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,22 +683,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -648,6 +719,15 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
@@ -674,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -684,10 +764,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
+name = "syn-mid"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -696,23 +794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -734,10 +815,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -746,25 +839,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "winnow"
-version = "0.5.12"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "memchr",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "tap",
+ "windows-targets",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/packages/indexer-native/native/Cargo.toml
+++ b/packages/indexer-native/native/Cargo.toml
@@ -1,27 +1,21 @@
 [package]
 name = "indexer-native"
-version = "0.1.0"
-authors = ["Zac Burns <That3Percent@gmail.com>"]
+version = "0.2.0"
+authors = [
+  "Zac Burns <That3Percent@gmail.com>",
+  "Theo Butler <theodusbutler@gmail.com>",
+]
 license = "MIT"
-build = "build.rs"
 edition = "2018"
-exclude = ["artifacts.json", "index.node"]
 
 [lib]
-name = "indexer_native"
 crate-type = ["cdylib"]
 
-[build-dependencies]
-neon-build = "0.10.1"
-
 [dependencies]
-neon = "0.10"
-neon-utils = { git = "https://github.com/edgeandnode/neon-utils", rev = "b757548" }
-secp256k1 = { version = "0.27", features = ["recovery"] }
-never = "0.1"
-keccak-hash = "0.10.0"
-lazy_static = "1.4"
+alloy-primitives = "0.3.1"
 arc-swap = "1.2"
 eip-712-derive = { git = "https://github.com/graphprotocol/eip-712-derive" }
-hex = "0.4.2"
-primitive-types = "0.12.1"
+keccak-hash = "0.10.0"
+lazy_static = "1.4"
+neon = { version = "0.10", default-features = false, features = ["napi-6"] }
+secp256k1 = { version = "0.27", features = ["recovery"] }

--- a/packages/indexer-native/native/build.rs
+++ b/packages/indexer-native/native/build.rs
@@ -1,7 +1,0 @@
-extern crate neon_build;
-
-fn main() {
-    neon_build::setup(); // must be called in build.rs
-
-    // add project-specific build logic here...
-}

--- a/packages/indexer-native/native/src/attestation.rs
+++ b/packages/indexer-native/native/src/attestation.rs
@@ -1,47 +1,46 @@
-use super::*;
-use eip_712_derive::{
-    sign_typed, Bytes32, DomainSeparator, Eip712Domain, MemberVisitor, StructType, U256,
-};
-use neon_utils::{
-    errors::SafeJsResult,
-    js_object,
-    marshalling::{codecs::decode, IntoHandle},
-};
+use std::convert::TryInto;
+
+use alloy_primitives::{Address, B256, U256};
+use eip_712_derive::{sign_typed, DomainSeparator, Eip712Domain, MemberVisitor, StructType};
+use keccak_hash::keccak;
+use neon::prelude::Finalize;
 use secp256k1::SecretKey;
 
 pub struct AttestationSigner {
-    subgraph_deployment_id: Bytes32,
+    subgraph_deployment_id: B256,
     domain_separator: DomainSeparator,
     signer: SecretKey,
 }
+
+impl Finalize for AttestationSigner {}
 
 impl AttestationSigner {
     pub fn new(
         chain_id: U256,
         dispute_manager: Address,
         signer: SecretKey,
-        subgraph_deployment_id: Bytes32,
+        subgraph_deployment_id: B256,
     ) -> Self {
+        let salt = "0xa070ffb1cd7409649bf77822cce74495468e06dbfaef09556838bf188679b9c2"
+            .parse::<B256>()
+            .unwrap();
         let domain = Eip712Domain {
             name: "Graph Protocol".to_owned(),
             version: "0".to_owned(),
-            chain_id,
-            verifying_contract: eip_712_derive::Address(dispute_manager),
-            salt: decode("a070ffb1cd7409649bf77822cce74495468e06dbfaef09556838bf188679b9c2")
-                .unwrap(),
+            chain_id: eip_712_derive::U256(chain_id.to_be_bytes()),
+            verifying_contract: eip_712_derive::Address(*dispute_manager.0),
+            salt: salt.0,
         };
-        let domain_separator = DomainSeparator::new(&domain);
-
         Self {
-            domain_separator,
+            domain_separator: DomainSeparator::new(&domain),
             signer,
             subgraph_deployment_id,
         }
     }
 
     pub fn create_attestation(&self, request: &str, response: &str) -> Attestation {
-        let request_cid = keccak(request).to_fixed_bytes();
-        let response_cid = keccak(response).to_fixed_bytes();
+        let request_cid = keccak(request).to_fixed_bytes().into();
+        let response_cid = keccak(response).to_fixed_bytes().into();
 
         let receipt = Receipt {
             request_cid,
@@ -57,53 +56,37 @@ impl AttestationSigner {
         let s = rs[32..64].try_into().unwrap();
 
         Attestation {
+            request_cid,
+            response_cid,
+            subgraph_deployment_id: self.subgraph_deployment_id,
             v,
             r,
             s,
-            subgraph_deployment_id: self.subgraph_deployment_id,
-            request_cid,
-            response_cid,
         }
     }
 }
 
 pub struct Receipt {
-    request_cid: Bytes32,
-    response_cid: Bytes32,
-    subgraph_deployment_id: Bytes32,
+    request_cid: B256,
+    response_cid: B256,
+    subgraph_deployment_id: B256,
 }
 
 impl StructType for Receipt {
     const TYPE_NAME: &'static str = "Receipt";
     fn visit_members<T: MemberVisitor>(&self, visitor: &mut T) {
-        visitor.visit("requestCID", &self.request_cid);
-        visitor.visit("responseCID", &self.response_cid);
-        visitor.visit("subgraphDeploymentID", &self.subgraph_deployment_id);
+        visitor.visit("requestCID", &self.request_cid.0);
+        visitor.visit("responseCID", &self.response_cid.0);
+        visitor.visit("subgraphDeploymentID", &self.subgraph_deployment_id.0);
     }
 }
 
 #[derive(Debug)]
 pub struct Attestation {
-    pub request_cid: Bytes32,
-    pub response_cid: Bytes32,
-    pub subgraph_deployment_id: Bytes32,
-    // pub query_version: String,
+    pub request_cid: B256,
+    pub response_cid: B256,
+    pub subgraph_deployment_id: B256,
     pub v: u8,
-    pub r: Bytes32,
-    pub s: Bytes32,
-}
-
-impl IntoHandle for Attestation {
-    type Handle = JsObject;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> SafeJsResult<'c, Self::Handle> {
-        js_object!(cx => {
-            requestCID: &self.request_cid,
-            responseCID: &self.response_cid,
-            subgraphDeploymentID: &self.subgraph_deployment_id,
-            // queryVersion: &self.query_version,
-            v: self.v as u32,
-            r: &self.r,
-            s: &self.s,
-        })
-    }
+    pub r: B256,
+    pub s: B256,
 }

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -16,33 +16,15 @@
   },
   "author": "Zac Burns <That3Percent@gmail.com>",
   "license": "MIT",
-  "os": [
-    "darwin",
-    "linux"
-  ],
-  "cpu": [
-    "x64",
-    "arm",
-    "arm64"
-  ],
-  "engines": {
-    "node": ">=12.22.0"
-  },
   "scripts": {
-    "build": "cd native && cargo-cp-artifact -a cdylib indexer_native ../binary/index.node -- cargo build --message-format=json-render-diagnostics",
-    "build-debug": "yarn build --",
-    "build-release": "yarn build --release",
-    "pull-or-build": "node-pre-gyp install --fallback-to-build=false --update-binary || yarn build-release",
-    "package": "node-pre-gyp package",
-    "publish-github-draft": "node-pre-gyp-github publish",
-    "publish-github": "node-pre-gyp-github publish --release",
-    "build-test-pack-publish": "yarn build-release && yarn test && yarn package && yarn publish-github-draft",
+    "build": "cd native && cargo-cp-artifact -nc ../binary/index.node -- cargo build --release --message-format=json-render-diagnostics",
     "format": "prettier --write 'lib/**/*.js'",
     "lint": "eslint .",
     "prepare": "yarn format && yarn lint",
-    "install": "yarn pull-or-build",
-    "test": "jest --colors --verbose --forceExit",
     "test:ci": "jest --verbose --ci",
+    "install": "yarn build",
+    "test": "yarn build && jest --colors --verbose --forceExit",
+    "test:ci": "yarn build && jest --verbose --ci",
     "clean": "rm -rf ./node_modules ./binary ./build ./coverage ./native/target ./native/artifacts.json ./native/index.node"
   },
   "dependencies": {
@@ -58,13 +40,6 @@
     "ethers": "5.7.0",
     "jest": "<30.0.0-0",
     "prettier": "3.0.3"
-  },
-  "binary": {
-    "module_name": "index",
-    "module_path": "./binary",
-    "host": "https://github.com/graphprotocol/indexer/releases/download/",
-    "remote_path": "v{version}",
-    "package_name": "graphprotocol-indexer-native-v{version}-{node_abi}-{platform}-{arch}.tar.gz"
   },
   "gitHead": "972ab96774007b2aee15b1da169d2ff4be9f9d27"
 }


### PR DESCRIPTION
I was previously unable to modify indexer-native without the native module failing to self-register. Switching to napi-6 seems to resolve this issue.