### PR TITLE
Fix floating promises

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed bug causing the network subgraph to be removed after syncing
 
 ## [0.20.21] - 2023-08-22
 ### Fixed

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -996,7 +996,7 @@ export class Agent {
     // Ensure the network subgraph deployment is _always_ indexed
     // ----------------------------------------------------------------------------------------
     let indexingNetworkSubgraph = false
-    this.multiNetworks.map(async ({ network }) => {
+    await this.multiNetworks.map(async ({ network }) => {
       if (network.networkSubgraph.deployment) {
         const networkDeploymentID = network.networkSubgraph.deployment.id
         if (!deploymentInList(targetDeployments, networkDeploymentID)) {
@@ -1069,7 +1069,7 @@ export class Agent {
         // Ensure the deployment is deployed to the indexer
         // Note: we're not waiting here, as sometimes indexing a subgraph
         // will block if the IPFS files cannot be retrieved
-        this.graphNode.ensure(name, deployment)
+        await this.graphNode.ensure(name, deployment)
       }),
     )
 

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -994,7 +994,7 @@ export class Agent {
     // ----------------------------------------------------------------------------------------
     // Ensure the network subgraph deployment is _always_ indexed
     // ----------------------------------------------------------------------------------------
-    this.multiNetworks.map(async ({ network }) => {
+    await this.multiNetworks.map(async ({ network }) => {
       if (network.networkSubgraph.deployment) {
         const networkDeploymentID = network.networkSubgraph.deployment.id
         if (!deploymentInList(targetDeployments, networkDeploymentID)) {

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -40,7 +40,6 @@ import {
 import PQueue from 'p-queue'
 import pMap from 'p-map'
 import pFilter from 'p-filter'
-import isEqual from 'lodash.isequal'
 import mapValues from 'lodash.mapvalues'
 import zip from 'lodash.zip'
 
@@ -135,9 +134,6 @@ export const convertSubgraphBasedRulesToDeploymentBased = (
   rules.push(...toAdd)
   return rules
 }
-
-const deploymentIDSet = (deployments: SubgraphDeploymentID[]): Set<string> =>
-  new Set(deployments.map(id => id.bytes32))
 
 // Represents a pair of Network and Operator instances belonging to the same protocol
 // network. Used when mapping over multiple protocol networks.

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -539,7 +539,7 @@ export async function run(
   // --------------------------------------------------------------------------------
   // * Cost Model Automation
   // --------------------------------------------------------------------------------
-  startCostModelAutomation({
+  await startCostModelAutomation({
     logger,
     networks,
     indexerManagement: indexerManagementClient,

--- a/packages/indexer-agent/src/cost.ts
+++ b/packages/indexer-agent/src/cost.ts
@@ -48,12 +48,12 @@ interface CostModelAutomationOptions {
   metrics: CostModelAutomationMetrics
 }
 
-export const startCostModelAutomation = ({
+export const startCostModelAutomation = async ({
   logger,
   networks,
   indexerManagement,
   metrics,
-}: StartCostModelAutomationOptions): void => {
+}: StartCostModelAutomationOptions): Promise<void> => {
   logger = logger.child({ component: 'CostModelAutomation' })
 
   const automationMetrics = registerMetrics(metrics)
@@ -63,7 +63,7 @@ export const startCostModelAutomation = ({
     n => n.specification.networkIdentifier === 'eip155:1',
   )
   if (mainnet && mainnet.specification.dai.inject) {
-    monitorAndInjectDai({
+    await monitorAndInjectDai({
       logger,
       ethereum: mainnet.networkProvider,
       contracts: mainnet.contracts,

--- a/packages/indexer-agent/src/index.ts
+++ b/packages/indexer-agent/src/index.ts
@@ -70,4 +70,4 @@ async function main(): Promise<void> {
   await processArgumentsAndRun(args)
 }
 
-main()
+void main()

--- a/packages/indexer-agent/src/syncing-server.ts
+++ b/packages/indexer-agent/src/syncing-server.ts
@@ -46,6 +46,7 @@ export const createSyncingServer = async ({
   server.post(
     '/network/:networkIdentifier',
     bodyParser.json(),
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (req, res) => {
       const { query, variables } = req.body
       const { networkIdentifier: unvalidatedNetworkIdentifier } = req.params

--- a/packages/indexer-common/src/network.ts
+++ b/packages/indexer-common/src/network.ts
@@ -191,7 +191,7 @@ export class Network {
     // --------------------------------------------------------------------------------
     // * Allocation Receipt Collector
     // --------------------------------------------------------------------------------
-    const receiptCollector = new AllocationReceiptCollector({
+    const receiptCollector = await AllocationReceiptCollector.create({
       logger,
       metrics,
       transactionManager: transactionManager,

--- a/packages/indexer-common/src/transactions.ts
+++ b/packages/indexer-common/src/transactions.ts
@@ -203,7 +203,7 @@ export class TransactionManager {
         // This case typically indicates a successful transaction being retried.
         // Let's introduce a 30 second delay to ensure the previous transaction has
         // a chance to be mined and return to the reconciliation loop so the agent can reevaluate.
-        delay(30000)
+        await delay(30000)
         throw indexerError(
           IndexerErrorCode.IE058,
           `Original transaction was not confirmed though it may have been successful`,

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -312,7 +312,7 @@ export default {
     // If the network subgraph deployment is present, validate if the `chainId` we get from our
     // provider is consistent.
     if (argv.networkSubgraphDeployment) {
-      validateProviderNetworkIdentifier(
+      await validateProviderNetworkIdentifier(
         protocolNetwork,
         argv.networkSubgraphDeployment,
         graphNode,


### PR DESCRIPTION
Adds `await` before `async` function calls.
- Fixes network subgraph deployments being removed right after they are synced.
- Add logs inside `reconcileDeployment` function.
 