### PR TITLE
Relax network subgraph validation in Indexer Service startup

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -1302,6 +1302,8 @@ export class Agent {
     )
   }
 
+  // TODO: This could be a initialization check inside Network.create() once/if the Indexer Service
+  // uses Network instances.
   async ensureNetworkSubgraphIsIndexing(network: Network) {
     if (
       network.specification.subgraphs.networkSubgraph.deployment !== undefined

--- a/packages/indexer-service/CHANGELOG.md
+++ b/packages/indexer-service/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Relax network subgraph validation during indexer-service startup
 
 ## [0.20.21] - 2023-08-24
 ### Changed

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -312,12 +312,18 @@ export default {
     // If the network subgraph deployment is present, validate if the `chainId` we get from our
     // provider is consistent.
     if (argv.networkSubgraphDeployment) {
-      await validateProviderNetworkIdentifier(
-        protocolNetwork,
-        argv.networkSubgraphDeployment,
-        graphNode,
-        logger,
-      )
+      try {
+        await validateProviderNetworkIdentifier(
+          protocolNetwork,
+          argv.networkSubgraphDeployment,
+          graphNode,
+          logger,
+        )
+      } catch (e) {
+        logger.warn(
+          'Failed to validate Network Subgraph on index-nodes. Will use external subgraph endpoint instead',
+        )
+      }
     }
 
     logger.info('Connect to contracts', {


### PR DESCRIPTION
Emit warnings instead of throwing an error, which is causing the process to exit.