### PR TITLE
fix: rollback cost-model to v0.1.16

### DIFF
--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphprotocol/common-ts": "2.0.9",
-    "@graphprotocol/cost-model": "0.1.18",
+    "@graphprotocol/cost-model": "0.1.16",
     "@thi.ng/heaps": "1.2.38",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.intersection": "^4.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,13 +895,13 @@
     console-table-printer "^2.11.1"
     ethers "^5.6.0"
 
-"@graphprotocol/cost-model@0.1.18":
-  version "0.1.18"
-  resolved "https://registry.npmjs.org/@graphprotocol/cost-model/-/cost-model-0.1.18.tgz"
-  integrity sha512-OZGQwUi5+YQM/mT/Zei09P5S28YYbP+YDFI8sZnJmqp6OrDTxD3f6L9E6upcxzqRxgXqewJC3JBwSC1D0wMs4g==
+"@graphprotocol/cost-model@0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/cost-model/-/cost-model-0.1.16.tgz#42e6889a23934f293f119db9ac23159be019df0c"
+  integrity sha512-oDBhXH4sdKLduw0PgcK6rWPrzqJ4eFH9BTWz81c2iMIdTrm3n92eixCrhTwB3Nd1JpM1y0Bz9sMIvRGvC6htoA==
   dependencies:
-    "@mapbox/node-pre-gyp" "1.0.11"
-    cargo-cp-artifact "0.1.8"
+    "@mapbox/node-pre-gyp" "1.0.9"
+    cargo-cp-artifact "0.1.6"
 
 "@graphprotocol/pino-sentry-simple@0.7.1":
   version "0.7.1"
@@ -2096,6 +2096,21 @@
   version "1.0.11"
   resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz"
   integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
+  dependencies:
+    detect-libc "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.7"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
+"@mapbox/node-pre-gyp@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
+  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
   dependencies:
     detect-libc "^2.0.0"
     https-proxy-agent "^5.0.0"
@@ -4657,6 +4672,11 @@ caniuse-lite@^1.0.30001517:
   version "1.0.30001538"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz"
   integrity sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==
+
+cargo-cp-artifact@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz#df1bc9dad036ae0f4230639a869182e1d5850f89"
+  integrity sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==
 
 cargo-cp-artifact@0.1.8:
   version "0.1.8"


### PR DESCRIPTION
This gets us back to a situation where we can build & test the main branch on the local network.