### PR TITLE
agent: if alias does not exist try the actual flag

### DIFF
--- a/packages/indexer-agent/src/commands/start-multi-network.ts
+++ b/packages/indexer-agent/src/commands/start-multi-network.ts
@@ -28,7 +28,7 @@ export function parseNetworkSpecifications(
   argv: any,
   logger: Logger,
 ): spec.NetworkSpecification[] {
-  const dir: string = argv.dir
+  const dir: string = argv.dir || argv['network-specifications-directory']
   const yamlFiles = scanDirectoryForYamlFiles(dir, logger)
   return parseYamlFiles(yamlFiles)
 }


### PR DESCRIPTION
when trying to run locally for some reason `yargs` doesn't show me `dir` as a parsed arg, I would expect it to create aliases automatically so we can reference it. But adding this as safe guards for anyone it doesn't work.