### PR TITLE
Docs: updated feature support matrix with Graph Node v0.34.1

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -40,7 +40,7 @@ graph-node: >=0.34.1 <0.35.0
 ```
 
 ### Latest Council snapshot
-[GPP-0028 Update Feature Support Matrix (Graph Node v0.32.0)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xa7dcaf27d3b8cb6c135c398753a82fb4a6fc1ff5ad666cb131109f2de506253c)
+[GPP-0037 Update Feature Support Matrix (Graph Node v0.34.1)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x840a7de34b1dac9c7ef03d3170540abc5957ffd00564777aac9b253068a93723)
 
 
 

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -36,7 +36,7 @@ The accepted `graph-node` version range must always be specified; it always comp
 The latest for the feature matrix above:
 
 ```
-graph-node: >=0.33.0 <0.34.0
+graph-node: >=0.34.1 <0.35.0
 ```
 
 ### Latest Council snapshot


### PR DESCRIPTION
Updated the Feature Matrix Support with the recommended minimum Graph Node version version [v0.34.1](https://github.com/graphprotocol/graph-node/releases/tag/untagged-d207d57ec36b1c1623ac).

Next steps:
1. @PedroMD creates the GGP (Graph Governance Proposal) referencing this PR (https://snapshot.org/#/council.graphprotocol.eth).
2. Council votes on the proposal, ratifying the latest Feature Matrix Support.
3. @PedroMD adds the proposal link to the matrix and merges this PR.