### PR TITLE
docs: Release graph-node v0.35.0 to Arbitrum-One and Ethereum-Mainnet indexers

### DIFF
--- a/docs/networks/arbitrum-one.md
+++ b/docs/networks/arbitrum-one.md
@@ -10,7 +10,7 @@ Network information can be found at https://thegraph.com/explorer?chain=arbitrum
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
-| graph-node      | [0.34.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.34.0)   |
+| graph-node      | [0.35.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.35.0)   |
 
 ## Network Parameters
 

--- a/docs/networks/ethereum-mainnet.md
+++ b/docs/networks/ethereum-mainnet.md
@@ -10,7 +10,7 @@ Network information can be found at https://thegraph.com/explorer?chain=mainnet.
 | indexer-agent   | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-cli     | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
 | indexer-service | [0.20.16](https://github.com/graphprotocol/indexer/releases/tag/v0.20.16)    |
-| graph-node      | [0.34.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.34.0)   |
+| graph-node      | [0.35.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.35.0)   |
 
 ## Network Parameters
 


### PR DESCRIPTION
## Changes
- Update suggested graph-node version to v0.35.0 for the Arbitrum-One and Ethereum-Mainnet protocol networks