### PR TITLE
feat(indexer-service): Add graph-node version endpoint from status api

### DIFF
--- a/packages/indexer-service/src/server/status.ts
+++ b/packages/indexer-service/src/server/status.ts
@@ -34,7 +34,7 @@ export const createStatusServer = async ({
     'cachedEthereumCalls',
     'subgraphFeatures',
     'apiVersions',
-    'versions',
+    'version',
   ]
   const filteredSchema = wrapSchema({
     schema,

--- a/packages/indexer-service/src/server/status.ts
+++ b/packages/indexer-service/src/server/status.ts
@@ -34,6 +34,7 @@ export const createStatusServer = async ({
     'cachedEthereumCalls',
     'subgraphFeatures',
     'apiVersions',
+    'versions',
   ]
   const filteredSchema = wrapSchema({
     schema,


### PR DESCRIPTION
The graph-node is exposing the version information using the following struct, however, it's not exposed through the indexer-service status endpoint. 

This PR adds that information so that the gateway can have access to it.

```
struct Version {
    version: String,
    commit: String,
}
```
