### PR TITLE
Support Cost models on Arbitrum

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "prepare": "lerna run prepare",
+    "format": "lerna run format",
     "release": "./scripts/release.sh",
     "test": "lerna --concurrency 1 run test --stream --ignore @graphprotocol/indexer-service",
     "test:ci": "lerna --concurrency 1 run test:ci --stream --ignore @graphprotocol/indexer-service",

--- a/packages/indexer-agent/src/db/migrations/12-add-protocol-network-field-cost-model.ts
+++ b/packages/indexer-agent/src/db/migrations/12-add-protocol-network-field-cost-model.ts
@@ -1,0 +1,61 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { caip2IdRegex } from '@graphprotocol/indexer-common'
+import { DataTypes, QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.debug(`Checking if 'CostModel' table exists`)
+  const tables = await queryInterface.showAllTables()
+  if (!tables.includes('CostModel')) {
+    logger.info(`Indexing rules table does not exist, migration not necessary`)
+    return
+  }
+
+  logger.debug(`Checking if 'CostModel' table needs to be migrated`)
+  const table = await queryInterface.describeTable('CostModel')
+  const protocolNetwork = table.protocolNetwork
+  if (protocolNetwork) {
+    logger.info(
+      `'protocolNetwork' column already exist, migration not necessary`,
+    )
+    return
+  }
+
+  logger.info(`Add 'protocolNetwork' column to 'CostModel' table`)
+  await queryInterface.addColumn('CostModel', 'protocolNetwork', {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      is: caip2IdRegex,
+    },
+  })
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  return await queryInterface.sequelize.transaction({}, async transaction => {
+    const tables = await queryInterface.showAllTables()
+
+    if (tables.includes('CostModel')) {
+      logger.info(`Remove 'protocolNetwork' column`)
+      await context.queryInterface.removeColumn(
+        'CostModel',
+        'protocolNetwork',
+        {
+          transaction,
+        },
+      )
+    }
+  })
+}

--- a/packages/indexer-cli/src/commands/indexer/cost/set/model.ts
+++ b/packages/indexer-cli/src/commands/indexer/cost/set/model.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 import { loadValidatedConfig } from '../../../../config'
 import { createIndexerManagementClient } from '../../../../client'
-import { fixParameters } from '../../../../command-helpers'
+import { extractProtocolNetworkOption, fixParameters } from '../../../../command-helpers'
 import {
   parseCostModel,
   parseDeploymentID,
@@ -18,7 +18,7 @@ ${chalk.bold('graph indexer cost set model')} [options] <deployment-id> <file>
 ${chalk.bold('graph indexer cost set model')} [options] global <file>
 
 ${chalk.dim('Options:')}
-
+  -n, --network                 Protocol network
   -h, --help                    Show usage information
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
 `
@@ -31,6 +31,13 @@ module.exports = {
     const { print, parameters } = toolbox
 
     const { h, help, merged, o, output } = parameters.options
+
+    const protocolNetwork = extractProtocolNetworkOption(parameters.options, true)
+
+    if (!protocolNetwork) {
+      throw new Error('Protocol network is required')
+    }
+
     const [deployment, filename] = fixParameters(parameters, { h, help, merged }) || []
     const outputFormat = o || output || 'table'
 
@@ -69,6 +76,7 @@ module.exports = {
       deployment,
       model,
       variables: null,
+      protocolNetwork,
     })
 
     try {

--- a/packages/indexer-cli/src/cost.ts
+++ b/packages/indexer-cli/src/cost.ts
@@ -204,6 +204,7 @@ export const costModels = async (
           deployment
           model
           variables
+          protocolNetwork
         }
       }
     `)
@@ -228,6 +229,7 @@ export const costModel = async (
             deployment
             model
             variables
+            protocolNetwork
           }
         }
       `,
@@ -258,6 +260,7 @@ export const setCostModel = async (
             deployment
             model
             variables
+            protocolNetwork
           }
         }
       `,
@@ -284,6 +287,7 @@ export const deleteCostModels = async (
             deployment
             model
             variables
+            protocolNetwork
           }
         }
       `,

--- a/packages/indexer-cli/src/cost.ts
+++ b/packages/indexer-cli/src/cost.ts
@@ -3,6 +3,7 @@ import {
   CostModelAttributes,
   GraphQLCostModel,
   IndexerManagementClient,
+  validateNetworkIdentifier,
 } from '@graphprotocol/indexer-common'
 import gql from 'graphql-tag'
 import yaml from 'yaml'
@@ -30,6 +31,7 @@ const COST_MODEL_PARSERS: Record<keyof CostModelAttributes, (x: never) => any> =
   deployment: parseDeploymentID,
   model: x => x,
   variables: nullPassThrough(JSON.parse),
+  protocolNetwork: x => validateNetworkIdentifier(x),
 }
 
 const COST_MODEL_FORMATTERS: Record<
@@ -40,6 +42,7 @@ const COST_MODEL_FORMATTERS: Record<
   deployment: (d: SubgraphDeploymentIDIsh) => (typeof d === 'string' ? d : d.ipfsHash),
   model: x => x,
   variables: nullPassThrough(s => JSON.stringify(s, null, 2)),
+  protocolNetwork: x => validateNetworkIdentifier(x),
 }
 
 const COST_MODEL_CONVERTERS_FROM_GRAPHQL: Record<
@@ -51,6 +54,7 @@ const COST_MODEL_CONVERTERS_FROM_GRAPHQL: Record<
   deployment: parseDeploymentID,
   model: x => x,
   variables: nullPassThrough(JSON.parse),
+  protocolNetwork: x => validateNetworkIdentifier(x),
 }
 
 const COST_MODEL_CONVERTERS_TO_GRAPHQL: Record<
@@ -62,6 +66,7 @@ const COST_MODEL_CONVERTERS_TO_GRAPHQL: Record<
   deployment: (x: SubgraphDeploymentIDIsh) => x.toString(),
   model: x => x,
   variables: nullPassThrough(JSON.stringify),
+  protocolNetwork: x => validateNetworkIdentifier(x),
 }
 
 /**

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -360,12 +360,14 @@ const SCHEMA_SDL = gql`
     deployment: String!
     model: String
     variables: String
+    protocolNetwork: String!
   }
 
   input CostModelInput {
     deployment: String!
     model: String
     variables: String
+    protocolNetwork: String!
   }
 
   type Query {

--- a/packages/indexer-common/src/indexer-management/models/cost-model.ts
+++ b/packages/indexer-common/src/indexer-management/models/cost-model.ts
@@ -2,7 +2,7 @@
 
 import { Optional, Model, DataTypes, Sequelize } from 'sequelize'
 import { utils } from 'ethers'
-import { validateNetworkIdentifier } from '../../parsers/validators'
+import { caip2IdRegex } from '../../parsers/validators'
 
 export interface GraphQLCostModel {
   deployment: string
@@ -108,18 +108,7 @@ export const defineCostModelModels = (sequelize: Sequelize): CostModelModels => 
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
-          isProtocolNetwork: (value: string) => {
-            if (typeof value !== 'string') {
-              throw new Error('Protocol network must be a string')
-            }
-
-            // must be `eip155:`
-            if (validateNetworkIdentifier(value)) {
-              return
-            }
-
-            throw new Error(`Protocol network must be a valid 'eip155' network`)
-          },
+          is: caip2IdRegex,
         },
       },
       model: {

--- a/packages/indexer-service/src/server/cost.ts
+++ b/packages/indexer-service/src/server/cost.ts
@@ -94,6 +94,7 @@ export const createCostServer = async ({
         deployment: String!
         model: String
         variables: String
+        protocolNetwork: String!
       }
 
       type Query {
@@ -126,6 +127,7 @@ export const createCostServer = async ({
                       deployment
                       model
                       variables
+                      protocolNetwork
                     }
                   }
                 `,
@@ -172,6 +174,7 @@ export const createCostServer = async ({
                       deployment
                       model
                       variables
+                      protocolNetwork
                     }
                   }
                 `,


### PR DESCRIPTION
- [X] Create `protocolNetwork` on `CostModel` table
- [x] Write migration for `protocolNetwork` 
- [ ] Write a  backfill script for existing `CostModel`s
- [X] `graph indexer cost set model` command to require `--network` flag
  - [ ] write tests  
- [X] Return `protocolNetwork` from `/cost` endpoint
- [ ] Use the Mainnet contracts for GRT/DAI price conversion