### PR TITLE
Update allocation resolverwes to support exponential rebates contract changes

### DIFF
--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -75,7 +75,7 @@ module.exports = {
     try {
       poi = validatePOI(unformattedPoi)
     } catch (error) {
-      spinner.fail(`Invalid POI provided, '${unformattedPoi}'. ` + error.message())
+      spinner.fail(`Invalid POI provided, '${unformattedPoi}'. ` + error.message)
       process.exitCode = 1
       return
     }

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -616,28 +616,27 @@ export default {
         )
       }
 
-      const events = receipt.events || receipt.logs
-      const event =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.staking.interface.getEventTopic('AllocationCreated'),
-          ),
-        )
-      if (!event) {
-        throw indexerError(IndexerErrorCode.IE014, `Allocation was never mined`)
-      }
-
-      const createEvent = contracts.staking.interface.decodeEventLog(
+      const createAllocationEventLogs = network.transactionManager.findEvent(
         'AllocationCreated',
-        event.data,
-        event.topics,
+        network.contracts.staking.interface,
+        'subgraphDeploymentID',
+        subgraphDeployment.toString(),
+        receipt,
+        logger,
       )
 
+      if (!createAllocationEventLogs) {
+        throw indexerError(
+          IndexerErrorCode.IE014,
+          `Allocation create transaction was never mined`,
+        )
+      }
+
       logger.info(`Successfully allocated to subgraph deployment`, {
-        amountGRT: formatGRT(createEvent.tokens),
-        allocation: createEvent.allocationID,
-        epoch: createEvent.epoch.toString(),
+        amountGRT: formatGRT(createAllocationEventLogs.tokens),
+        allocation: createAllocationEventLogs.allocationID,
+        epoch: createAllocationEventLogs.epoch.toString(),
+        transaction: receipt.transactionHash,
       })
 
       logger.debug(
@@ -667,7 +666,7 @@ export default {
         type: 'allocate',
         transactionID: receipt.transactionHash,
         deployment,
-        allocation: createEvent.allocationID,
+        allocation: createAllocationEventLogs.allocationID,
         allocatedTokens: formatGRT(allocationAmount.toString()),
         protocolNetwork,
       }
@@ -758,41 +757,32 @@ export default {
         )
       }
 
-      const events = receipt.events || receipt.logs
+      const closeAllocationEventLogs = transactionManager.findEvent(
+        'AllocationClosed',
+        contracts.staking.interface,
+        'allocationID',
+        allocation,
+        receipt,
+        logger,
+      )
 
-      const closeEvent =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.staking.interface.getEventTopic('AllocationClosed'),
-          ),
-        )
-      if (!closeEvent) {
+      if (!closeAllocationEventLogs) {
         throw indexerError(
-          IndexerErrorCode.IE014,
+          IndexerErrorCode.IE015,
           `Allocation close transaction was never successfully mined`,
         )
       }
-      const closeAllocationEventLogs = contracts.staking.interface.decodeEventLog(
-        'AllocationClosed',
-        closeEvent.data,
-        closeEvent.topics,
+
+      const rewardsEventLogs = transactionManager.findEvent(
+        'RewardsAssigned',
+        contracts.rewardsManager.interface,
+        'allocationID',
+        allocation,
+        receipt,
+        logger,
       )
 
-      const rewardsEvent =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.rewardsManager.interface.getEventTopic('RewardsAssigned'),
-          ),
-        )
-      const rewardsAssigned = rewardsEvent
-        ? contracts.rewardsManager.interface.decodeEventLog(
-            'RewardsAssigned',
-            rewardsEvent.data,
-            rewardsEvent.topics,
-          ).amount
-        : 0
+      const rewardsAssigned = rewardsEventLogs ? rewardsEventLogs.amount : 0
 
       if (rewardsAssigned == 0) {
         logger.warn('No rewards were distributed upon closing the allocation')
@@ -1075,57 +1065,45 @@ export default {
         )
       }
 
-      const events = receipt.events || receipt.logs
-      const createEvent =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.staking.interface.getEventTopic('AllocationCreated'),
-          ),
-        )
-      if (!createEvent) {
+      const createAllocationEventLogs = transactionManager.findEvent(
+        'AllocationCreated',
+        contracts.staking.interface,
+        'subgraphDeploymentID',
+        allocationData.subgraphDeployment.id.toString(),
+        receipt,
+        logger,
+      )
+
+      if (!createAllocationEventLogs) {
         throw indexerError(IndexerErrorCode.IE014, `Allocation was never mined`)
       }
 
-      const createAllocationEventLogs = contracts.staking.interface.decodeEventLog(
-        'AllocationCreated',
-        createEvent.data,
-        createEvent.topics,
+      const closeAllocationEventLogs = transactionManager.findEvent(
+        'AllocationClosed',
+        contracts.staking.interface,
+        'allocationID',
+        allocation,
+        receipt,
+        logger,
       )
 
-      const closeEvent =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.staking.interface.getEventTopic('AllocationClosed'),
-          ),
-        )
-      if (!closeEvent) {
+      if (!closeAllocationEventLogs) {
         throw indexerError(
-          IndexerErrorCode.IE014,
+          IndexerErrorCode.IE015,
           `Allocation close transaction was never successfully mined`,
         )
       }
-      const closeAllocationEventLogs = contracts.staking.interface.decodeEventLog(
-        'AllocationClosed',
-        closeEvent.data,
-        closeEvent.topics,
+
+      const rewardsEventLogs = transactionManager.findEvent(
+        'RewardsAssigned',
+        contracts.rewardsManager.interface,
+        'allocationID',
+        allocation,
+        receipt,
+        logger,
       )
 
-      const rewardsEvent =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        events.find((event: any) =>
-          event.topics.includes(
-            contracts.rewardsManager.interface.getEventTopic('RewardsAssigned'),
-          ),
-        )
-      const rewardsAssigned = rewardsEvent
-        ? contracts.rewardsManager.interface.decodeEventLog(
-            'RewardsAssigned',
-            rewardsEvent.data,
-            rewardsEvent.topics,
-          ).amount
-        : 0
+      const rewardsAssigned = rewardsEventLogs ? rewardsEventLogs.amount : 0
 
       if (rewardsAssigned == 0) {
         logger.warn('No rewards were distributed upon closing the allocation')

--- a/packages/indexer-common/src/transactions.ts
+++ b/packages/indexer-common/src/transactions.ts
@@ -22,6 +22,8 @@ import { IndexerError, indexerError, IndexerErrorCode } from './errors'
 import { TransactionConfig, TransactionType } from './types'
 import { NetworkSubgraph } from './network-subgraph'
 import gql from 'graphql-tag'
+import intersection from 'lodash.intersection'
+import updatedStakingAbi from './abi/stakingUpdatedABI.json'
 
 export class TransactionManager {
   ethereum: providers.BaseProvider
@@ -392,5 +394,64 @@ export class TransactionManager {
         )
         return isOperator
       })
+  }
+
+  findEvent(
+    eventType: string,
+    contractInterface: utils.Interface,
+    logKey: string,
+    logValue: string,
+    receipt: ContractReceipt,
+    logger: Logger,
+  ): utils.Result | undefined {
+    const events: Event[] | providers.Log[] = receipt.events || receipt.logs
+    const decodedEvents: utils.Result[] = []
+    const updatedStakingIface = new utils.Interface(updatedStakingAbi)
+
+    // With exponential rebates, the AllocationClosed event changed signature
+    // so it has a different topic. Until these changes are deployed in both mainnet and
+    // testnet, we need to search for both.
+    // TODO: Update to a new common-ts and remove this hack once exponential rebates is on mainnet
+    const newAbiTopic = updatedStakingIface.getEventTopic('AllocationClosed')
+    const expectedTopics = [contractInterface.getEventTopic(eventType)]
+    if (eventType == 'AllocationClosed') {
+      expectedTopics.push(newAbiTopic)
+    }
+
+    const result = events
+      .filter((event) => intersection(event.topics, expectedTopics).length > 0)
+      .map((event) => {
+        let decoded: utils.Result
+        if (eventType == 'AllocationClosed' && event.topics.includes(newAbiTopic)) {
+          decoded = updatedStakingIface.decodeEventLog(
+            eventType,
+            event.data,
+            event.topics,
+          )
+        } else {
+          decoded = contractInterface.decodeEventLog(eventType, event.data, event.topics)
+        }
+        decodedEvents.push(decoded)
+        return decoded
+      })
+      .find(
+        (eventLogs: utils.Result) =>
+          eventLogs[logKey].toLocaleLowerCase() === logValue.toLocaleLowerCase(),
+      )
+
+    logger.trace('Searched for event logs', {
+      function: 'findEvent',
+      expectedTopics,
+      events,
+      decodedEvents,
+      eventType,
+      logKey,
+      logValue,
+      receipt,
+      found: !!result,
+      result,
+    })
+
+    return result
   }
 }


### PR DESCRIPTION
#### Changes
- Move `findEvent()` function to `TransactionManager`, so it can be used in `allocations` resolvers. `findEvent()` contains the update to flexible ABI usage that was used to support the transition to exponential rebates. 
- Fix log message bug in `allocations close` CLI command function