### PR TITLE
chore: use sepolia instead of goerli for tests

### DIFF
--- a/packages/indexer-agent/src/__tests__/indexer.ts
+++ b/packages/indexer-agent/src/__tests__/indexer.ts
@@ -42,7 +42,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
   status: 'potential',
-  protocolNetwork: 'eip155:5',
+  protocolNetwork: 'eip155:11155111',
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
@@ -63,7 +63,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
   status: 'potential',
-  protocolNetwork: 'eip155:5',
+  protocolNetwork: 'eip155:11155111',
 }
 
 const POI_DISPUTES_CONVERTERS_FROM_GRAPHQL: Record<
@@ -116,7 +116,7 @@ let graphNode: GraphNode
 let operator: Operator
 let metrics: Metrics
 
-const PUBLIC_JSON_RPC_ENDPOINT = 'https://ethereum-goerli.publicnode.com'
+const PUBLIC_JSON_RPC_ENDPOINT = 'https://ethereum-sepolia.publicnode.com'
 
 const testProviderUrl =
   process.env.INDEXER_TEST_JRPC_PROVIDER_URL ?? PUBLIC_JSON_RPC_ENDPOINT
@@ -149,7 +149,7 @@ const setup = async () => {
   )
 
   const networkSpecification = specification.NetworkSpecification.parse({
-    networkIdentifier: 'eip155:5',
+    networkIdentifier: 'eip155:11155111',
     gateway: {
       url: 'http://127.0.0.1:8030/',
     },
@@ -165,7 +165,7 @@ const setup = async () => {
     subgraphs: {
       maxBlockDistance: 10000,
       networkSubgraph: {
-        url: 'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli',
+        url: 'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-sepolia',
       },
       epochSubgraph: {
         url: 'http://test-url.xyz',
@@ -244,7 +244,7 @@ describe('Indexer tests', () => {
       previousEpochReferenceProof:
         '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
       status: 'potential',
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     const disputes = [badDispute]
@@ -284,7 +284,7 @@ describe('Indexer tests', () => {
       expectedResult,
     )
     await expect(
-      operator.fetchPOIDisputes('potential', 205, 'eip155:5'),
+      operator.fetchPOIDisputes('potential', 205, 'eip155:11155111'),
     ).resolves.toEqual(expectedFilteredResult)
   })
 })

--- a/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
@@ -108,8 +108,8 @@ describe('Allocation Manager', () => {
   // so we set its timeout to a higher value than usual.
   jest.setTimeout(30_000)
 
-  // Reuse an existing allocation with 25 sextillion allocated GRT
-  const allocationID = '0x96737b6a31f40edaf96c567efbb98935aa906ab9'
+  // Reuse an existing allocation allocated GRT
+  const allocationID = '0x973a6cfb5dc9eb523c5f0734bd6879995a3c0895'
 
   // Redefine test actions to use that allocation ID
   const unallocateAction = {
@@ -147,7 +147,7 @@ describe('Allocation Manager', () => {
     expect(unallocate.action.type).toBe(ActionType.UNALLOCATE)
     expect(unallocate.allocates.isZero()).toBeTruthy()
     expect(unallocate.rewards.isZero()).toBeFalsy()
-    expect(unallocate.unallocates).toStrictEqual(parseGRT('25000'))
+    expect(unallocate.unallocates).toStrictEqual(parseGRT('250'))
     expect(unallocate.balance).toStrictEqual(
       unallocate.allocates.sub(unallocate.unallocates).sub(unallocate.rewards),
     )
@@ -156,8 +156,8 @@ describe('Allocation Manager', () => {
     expect(reallocate.action.type).toBe(ActionType.REALLOCATE)
     expect(reallocate.allocates).toStrictEqual(parseGRT('10000'))
     expect(reallocate.rewards.isZero()).toBeTruthy()
-    expect(reallocate.unallocates).toStrictEqual(parseGRT('25000'))
-    expect(reallocate.balance).toStrictEqual(parseGRT('-15000'))
+    expect(reallocate.unallocates).toStrictEqual(parseGRT('250'))
+    expect(reallocate.balance).toStrictEqual(parseGRT('9750'))
   })
 
   test('validateActionBatchFeasibility() validates and correctly sorts actions based on net token balance', async () => {

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
@@ -167,8 +167,8 @@ async function actionInputToExpected(
 
   // We expect the protocol network to be transformed to it's CAIP2-ID
   // form for all inputs
-  if (input.protocolNetwork === 'goerli') {
-    expected.protocolNetwork = 'eip155:5'
+  if (input.protocolNetwork === 'sepolia') {
+    expected.protocolNetwork = 'eip155:11155111'
   }
 
   return expected
@@ -509,7 +509,7 @@ describe('Actions', () => {
 
   test('Reject action with invalid params for action type', async () => {
     const inputAction = invalidReallocateAction
-    const expected = { ...inputAction, protocolNetwork: 'eip155:5' }
+    const expected = { ...inputAction, protocolNetwork: 'eip155:11155111' }
     const fields = JSON.stringify(expected)
     await expect(
       client.mutation(QUEUE_ACTIONS_MUTATION, { actions: [inputAction] }).toPromise(),
@@ -632,7 +632,7 @@ describe('Actions', () => {
 
   test('Reject unallocate action with inactive allocationID', async () => {
     // This allocation has been closed on chain
-    const closedAllocation = '0x0001572b5fde192fc1c65630fabb5e13d3ad173e'
+    const closedAllocation = '0x0641209ae448c710ab8d04a8c8a13053d138d8c6'
 
     // Reuse a valid inputAction but use an allocationID dedicated to this test purpose,
     // as the previously used allocationID does not exist on chain.
@@ -709,7 +709,7 @@ describe('Actions', () => {
       reason: 'indexingRule',
       priority: 0,
       //  When writing directly to the database, `protocolNetwork` must be in the CAIP2-ID format.
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     } as ActionInput
 
     const proposedAction = {
@@ -720,7 +720,7 @@ describe('Actions', () => {
       source: 'indexerAgent',
       reason: 'indexingRule',
       priority: 0,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     } as ActionInput
 
     await managementModels.Action.create(failedAction, {
@@ -764,7 +764,7 @@ describe('Actions', () => {
       reason: 'indexingRule',
       priority: 0,
       //  When writing directly to the database, `protocolNetwork` must be in the CAIP2-ID format.
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     } as ActionInput
 
     const proposedAction = {
@@ -775,7 +775,7 @@ describe('Actions', () => {
       source: 'indexerAgent',
       reason: 'indexingRule',
       priority: 0,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     } as ActionInput
 
     await managementModels.Action.create(successfulAction, {
@@ -817,7 +817,7 @@ describe('Actions', () => {
       reason: 'indexingRule',
       priority: 0,
       //  When writing directly to the database, `protocolNetwork` must be in the CAIP2-ID format.
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     } as ActionInput
 
     const queuedAllocateAction = {
@@ -829,7 +829,7 @@ describe('Actions', () => {
       source: 'indexerAgent',
       reason: 'indexingRule',
       priority: 0,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     } as ActionInput
 
     await managementModels.Action.create(queuedUnallocateAction, {

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
@@ -154,7 +154,7 @@ describe('Indexing rules', () => {
       identifier: INDEXING_RULE_GLOBAL,
       identifierType: SubgraphIdentifierType.GROUP,
       allocationAmount: '1000',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expected = {
@@ -171,7 +171,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.RULES,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Update the rule and ensure the right data is returned
@@ -180,7 +180,10 @@ describe('Indexing rules', () => {
     ).resolves.toHaveProperty('data.setIndexingRule', expected)
 
     // Query the rule to make sure it's updated in the db
-    const ruleIdentifier = { identifier: INDEXING_RULE_GLOBAL, protocolNetwork: 'goerli' }
+    const ruleIdentifier = {
+      identifier: INDEXING_RULE_GLOBAL,
+      protocolNetwork: 'sepolia',
+    }
 
     const result = await client
       .query(INDEXING_RULE_QUERY, { identifier: ruleIdentifier, merged: false })
@@ -205,12 +208,12 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.RULES,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expected = {
       ...input,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Update the rule
@@ -219,7 +222,10 @@ describe('Indexing rules', () => {
     ).resolves.toHaveProperty('data.setIndexingRule', expected)
 
     // Query the rule to make sure it's updated in the db
-    const ruleIdentifier = { identifier: INDEXING_RULE_GLOBAL, protocolNetwork: 'goerli' }
+    const ruleIdentifier = {
+      identifier: INDEXING_RULE_GLOBAL,
+      protocolNetwork: 'sepolia',
+    }
     await expect(
       client
         .query(INDEXING_RULE_QUERY, { identifier: ruleIdentifier, merged: false })
@@ -233,7 +239,7 @@ describe('Indexing rules', () => {
       identifierType: SubgraphIdentifierType.GROUP,
       allocationAmount: '1',
       minSignal: '2',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const original = {
@@ -249,7 +255,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.RULES,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Write the original
@@ -265,13 +271,13 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       autoRenewal: true,
       safety: false,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expected = {
       ...original,
       ...update,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Update the rule
@@ -280,7 +286,10 @@ describe('Indexing rules', () => {
     ).resolves.toHaveProperty('data.setIndexingRule', expected)
 
     // Query the rule to make sure it's updated in the db
-    const ruleIdentifier = { identifier: INDEXING_RULE_GLOBAL, protocolNetwork: 'goerli' }
+    const ruleIdentifier = {
+      identifier: INDEXING_RULE_GLOBAL,
+      protocolNetwork: 'sepolia',
+    }
     await expect(
       client
         .query(INDEXING_RULE_QUERY, { identifier: ruleIdentifier, merged: false })
@@ -296,7 +305,7 @@ describe('Indexing rules', () => {
       allocationAmount: '1',
       minSignal: '2',
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const original = {
@@ -312,7 +321,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Write the original
@@ -330,13 +339,13 @@ describe('Indexing rules', () => {
       autoRenewal: false,
       requireSupported: false,
       safety: false,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expected = {
       ...original,
       ...update,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Update the rule
@@ -364,14 +373,14 @@ describe('Indexing rules', () => {
       allocationLifetime: null,
       decisionBasis: IndexingDecisionBasis.NEVER,
       autoRenewal: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expectedAgain = {
       ...original,
       ...update,
       ...updateAgain,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
     expectedAgain.identifier = originalIdentifier
 
@@ -402,7 +411,7 @@ describe('Indexing rules', () => {
       allocationAmount: '1',
       minSignal: '1',
       decisionBasis: IndexingDecisionBasis.NEVER,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const deploymentInput = {
@@ -414,7 +423,7 @@ describe('Indexing rules', () => {
       requireSupported: false,
       autoRenewal: false,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const globalExpected = {
@@ -430,7 +439,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.NEVER,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     const deploymentExpected = {
@@ -446,7 +455,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       requireSupported: false,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
     deploymentExpected.identifier = 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC'
 
@@ -461,7 +470,7 @@ describe('Indexing rules', () => {
     // Query the global rule
     const globalRuleIdentifier = {
       identifier: INDEXING_RULE_GLOBAL,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client
@@ -475,7 +484,7 @@ describe('Indexing rules', () => {
     // Query the rule for the deployment
     const deploymentRuleIdentifier = {
       identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client
@@ -489,7 +498,7 @@ describe('Indexing rules', () => {
     // Query all rules together
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [globalExpected, deploymentExpected])
   })
@@ -502,7 +511,7 @@ describe('Indexing rules', () => {
       minSignal: '2',
       allocationLifetime: 20,
       autoRenewal: false,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expected = {
@@ -518,7 +527,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.RULES,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Write the rule
@@ -529,12 +538,12 @@ describe('Indexing rules', () => {
     // Query all rules
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [expected])
 
     // Delete the rule
-    const ruleIdentifier = { identifier: expected.identifier, protocolNetwork: 'goerli' }
+    const ruleIdentifier = { identifier: expected.identifier, protocolNetwork: 'sepolia' }
     await expect(
       client
         .mutation(DELETE_INDEXING_RULE_MUTATION, {
@@ -546,7 +555,7 @@ describe('Indexing rules', () => {
     // Query all rules together
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [])
   })
@@ -558,7 +567,7 @@ describe('Indexing rules', () => {
       allocationAmount: '1',
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const expectedBefore = {
@@ -573,7 +582,7 @@ describe('Indexing rules', () => {
       minAverageQueryFees: null,
       custom: null,
       decisionBasis: IndexingDecisionBasis.RULES,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Write the rule
@@ -584,7 +593,7 @@ describe('Indexing rules', () => {
     // Query all rules
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [expectedBefore])
 
@@ -603,7 +612,7 @@ describe('Indexing rules', () => {
     // Query the rules again to see that the update went through
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [
       { ...expectedBefore, allocationAmount: null },
@@ -622,7 +631,7 @@ describe('Indexing rules', () => {
       requireSupported: true,
       autoRenewal: true,
       safety: false,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const deploymentInput = {
@@ -635,7 +644,7 @@ describe('Indexing rules', () => {
       autoRenewal: false,
       requireSupported: false,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const globalExpected = {
@@ -650,7 +659,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.NEVER,
       requireSupported: true,
       safety: false,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     const deploymentExpected = {
@@ -666,7 +675,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       requireSupported: false,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     const deploymentMergedExpected = {
@@ -682,7 +691,7 @@ describe('Indexing rules', () => {
       decisionBasis: IndexingDecisionBasis.OFFCHAIN,
       requireSupported: false,
       safety: true,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }
 
     // Write the orginals
@@ -696,7 +705,7 @@ describe('Indexing rules', () => {
     // Query the global rule
     const globalRuleIdentifier = {
       identifier: INDEXING_RULE_GLOBAL,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client
@@ -710,7 +719,7 @@ describe('Indexing rules', () => {
     // Query the rule for the deployment merged with the global rule
     const ruleIdentifier = {
       identifier: 'QmZSJPm74tvhgr8uzhqvyQm2J6YSbUEj4nF6j8WxxUQLsC',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client
@@ -724,14 +733,14 @@ describe('Indexing rules', () => {
     // Query all rules together (without merging)
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [globalExpected, deploymentExpected])
 
     // Query all rules together (with merging)
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: true, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: true, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [
       globalExpected,
@@ -747,14 +756,14 @@ describe('Indexing rules', () => {
       minSignal: '1',
       decisionBasis: IndexingDecisionBasis.NEVER,
       minAverageQueryFees: '1',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     await client.mutation(SET_INDEXING_RULE_MUTATION, { rule: globalInput }).toPromise()
 
     const globalRuleIdentifier = {
       identifier: INDEXING_RULE_GLOBAL,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client
@@ -766,7 +775,7 @@ describe('Indexing rules', () => {
 
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [
       {
@@ -783,7 +792,7 @@ describe('Indexing rules', () => {
         minAverageQueryFees: null,
         minSignal: null,
         minStake: null,
-        protocolNetwork: 'eip155:5',
+        protocolNetwork: 'eip155:11155111',
       },
     ])
   })
@@ -798,7 +807,7 @@ describe('Indexing rules', () => {
       minAverageQueryFees: '1',
       requireSupported: false,
       safety: false,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     const deploymentInput = {
@@ -808,7 +817,7 @@ describe('Indexing rules', () => {
       minSignal: '2',
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     await client.mutation(SET_INDEXING_RULE_MUTATION, { rule: globalInput }).toPromise()
@@ -818,11 +827,11 @@ describe('Indexing rules', () => {
 
     const globalRuleIdentifier = {
       identifier: INDEXING_RULE_GLOBAL,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     const deploymentRuleIdentifier = {
       identifier: '0xa4e311bfa7edabed7b31d93e0b3e751659669852ef46adbedd44dc2454db4bf3',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
 
     await expect(
@@ -835,7 +844,7 @@ describe('Indexing rules', () => {
 
     await expect(
       client
-        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+        .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
         .toPromise(),
     ).resolves.toHaveProperty('data.indexingRules', [
       {
@@ -854,7 +863,7 @@ describe('Indexing rules', () => {
         minStake: null,
         requireSupported: true,
         safety: true,
-        protocolNetwork: 'eip155:5',
+        protocolNetwork: 'eip155:11155111',
       },
     ])
   })
@@ -879,7 +888,7 @@ describe('Indexing rules', () => {
     // Must not create any Rule in the database
 
     const rows = await client
-      .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'goerli' })
+      .query(INDEXING_RULES_QUERY, { merged: false, protocolNetwork: 'sepolia' })
       .toPromise()
     expect(rows.data.indexingRules).toEqual([])
   })

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.test.ts
@@ -112,7 +112,7 @@ const TEST_DISPUTE_1: POIDisputeAttributes = {
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
   status: 'potential',
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 }
 const TEST_DISPUTE_2: POIDisputeAttributes = {
   allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
@@ -132,7 +132,7 @@ const TEST_DISPUTE_2: POIDisputeAttributes = {
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
   status: 'potential',
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 }
 
 const TEST_DISPUTE_3: POIDisputeAttributes = {
@@ -153,7 +153,7 @@ const TEST_DISPUTE_3: POIDisputeAttributes = {
   previousEpochReferenceProof:
     '0xd04b5601739a1638719696d0735c92439267a89248c6fd21388d9600f5c942f6',
   status: 'potential',
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 }
 
 const TEST_DISPUTES_ARRAY = [TEST_DISPUTE_1, TEST_DISPUTE_2]
@@ -163,8 +163,8 @@ function toObject(dispute: POIDisputeAttributes): Record<string, any> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const expected: Record<string, any> = Object.assign({}, dispute)
   expected.allocationAmount = expected.allocationAmount.toString()
-  if (expected.protocolNetwork === 'goerli') {
-    expected.protocolNetwork = 'eip155:5'
+  if (expected.protocolNetwork === 'sepolia') {
+    expected.protocolNetwork = 'eip155:11155111'
   }
   return expected
 }
@@ -237,7 +237,7 @@ describe('POI disputes', () => {
   test('Get non-existent dispute', async () => {
     const identifier = {
       allocationID: '0x0000000000000000000000000000000000000001',
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     }
     await expect(
       client.query(GET_POI_DISPUTE_QUERY, { identifier }).toPromise(),
@@ -252,9 +252,9 @@ describe('POI disputes', () => {
     for (const dispute of disputes) {
       const identifier = {
         allocationID: dispute.allocationID,
-        protocolNetwork: 'eip155:5',
+        protocolNetwork: 'eip155:11155111',
       }
-      const expected = { ...dispute, protocolNetwork: 'eip155:5' }
+      const expected = { ...dispute, protocolNetwork: 'eip155:11155111' }
       await expect(
         client.query(GET_POI_DISPUTE_QUERY, { identifier }).toPromise(),
       ).resolves.toHaveProperty('data.dispute', expected)
@@ -269,7 +269,7 @@ describe('POI disputes', () => {
     // Once persisted, the protocol network identifier assumes the CAIP2-ID format
     const expected = disputes.map((dispute) => ({
       ...dispute,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }))
 
     await expect(
@@ -277,7 +277,7 @@ describe('POI disputes', () => {
         .query(GET_POI_DISPUTES_QUERY, {
           status: 'potential',
           minClosedEpoch: 0,
-          protocolNetwork: 'goerli',
+          protocolNetwork: 'sepolia',
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', expected)
@@ -289,14 +289,14 @@ describe('POI disputes', () => {
     await client.mutation(STORE_POI_DISPUTES_MUTATION, { disputes: disputes }).toPromise()
 
     // Once persisted, the protocol network identifier assumes the CAIP2-ID format
-    const expected = [{ ...TEST_DISPUTE_2, protocolNetwork: 'eip155:5' }]
+    const expected = [{ ...TEST_DISPUTE_2, protocolNetwork: 'eip155:11155111' }]
 
     await expect(
       client
         .query(GET_POI_DISPUTES_QUERY, {
           status: 'potential',
           minClosedEpoch: 205,
-          protocolNetwork: 'goerli',
+          protocolNetwork: 'sepolia',
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', expected)
@@ -310,7 +310,7 @@ describe('POI disputes', () => {
     const identifiers = [
       {
         allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
-        protocolNetwork: 'goerli',
+        protocolNetwork: 'sepolia',
       },
     ]
     await expect(
@@ -325,7 +325,7 @@ describe('POI disputes', () => {
     // Once persisted, the protocol network identifier assumes the CAIP2-ID format
     const expected = disputes.map((dispute) => ({
       ...dispute,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }))
 
     await expect(
@@ -333,7 +333,7 @@ describe('POI disputes', () => {
         .query(GET_POI_DISPUTES_QUERY, {
           status: 'potential',
           minClosedEpoch: 0,
-          protocolNetwork: 'goerli',
+          protocolNetwork: 'sepolia',
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', expected)
@@ -347,11 +347,11 @@ describe('POI disputes', () => {
     const identifiers = [
       {
         allocationID: '0xbAd8935f75903A1eF5ea62199d98Fd7c3c1ab20C',
-        protocolNetwork: 'goerli',
+        protocolNetwork: 'sepolia',
       },
       {
         allocationID: '0x085fd2ADc1B96c26c266DecAb6A3098EA0eda619',
-        protocolNetwork: 'goerli',
+        protocolNetwork: 'sepolia',
       },
     ]
 
@@ -363,7 +363,7 @@ describe('POI disputes', () => {
     // Once persisted, the protocol network identifier assumes the CAIP2-ID format
     const expected = disputes.map((dispute) => ({
       ...dispute,
-      protocolNetwork: 'eip155:5',
+      protocolNetwork: 'eip155:11155111',
     }))
 
     await expect(
@@ -371,7 +371,7 @@ describe('POI disputes', () => {
         .query(GET_POI_DISPUTES_QUERY, {
           status: 'potential',
           minClosedEpoch: 0,
-          protocolNetwork: 'goerli',
+          protocolNetwork: 'sepolia',
         })
         .toPromise(),
     ).resolves.toHaveProperty('data.disputes', expected)

--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -14,14 +14,14 @@ import {
 } from '@graphprotocol/indexer-common'
 import { connectDatabase, Metrics, Logger, parseGRT } from '@graphprotocol/common-ts'
 
-const PUBLIC_JSON_RPC_ENDPOINT = 'https://ethereum-goerli.publicnode.com'
+const PUBLIC_JSON_RPC_ENDPOINT = 'https://ethereum-sepolia.publicnode.com'
 
 const testProviderUrl =
   process.env.INDEXER_TEST_JRPC_PROVIDER_URL ?? PUBLIC_JSON_RPC_ENDPOINT
 
 export const testNetworkSpecification: specification.NetworkSpecification =
   specification.NetworkSpecification.parse({
-    networkIdentifier: 'goerli',
+    networkIdentifier: 'sepolia',
     gateway: {
       url: 'http://127.0.0.1:8030/',
     },
@@ -37,7 +37,7 @@ export const testNetworkSpecification: specification.NetworkSpecification =
     subgraphs: {
       maxBlockDistance: 10000,
       networkSubgraph: {
-        url: 'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli',
+        url: 'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-sepolia',
       },
       epochSubgraph: {
         url: 'http://test-url.xyz',
@@ -90,7 +90,7 @@ export const createTestManagementClient = async (
       parallelAllocations: 1,
       requireSupported: true,
       safety: true,
-      protocolNetwork: 'goerli',
+      protocolNetwork: 'sepolia',
     },
   }
 
@@ -143,7 +143,7 @@ export const queuedAllocateAction = {
   source: 'indexerAgent',
   reason: 'indexingRule',
   priority: 0,
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 } as ActionInput
 
 export const invalidUnallocateAction = {
@@ -157,7 +157,7 @@ export const invalidUnallocateAction = {
   source: 'indexerAgent',
   reason: 'indexingRule',
   priority: 0,
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 } as ActionInput
 
 export const invalidReallocateAction = {
@@ -171,5 +171,5 @@ export const invalidReallocateAction = {
   source: 'indexerAgent',
   reason: 'indexingRule',
   priority: 0,
-  protocolNetwork: 'goerli',
+  protocolNetwork: 'sepolia',
 } as ActionInput

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -277,7 +277,7 @@ export async function validateProviderNetworkIdentifier(
 export function networkIsL1(networkIdentifier: string): boolean {
   // Normalize network identifier
   networkIdentifier = resolveChainId(networkIdentifier)
-  return networkIdentifier === 'eip155:1' || networkIdentifier === 'eip155:5'
+  return networkIdentifier === 'eip155:1' || networkIdentifier === 'eip155:11155111'
 }
 
 // Convenience function to check if a given network identifier is a supported Layer-2 protocol network

--- a/packages/indexer-common/src/parsers/__tests__/parsers.ts
+++ b/packages/indexer-common/src/parsers/__tests__/parsers.ts
@@ -2,9 +2,9 @@ import { validateNetworkIdentifier } from '../validators'
 
 describe('validateNetworkIdentifier tests', () => {
   it('should parse valid network identifiers', () => {
-    expect(validateNetworkIdentifier('goerli')).toBe('eip155:5')
+    expect(validateNetworkIdentifier('sepolia')).toBe('eip155:11155111')
     expect(validateNetworkIdentifier('mainnet')).toBe('eip155:1')
     expect(validateNetworkIdentifier('eip155:1')).toBe('eip155:1')
-    expect(validateNetworkIdentifier('eip155:5')).toBe('eip155:5')
+    expect(validateNetworkIdentifier('eip155:11155111')).toBe('eip155:11155111')
   })
 })

--- a/packages/indexer-service/src/server/__tests__/server.test.ts
+++ b/packages/indexer-service/src/server/__tests__/server.test.ts
@@ -61,7 +61,7 @@ const setup = async () => {
   queryFeeModels = defineQueryFeeModels(sequelize)
   models = defineIndexerManagementModels(sequelize)
   address = '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1'
-  contracts = await connectContracts(getTestProvider('goerli'), 5, undefined)
+  contracts = await connectContracts(getTestProvider('sepolia'), 11155111, undefined)
   sequelize = await sequelize.sync({ force: true })
   const statusEndpoint = 'http://127.0.0.1:8030/graphql'
   indexingStatusResolver = new IndexingStatusResolver({


### PR DESCRIPTION
locally I had issues running the tests. It turned out we were still using `goerli` which is deprecated now so updating the test RPC to sepolia