### PR TITLE
common: Reduce stringency of action validation when adding to queue

### DIFF
--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -1,5 +1,6 @@
 import { NetworkMonitor } from './indexer-management'
 import { AllocationStatus } from './allocations'
+import { Logger } from '@graphprotocol/common-ts'
 import { WhereOperators, WhereOptions } from 'sequelize'
 import { Op } from 'sequelize'
 import { WhereAttributeHashValue } from 'sequelize/types/model'
@@ -81,6 +82,7 @@ export const isValidActionInput = (
 export const validateActionInputs = async (
   actions: ActionInput[],
   networkMonitor: NetworkMonitor,
+  logger: Logger,
 ): Promise<void> => {
   // Validate actions before adding to queue
   // TODO: Perform all checks simultaneously and throw combined error if 1 or more fail
@@ -125,7 +127,7 @@ export const validateActionInputs = async (
       action.deploymentID,
     )
     if (!subgraphDeployment) {
-      throw new Error(
+      logger.warn(
         `No subgraphDeployment with ipfsHash = '${action.deploymentID}' found on the network`,
       )
     }

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
@@ -28,7 +28,6 @@ import {
 import { CombinedError } from '@urql/core'
 import { GraphQLError } from 'graphql'
 import {
-  allocateToNotPublishedDeployment,
   createTestManagementClient,
   invalidReallocateAction,
   invalidUnallocateAction,
@@ -36,7 +35,6 @@ import {
   subgraphDeployment1,
   subgraphDeployment2,
   subgraphDeployment3,
-  notPublishedSubgraphDeployment,
 } from '../util'
 
 const QUEUE_ACTIONS_MUTATION = gql`
@@ -630,23 +628,6 @@ describe('Actions', () => {
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.actions', [expectedUpdated])
-  })
-
-  test('Reject action with deployment not on network', async () => {
-    const inputActions = [allocateToNotPublishedDeployment]
-
-    await expect(
-      client.mutation(QUEUE_ACTIONS_MUTATION, { actions: inputActions }).toPromise(),
-    ).resolves.toHaveProperty(
-      'error',
-      new CombinedError({
-        graphQLErrors: [
-          new GraphQLError(
-            `No subgraphDeployment with ipfsHash = '${notPublishedSubgraphDeployment}' found on the network`,
-          ),
-        ],
-      }),
-    )
   })
 
   test('Reject unallocate action with inactive allocationID', async () => {

--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -132,25 +132,11 @@ export const defaults: IndexerManagementDefaults = {
 export const subgraphDeployment1 = 'Qmew9PZUJCoDzXqqU6vGyTENTKHrrN4dy5h94kertfudqy'
 export const subgraphDeployment2 = 'QmWq1pmnhEvx25qxpYYj9Yp6E1xMKMVoUjXVQBxUJmreSe'
 export const subgraphDeployment3 = 'QmRhH2nhNibDVPZmYqq3TUZZARZ77vgjYCvPNiGBCogtgM'
-export const notPublishedSubgraphDeployment =
-  'QmeqJ6hsdyk9dVbo1tvRgAxWrVS3rkERiEMsxzPShKLco6'
 
 export const queuedAllocateAction = {
   status: ActionStatus.QUEUED,
   type: ActionType.ALLOCATE,
   deploymentID: subgraphDeployment1,
-  amount: '10000',
-  force: false,
-  source: 'indexerAgent',
-  reason: 'indexingRule',
-  priority: 0,
-  protocolNetwork: 'goerli',
-} as ActionInput
-
-export const allocateToNotPublishedDeployment = {
-  status: ActionStatus.QUEUED,
-  type: ActionType.ALLOCATE,
-  deploymentID: notPublishedSubgraphDeployment,
   amount: '10000',
   force: false,
   source: 'indexerAgent',

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -173,7 +173,7 @@ export default {
     await multiNetworks.mapNetworkMapped(
       groupBy(actions, (action) => action.protocolNetwork),
       (network: Network, actions: ActionInput[]) =>
-        validateActionInputs(actions, network.networkMonitor),
+        validateActionInputs(actions, network.networkMonitor, logger),
     )
 
     const alreadyQueuedActions = await ActionManager.fetchActions(models, {


### PR DESCRIPTION
### Changes
- Remove the check that confirms the deployment is already published to the network; to avoid race conditions waiting for the network subgraph to update. In the case that the deployment cannot be found on the network emit a warning and continue.