### PR TITLE
Adding optimism to feature support matrix

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -23,6 +23,7 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:43114             | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:250               | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:137               | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:10                | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features** |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings     |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                      |               | Yes         | Yes          | No                | No                   | No               |

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -28,7 +28,9 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | ipfs.cat in mappings     |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                      |               | Yes         | Yes          | No                | No                   | No               |
 | File data sources: IPFS  |               | Yes         | Yes          | No                | Yes                  | Yes              |
-| Substreams data sources  | mainnet       | Yes         | Yes          | Yes               | Yes                  | Yes              | 
+| Substreams: mainnet      |               | Yes         | Yes          | Yes               | Yes                  | Yes              | 
+| Substreams: optimism     |               | Yes         | Yes          | Yes               | Yes                  | Yes              | 
+
 
 The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it. 
 The latest for the feature matrix above:


### PR DESCRIPTION
As part of the Chain Integration Process, InfraDAO (4 different Indexers) has tested Optimism, as a new Graph Node data source, by syncing nodes and locally testing subgraphs, digging into data determinsm with the help of Graphix. All findings are now being shared with the Council, [who will vote](https://snapshot.org/#/council.graphprotocol.eth) on supporting Optimism subgraphs on mainnet (supported features detailed in the matrix). 

This PR should be merged only if voted in favor by the Council. A link to the snapshot vote will be shared here too, once available. 