### PR TITLE
Reference conflict targets when upserting POIDisputes

### DIFF
--- a/packages/indexer-common/CHANGELOG.md
+++ b/packages/indexer-common/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reference SQL conflict targets when upserting `POIDisputes`.
 
 ## [0.20.21] - 2023-08-24
 ### Changed

--- a/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/poi-disputes.ts
@@ -67,6 +67,7 @@ export default {
         'previousEpochReferenceProof',
         'status',
       ],
+      conflictAttributes: ['allocationID', 'protocolNetwork'],
     })
     return createdDisputes.map((dispute: POIDispute) => dispute.toGraphQL())
   },

--- a/packages/indexer-common/src/operator.ts
+++ b/packages/indexer-common/src/operator.ts
@@ -574,7 +574,7 @@ export class Operator {
       )
     } catch (error) {
       const err = indexerError(IndexerErrorCode.IE039, error)
-      this.logger.error('Failed to store potential POI disputes', {
+      this.logger.error('Failed to fetch POI disputes', {
         err,
       })
       throw err


### PR DESCRIPTION
Besides that, fix a duplicate log message.