### PR TITLE
agent,common: Improve control of subgraph deployment health safety check

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -356,12 +356,6 @@ export class AllocationManager {
         `Subgraph deployment, '${deployment.ipfsHash}', is not syncing`,
       )
     }
-    if (status && status.health == 'failed') {
-      throw indexerError(
-        IndexerErrorCode.IE020,
-        `Subgraph deployment, '${deployment.ipfsHash}', failed during syncing`,
-      )
-    }
 
     logger.debug('Obtain a unique Allocation ID')
     const { allocationSigner, allocationId } = uniqueAllocationID(


### PR DESCRIPTION
## Effect
- Allow indexers to control the subgraph deployment safety check: 
    - Set `indexingRule.safety = true` to turn on the deployment health check. The agent will _not_ allocate to the deployment if it has `health = failed`.
    - Set `indexingRule.safety = false or null` to turn off the deployment health check. The agent will still allocate to  subgraph deployments with `health = failed`.
    
## Changes
- Move the deployment health check to earlier in the decision process, within `reconcileDeploymentAllocationAction()`.  This gives the check access to the indexingRule so it can use the `safety` property, it also is useful to prevent action from being added to the queue in the first place. In the previous/current setup the action does not included in a transaction but it will remain in the queue and continue to be retried.