### PR TITLE
common: log endpoint in freshness checker

### DIFF
--- a/packages/indexer-common/src/epoch-subgraph.ts
+++ b/packages/indexer-common/src/epoch-subgraph.ts
@@ -8,12 +8,14 @@ export class EpochSubgraph {
   endpointClient: AxiosInstance
   freshnessChecker: SubgraphFreshnessChecker
   logger: Logger
+  endpoint: string
 
   constructor(
     endpoint: string,
     freshnessChecker: SubgraphFreshnessChecker,
     logger: Logger,
   ) {
+    this.endpoint = endpoint
     this.endpointClient = axios.create({
       baseURL: endpoint,
       headers: { 'content-type': 'application/json' },

--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -128,11 +128,15 @@ export class GraphNode {
   // AxiosClient factory scoped by subgraph IFPS hash
   getQueryClient(deploymentIpfsHash: string): AxiosInstance {
     return axios.create({
-      baseURL: new URL(deploymentIpfsHash, this.queryBaseURL).toString(),
+      baseURL: this.getQueryEndpoint(deploymentIpfsHash),
       headers: { 'content-type': 'application/json' },
       responseType: 'text', // Don't parse responses as JSON
       transformResponse: (data) => data, // Don't transform responses
     })
+  }
+
+  getQueryEndpoint(deploymentIpfsHash: string): string {
+    return new URL(deploymentIpfsHash, this.queryBaseURL).toString()
   }
 
   public async subgraphDeployments(): Promise<SubgraphDeploymentID[]> {

--- a/packages/indexer-common/src/subgraphs.ts
+++ b/packages/indexer-common/src/subgraphs.ts
@@ -344,6 +344,7 @@ export interface SubgraphQueryInterface {
     query: DocumentNode,
     variables?: Record<string, any>,
   ): Promise<QueryResult<Data>>
+  endpoint?: string
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -427,6 +428,7 @@ export class SubgraphFreshnessChecker {
       this.logger.error(errorMsg, {
         subgraph: this.subgraphName,
         query: print(updatedQuery),
+        endpoint: subgraph.endpoint,
       })
       throw new Error(errorMsg)
     }
@@ -455,6 +457,7 @@ export class SubgraphFreshnessChecker {
         subgraph: this.subgraphName,
         error: queryShapeError,
         subgraphQueryResult,
+        endpoint: subgraph.endpoint,
       })
       throw new Error(errorMsg)
     }
@@ -471,6 +474,7 @@ export class SubgraphFreshnessChecker {
       freshnessThreshold: this.threshold,
       subgraph: this.subgraphName,
       retriesLeft,
+      endpoint: subgraph.endpoint,
     }
     this.logger.trace('Performing subgraph freshness check', logInfo)
 


### PR DESCRIPTION
Today indexers do not have a way to know what subgraph is "not fresh" this PR aims to introduce the `endpoint` of subgraph we consider is "not fresh" in the freshness checker

closes https://github.com/graphprotocol/indexer/issues/803

