### PR TITLE
agent: add tests for allocation decision consolidation

### DIFF
--- a/packages/indexer-agent/src/__tests__/agent.ts
+++ b/packages/indexer-agent/src/__tests__/agent.ts
@@ -1,4 +1,7 @@
-import { convertSubgraphBasedRulesToDeploymentBased } from '../agent'
+import {
+  convertSubgraphBasedRulesToDeploymentBased,
+  consolidateAllocationDecisions,
+} from '../agent'
 import {
   INDEXING_RULE_GLOBAL,
   IndexingDecisionBasis,
@@ -164,5 +167,44 @@ describe('Agent convenience function tests', () => {
     expect(
       convertSubgraphBasedRulesToDeploymentBased(inputRules, subgraphs, 1000),
     ).toEqual(inputRules)
+  })
+})
+
+describe('consolidateAllocationDecisions function', () => {
+  it('produces a set with unique deployment ids', () => {
+    const a = new SubgraphDeploymentID(
+      'QmXZiV6S13ha6QXq4dmaM3TB4CHcDxBMvGexSNu9Kc28EH',
+    )
+    const b = new SubgraphDeploymentID(
+      'QmRKs2ZfuwvmZA3QAWmCqrGUjV9pxtBUDP3wuc6iVGnjA2',
+    )
+    const c = new SubgraphDeploymentID(
+      'QmULAfA3eS5yojxeSR2KmbyuiwCGYPjymsFcpa6uYsu6CJ',
+    )
+
+    const allocationDecisions = {
+      'eip155:0': [
+        { deployment: a, toAllocate: false },
+        { deployment: b, toAllocate: true },
+      ],
+      'eip155:1': [
+        { deployment: b, toAllocate: true },
+        { deployment: c, toAllocate: false },
+      ],
+      'eip155:2': [
+        { deployment: c, toAllocate: true },
+        { deployment: a, toAllocate: false },
+      ],
+    }
+
+    const expected = new Set([c, b])
+
+    const result = consolidateAllocationDecisions(allocationDecisions)
+
+    expect(result).toStrictEqual(expected)
+    expect(result).toHaveProperty('size', 2)
+    expect(result).toContain(c)
+    expect(result).toContain(b)
+    expect(result).not.toContain(a)
   })
 })

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -540,13 +540,8 @@ export class Agent {
     }).tryMap(
       async ({ indexingRules, networkDeploymentAllocationDecisions }) => {
         logger.trace('Resolving target deployments')
-        const targetDeploymentIDs: Set<SubgraphDeploymentID> = new Set(
-          // Concatenate all AllocationDecisions from all protocol networks
-          Object.values(networkDeploymentAllocationDecisions)
-            .flat()
-            .filter(decision => decision.toAllocate === true)
-            .map(decision => decision.deployment),
-        )
+        const targetDeploymentIDs: Set<SubgraphDeploymentID> =
+          consolidateAllocationDecisions(networkDeploymentAllocationDecisions)
 
         // Add offchain subgraphs to the deployment list from rules
         Object.values(indexingRules)
@@ -1260,4 +1255,19 @@ export class Agent {
       }
     }
   }
+}
+
+export interface AllocationDecisionInterface {
+  toAllocate: boolean
+  deployment: SubgraphDeploymentID
+}
+export function consolidateAllocationDecisions(
+  allocationDecisions: Record<string, AllocationDecisionInterface[]>,
+): Set<SubgraphDeploymentID> {
+  return new Set(
+    Object.values(allocationDecisions)
+      .flat()
+      .filter(decision => decision.toAllocate === true)
+      .map(decision => decision.deployment),
+  )
 }


### PR DESCRIPTION
This PR refactors a small portion of the Reconciliation Loop for easier testing.