### PR TITLE
Update feature-support-matrix.md w/ Graph Node v0.33.0 as minimum ver…

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -33,7 +33,7 @@ The accepted `graph-node` version range must always be specified; it always comp
 The latest for the feature matrix above:
 
 ```
-graph-node: >=0.32 <0.33
+graph-node: >=0.33.0 <0.34.0
 ```
 
 ### Latest Council snapshot


### PR DESCRIPTION
There is a new Graph Node pre-release [v0.33.0-rc.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.33.0-rc.0).

As usual, A GGP (Graph Governance Proposal) will be created as a snapshot vote for Council approval. Once ratified, Graph Node v0.33.0 will be released for mainnet adoption, and this PR will be merged.