### PR TITLE
agent,common: Migrate subgraph deployment assignments to use explicit 'paused' mechanism

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -134,14 +134,11 @@ const setup = async () => {
   queryFeeModels = defineQueryFeeModels(sequelize)
   sequelize = await sequelize.sync({ force: true })
 
-  const indexNodeIDs = ['node_1']
-
   graphNode = new GraphNode(
     logger,
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    indexNodeIDs,
   )
 
   const yamlObj = loadTestYamlConfig()
@@ -163,7 +160,6 @@ const setup = async () => {
   indexerManagementClient = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults: {
       globalIndexingRule: {

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -990,7 +990,7 @@ export class Agent {
 
     // Stop indexing deployments that are no longer worth indexing
     await queue.addAll(
-      remove.map(deployment => async () => this.graphNode.remove(deployment)),
+      remove.map(deployment => async () => this.graphNode.pause(deployment)),
     )
 
     await queue.onIdle()

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -36,6 +36,7 @@ import {
   networkIsL2,
   networkIsL1,
   DeploymentManagementMode,
+  SubgraphStatus,
 } from '@graphprotocol/indexer-common'
 
 import PQueue from 'p-queue'
@@ -970,6 +971,8 @@ export class Agent {
     // Deploy/remove up to 10 subgraphs in parallel
     const queue = new PQueue({ concurrency: 10 })
 
+    const currentAssignments =
+      await this.graphNode.subgraphDeploymentsAssignments(SubgraphStatus.ALL)
     // Index all new deployments worth indexing
     await queue.addAll(
       deploy.map(deployment => async () => {
@@ -981,7 +984,7 @@ export class Agent {
         })
 
         // Ensure the deployment is deployed to the indexer
-        await this.graphNode.ensure(name, deployment)
+        await this.graphNode.ensure(name, deployment, currentAssignments)
       }),
     )
 

--- a/packages/indexer-agent/src/commands/common-options.ts
+++ b/packages/indexer-agent/src/commands/common-options.ts
@@ -7,21 +7,6 @@ import { parseDeploymentManagementMode } from '@graphprotocol/indexer-common'
 // Injects all CLI options shared between this module's commands into a `yargs.Argv` object.
 export function injectCommonStartupOptions(argv: Argv): Argv {
   argv
-    .option('index-node-ids', {
-      description:
-        'Node IDs of Graph nodes to use for indexing (separated by commas)',
-      type: 'string',
-      array: true,
-      required: true,
-      coerce: (
-        arg, // TODO: we shouldn't need to coerce because yargs already separates values by space
-      ) =>
-        arg.reduce(
-          (acc: string[], value: string) => [...acc, ...value.split(',')],
-          [],
-        ),
-      group: 'Indexer Infrastructure',
-    })
     .option('indexer-management-port', {
       description: 'Port to serve the indexer management API at',
       type: 'number',

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -558,6 +558,7 @@ export async function run(
         logger,
         graphNodeAdminEndpoint: argv.graphNodeAdminEndpoint,
         networkSpecifications,
+        graphNode: graphNode,
       },
       storage: new SequelizeStorage({ sequelize }),
       logger: console,

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -514,7 +514,6 @@ export async function run(
     argv.graphNodeAdminEndpoint,
     argv.graphNodeQueryEndpoint,
     argv.graphNodeStatusEndpoint,
-    argv.indexNodeIds,
   )
 
   // --------------------------------------------------------------------------------
@@ -615,7 +614,6 @@ export async function run(
   const indexerManagementClient = await createIndexerManagementClient({
     models: managementModels,
     graphNode,
-    indexNodeIDs: argv.indexNodeIds,
     logger,
     defaults: {
       globalIndexingRule: {

--- a/packages/indexer-agent/src/db/migrations/14-use-new-deployment-pause-mechanism.ts
+++ b/packages/indexer-agent/src/db/migrations/14-use-new-deployment-pause-mechanism.ts
@@ -1,0 +1,82 @@
+import { Logger } from '@graphprotocol/common-ts'
+import {
+  GraphNode,
+  specification,
+  SubgraphStatus,
+} from '@graphprotocol/indexer-common'
+import { QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+  networkSpecifications: specification.NetworkSpecification[]
+  graphNode: GraphNode
+  nodeIds: string[]
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { logger, graphNode } = context
+  logger.info(
+    'Begin up migration: migrate subgraph deployment assignments to new pause mechanism',
+  )
+
+  const indexNodes = (await graphNode.indexNodes()).filter(
+    (node: { id: string; deployments: Array<string> }) => {
+      return node.id && node.id !== 'removed'
+    },
+  )
+  logger.info('Index nodes', {
+    indexNodes,
+  })
+
+  const targetNode =
+    indexNodes.sort((nodeA, nodeB) => {
+      return nodeA.deployments.length - nodeB.deployments.length
+    })[0]?.id || 'default'
+
+  const virtuallyPausedDeploymentAssignments =
+    await graphNode.subgraphDeploymentsAssignments(SubgraphStatus.PAUSED)
+
+  logger.info(
+    'Reassigning paused subgraphs to valid node_id (targetNode), then pausing',
+    {
+      pausedSubgraphs: virtuallyPausedDeploymentAssignments.map(
+        details => details.id,
+      ),
+      targetNode,
+    },
+  )
+
+  for (const deploymentAssignment of virtuallyPausedDeploymentAssignments) {
+    await graphNode.reassign(deploymentAssignment.id, targetNode)
+    await graphNode.pause(deploymentAssignment.id)
+    logger.debug('Successfully reassigned and paused deployment', {
+      deployment: deploymentAssignment.id.ipfsHash,
+    })
+  }
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { logger, graphNode } = context
+  logger.info(
+    'Begin down migration: revert to using virtual subgraph deployment pause mechanism',
+  )
+
+  const pausedDeploymentAssignments =
+    await graphNode.subgraphDeploymentsAssignments(SubgraphStatus.PAUSED)
+
+  logger.info(`Reassigning paused subgraphs to node_id = 'removed'`, {
+    pausedSubgraphs: pausedDeploymentAssignments.map(details => details.id),
+  })
+
+  for (const deploymentAssignment of pausedDeploymentAssignments) {
+    await graphNode.reassign(deploymentAssignment.id, 'removed')
+    logger.debug(`Successfully reassigned deployment to node_id = 'removed'`, {
+      deployment: deploymentAssignment.id.ipfsHash,
+    })
+  }
+}

--- a/packages/indexer-cli/src/__tests__/util.ts
+++ b/packages/indexer-cli/src/__tests__/util.ts
@@ -83,13 +83,11 @@ export const setup = async (multiNetworksEnabled: boolean) => {
   sequelize = await sequelize.sync({ force: true })
 
   const statusEndpoint = 'http://127.0.0.1:8030/graphql'
-  const indexNodeIDs = ['node_1']
   const graphNode = new GraphNode(
     logger,
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    indexNodeIDs,
   )
 
   const network = await Network.create(
@@ -122,7 +120,6 @@ export const setup = async (multiNetworksEnabled: boolean) => {
   indexerManagementClient = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults,
     multiNetworks,

--- a/packages/indexer-common/src/allocations/__tests__/tap.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap.test.ts
@@ -51,7 +51,6 @@ const setup = async () => {
     'https://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    [],
   )
 
   const network = await Network.create(

--- a/packages/indexer-common/src/allocations/monitor.ts
+++ b/packages/indexer-common/src/allocations/monitor.ts
@@ -152,7 +152,9 @@ export const monitorEligibleAllocations = ({
       const allocations = [...activeAllocations, ...recentlyClosedAllocations]
 
       if (allocations.length == 0) {
-        throw new Error(`No data / indexer not found on chain`)
+        logger.warn(`No data / indexer not found on chain`, {
+          allocations: [],
+        })
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -86,6 +86,8 @@ export enum IndexerErrorCode {
   IE073 = 'IE073',
   IE074 = 'IE074',
   IE075 = 'IE075',
+  IE076 = 'IE076',
+  IE077 = 'IE077',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -165,6 +167,8 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE073: 'Failed to query subgraph features from indexing statuses endpoint',
   IE074: 'Failed to deploy subgraph: network not supported',
   IE075: 'Failed to connect to network contracts',
+  IE076: 'Failed to resume subgraph deployment',
+  IE077: 'Failed to allocate: subgraph not healthily syncing',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -331,30 +331,6 @@ export class GraphNode {
     }
   }
 
-  async remove(deployment: SubgraphDeploymentID): Promise<void> {
-    try {
-      this.logger.info(`Remove subgraph deployment`, {
-        deployment: deployment.display,
-      })
-      const response = await this.admin.request('subgraph_reassign', {
-        node_id: 'removed',
-        ipfs_hash: deployment.ipfsHash,
-      })
-      if (response.error) {
-        throw response.error
-      }
-      this.logger.info(`Successfully removed subgraph deployment`, {
-        deployment: deployment.display,
-      })
-    } catch (error) {
-      const errorCode = IndexerErrorCode.IE027
-      this.logger.error(INDEXER_ERROR_MESSAGES[errorCode], {
-        deployment: deployment.display,
-        error: indexerError(errorCode, error),
-      })
-    }
-  }
-
   async pause(deployment: SubgraphDeploymentID): Promise<void> {
     try {
       this.logger.info(`Pause subgraph deployment`, {

--- a/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
@@ -56,7 +56,6 @@ const setup = async () => {
     'https://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     'https://test-status-endpoint.xyz',
-    [],
   )
 
   const network = await Network.create(

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -101,7 +101,6 @@ const setupMonitor = async () => {
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    [],
   )
 
   const indexerOptions = spec.IndexerOptions.parse({

--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -41,9 +41,7 @@ export const createTestManagementClient = async (
     'http://test-admin-endpoint.xyz',
     'https://test-query-endpoint.xyz',
     statusEndpoint,
-    [],
   )
-  const indexNodeIDs = ['node_1']
 
   const networkSpecification = { ...testNetworkSpecification }
   networkSpecification.dai.inject = injectDai
@@ -78,7 +76,6 @@ export const createTestManagementClient = async (
   return await createIndexerManagementClient({
     models: managementModels,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults,
     multiNetworks,

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -645,14 +645,14 @@ export class AllocationManager {
     logger.debug(
       `Updating indexing rules so indexer-agent keeps the deployment synced but doesn't reallocate to it`,
     )
-    const offchainIndexingRule = {
+    const neverIndexingRule = {
       identifier: allocation.subgraphDeployment.id.ipfsHash,
       protocolNetwork: this.network.specification.networkIdentifier,
       identifierType: SubgraphIdentifierType.DEPLOYMENT,
-      decisionBasis: IndexingDecisionBasis.OFFCHAIN,
+      decisionBasis: IndexingDecisionBasis.NEVER,
     } as Partial<IndexingRuleAttributes>
 
-    await upsertIndexingRule(logger, this.models, offchainIndexingRule)
+    await upsertIndexingRule(logger, this.models, neverIndexingRule)
 
     return {
       actionID,

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -453,10 +453,6 @@ export interface IndexerManagementClientOptions {
   logger: Logger
   models: IndexerManagementModels
   graphNode: GraphNode
-  // TODO:L2: Do we need this information? The GraphNode class auto-selects nodes based
-  // on availability.
-  // Ford: there were some edge cases where the GraphNode was not able to auto handle it on its own
-  indexNodeIDs: string[]
   multiNetworks: MultiNetworks<Network> | undefined
   defaults: IndexerManagementDefaults
 }

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -318,7 +318,6 @@ export default {
       'http://fake-graph-node-admin-endpoint',
       argv.graphNodeQueryEndpoint,
       argv.graphNodeStatusEndpoint,
-      argv.indexNodeIds,
     )
 
     const networkProvider = await Network.provider(
@@ -483,7 +482,6 @@ export default {
     const indexerManagementClient = await createIndexerManagementClient({
       models,
       graphNode,
-      indexNodeIDs: ['node_1'], // This is just a dummy since the indexer-service doesn't manage deployments,
       logger,
       defaults: {
         // This is just a dummy, since we're never writing to the management

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -64,10 +64,7 @@ const setup = async () => {
   contracts = await connectContracts(getTestProvider('sepolia'), 11155111, undefined)
   sequelize = await sequelize.sync({ force: true })
   const statusEndpoint = 'http://127.0.0.1:8030/graphql'
-  indexingStatusResolver = new IndexingStatusResolver({
-    logger: logger,
-    statusEndpoint,
-  })
+  const queryEndpoint = 'http://127.0.0.1:8000/'
 
   const INDEXER_TEST_API_KEY: string = process.env['INDEXER_TEST_API_KEY'] || ''
   networkSubgraph = await NetworkSubgraph.create({
@@ -75,7 +72,6 @@ const setup = async () => {
     endpoint: `https://gateway-arbitrum.network.thegraph.com/api/${INDEXER_TEST_API_KEY}/subgraphs/name/graphprotocol/graph-network-arbitrum-sepolia`,
     deployment: undefined,
   })
-  const indexNodeIDs = ['node_1']
 
   const graphNode = new GraphNode(
     logger,
@@ -84,12 +80,10 @@ const setup = async () => {
     'http://fake-graph-node-admin-endpoint',
     queryEndpoint,
     statusEndpoint,
-    indexNodeIDs,
   )
   client = await createIndexerManagementClient({
     models,
     graphNode,
-    indexNodeIDs,
     logger,
     defaults: {
       // This is just a dummy, since we're never writing to the management


### PR DESCRIPTION
Graph-node recently added support for explicit pausing of subgraph deployments (in the past they were paused virtually by assigning the deployment to a nonexistent node). 

This PR adds a migration that interacts with the Graph Node indexingStatuses query and JSON-RPC server to update all virtually paused deployments (node = 'removed') to use the new explicit pausing mechanism. It also updates the process of deploying subgraphs, the indexer-agent will no longer specify the index node to which the deployment is assigned; instead the graph-node makes the assignment decisions. 

## Changes
- Migrate subgraph deployment assignments to use explicit pause mechanism
- Use recently added subgraph_pause method to explicitly pause subgraph deployments rather than virtually pausing them by assigning to a non-existent index node
- Remove index-node-ids startup parameter from indexer-agent
- Never send an index-node-id param with subgraph_deploy requests, the receiving graph-node will make the index-node-id decision based on the graph-node.toml config file