### PR TITLE
indexer-agent: Leave subgraph deployment assignment decisions to graph-node

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -134,14 +134,11 @@ const setup = async () => {
   queryFeeModels = defineQueryFeeModels(sequelize)
   sequelize = await sequelize.sync({ force: true })
 
-  const indexNodeIDs = ['node_1']
-
   graphNode = new GraphNode(
     logger,
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    indexNodeIDs,
   )
 
   const yamlObj = loadTestYamlConfig()
@@ -163,7 +160,6 @@ const setup = async () => {
   indexerManagementClient = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults: {
       globalIndexingRule: {

--- a/packages/indexer-agent/src/commands/common-options.ts
+++ b/packages/indexer-agent/src/commands/common-options.ts
@@ -7,21 +7,6 @@ import { parseDeploymentManagementMode } from '@graphprotocol/indexer-common'
 // Injects all CLI options shared between this module's commands into a `yargs.Argv` object.
 export function injectCommonStartupOptions(argv: Argv): Argv {
   argv
-    .option('index-node-ids', {
-      description:
-        'Node IDs of Graph nodes to use for indexing (separated by commas)',
-      type: 'string',
-      array: true,
-      required: true,
-      coerce: (
-        arg, // TODO: we shouldn't need to coerce because yargs already separates values by space
-      ) =>
-        arg.reduce(
-          (acc: string[], value: string) => [...acc, ...value.split(',')],
-          [],
-        ),
-      group: 'Indexer Infrastructure',
-    })
     .option('indexer-management-port', {
       description: 'Port to serve the indexer management API at',
       type: 'number',

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -514,7 +514,6 @@ export async function run(
     argv.graphNodeAdminEndpoint,
     argv.graphNodeQueryEndpoint,
     argv.graphNodeStatusEndpoint,
-    argv.indexNodeIds,
   )
 
   // --------------------------------------------------------------------------------
@@ -615,7 +614,6 @@ export async function run(
   const indexerManagementClient = await createIndexerManagementClient({
     models: managementModels,
     graphNode,
-    indexNodeIDs: argv.indexNodeIds,
     logger,
     defaults: {
       globalIndexingRule: {

--- a/packages/indexer-cli/src/__tests__/util.ts
+++ b/packages/indexer-cli/src/__tests__/util.ts
@@ -83,13 +83,11 @@ export const setup = async (multiNetworksEnabled: boolean) => {
   sequelize = await sequelize.sync({ force: true })
 
   const statusEndpoint = 'http://127.0.0.1:8030/graphql'
-  const indexNodeIDs = ['node_1']
   const graphNode = new GraphNode(
     logger,
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    indexNodeIDs,
   )
 
   const network = await Network.create(
@@ -122,7 +120,6 @@ export const setup = async (multiNetworksEnabled: boolean) => {
   indexerManagementClient = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults,
     multiNetworks,

--- a/packages/indexer-common/src/allocations/__tests__/tap.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap.test.ts
@@ -51,7 +51,6 @@ const setup = async () => {
     'https://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    [],
   )
 
   const network = await Network.create(

--- a/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
@@ -56,7 +56,6 @@ const setup = async () => {
     'https://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    [],
   )
 
   const network = await Network.create(

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -101,7 +101,6 @@ const setupMonitor = async () => {
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    [],
   )
 
   const indexerOptions = spec.IndexerOptions.parse({

--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -41,9 +41,7 @@ export const createTestManagementClient = async (
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    [],
   )
-  const indexNodeIDs = ['node_1']
 
   const networkSpecification = { ...testNetworkSpecification }
   networkSpecification.dai.inject = injectDai
@@ -78,7 +76,6 @@ export const createTestManagementClient = async (
   return await createIndexerManagementClient({
     models: managementModels,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults,
     multiNetworks,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -453,10 +453,6 @@ export interface IndexerManagementClientOptions {
   logger: Logger
   models: IndexerManagementModels
   graphNode: GraphNode
-  // TODO:L2: Do we need this information? The GraphNode class auto-selects nodes based
-  // on availability.
-  // Ford: there were some edge cases where the GraphNode was not able to auto handle it on its own
-  indexNodeIDs: string[]
   multiNetworks: MultiNetworks<Network> | undefined
   defaults: IndexerManagementDefaults
 }

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -318,7 +318,6 @@ export default {
       'http://fake-graph-node-admin-endpoint',
       argv.graphNodeQueryEndpoint,
       argv.graphNodeStatusEndpoint,
-      argv.indexNodeIds,
     )
 
     const networkProvider = await Network.provider(
@@ -483,7 +482,6 @@ export default {
     const indexerManagementClient = await createIndexerManagementClient({
       models,
       graphNode,
-      indexNodeIDs: ['node_1'], // This is just a dummy since the indexer-service doesn't manage deployments,
       logger,
       defaults: {
         // This is just a dummy, since we're never writing to the management

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -64,10 +64,7 @@ const setup = async () => {
   contracts = await connectContracts(getTestProvider('sepolia'), 11155111, undefined)
   sequelize = await sequelize.sync({ force: true })
   const statusEndpoint = 'http://127.0.0.1:8030/graphql'
-  indexingStatusResolver = new IndexingStatusResolver({
-    logger: logger,
-    statusEndpoint,
-  })
+  const queryEndpoint = 'http://127.0.0.1:8000/'
 
   const INDEXER_TEST_API_KEY: string = process.env['INDEXER_TEST_API_KEY'] || ''
   networkSubgraph = await NetworkSubgraph.create({
@@ -75,7 +72,6 @@ const setup = async () => {
     endpoint: `https://gateway-arbitrum.network.thegraph.com/api/${INDEXER_TEST_API_KEY}/subgraphs/name/graphprotocol/graph-network-arbitrum-sepolia`,
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
 
   const graphNode = new GraphNode(
     logger,
@@ -84,12 +80,10 @@ const setup = async () => {
     'http://fake-graph-node-admin-endpoint',
     queryEndpoint,
     statusEndpoint,
-    indexNodeIDs,
   )
   client = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults: {
       // This is just a dummy, since we're never writing to the management


### PR DESCRIPTION
[Hands off the assignments](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTd2ZHhyenNxd29sYjE3aWdxNWFxbDVrb3R5azF5bXBybWYyMDd2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jtKYsTf4BtrzzaMfMT/giphy.gif)

Resolve #853 

### Changes
- Use recently added subgraph_pause method to explicitly pause subgraph deployments rather than virtually pausing them by assigning to a non-existent index node
- Remove index-node-ids startup parameter from indexer-agent
- Never send an index-node-id param with subgraph_deploy requests, the receiving graph-node will make the index-node-id decision based on the graph-node.toml config file