### PR TITLE
Avoid race conditions when queuing actions (hopefully fixes #879)

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -251,16 +251,16 @@ describe('Actions', () => {
       [Op.and]: [{ status: 'failed' }, { type: 'allocate' }],
     })
 
-    await expect(ActionManager.fetchActions(models, filterOptions)).resolves.toHaveLength(
-      1,
-    )
-
-    await expect(ActionManager.fetchActions(models, filterOptions)).resolves.toHaveLength(
-      1,
-    )
+    await expect(
+      ActionManager.fetchActions(models, null, filterOptions),
+    ).resolves.toHaveLength(1)
 
     await expect(
-      ActionManager.fetchActions(models, {
+      ActionManager.fetchActions(models, null, filterOptions),
+    ).resolves.toHaveLength(1)
+
+    await expect(
+      ActionManager.fetchActions(models, null, {
         status: ActionStatus.FAILED,
         type: ActionType.ALLOCATE,
         updatedAt: { [Op.gte]: literal("NOW() - INTERVAL '1d'") },
@@ -268,7 +268,7 @@ describe('Actions', () => {
     ).resolves.toHaveLength(1)
 
     await expect(
-      ActionManager.fetchActions(models, {
+      ActionManager.fetchActions(models, null, {
         status: ActionStatus.FAILED,
         type: ActionType.ALLOCATE,
         updatedAt: { [Op.lte]: literal("NOW() - INTERVAL '1d'") },

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -121,7 +121,7 @@ export class ActionManager {
         logger.trace('Fetching approved actions')
         let actions: Action[] = []
         try {
-          actions = await ActionManager.fetchActions(this.models, {
+          actions = await ActionManager.fetchActions(this.models, null, {
             status: ActionStatus.APPROVED,
           })
           logger.trace(`Fetched ${actions.length} approved actions`)
@@ -292,6 +292,7 @@ export class ActionManager {
 
   public static async fetchActions(
     models: IndexerManagementModels,
+    transaction: Transaction | null,
     filter: ActionFilter,
     orderBy?: ActionParams,
     orderDirection?: OrderDirection,
@@ -302,6 +303,7 @@ export class ActionManager {
       : [['id', 'desc']]
 
     return await models.Action.findAll({
+      transaction,
       where: actionFilterToWhereOptions(filter),
       order: orderObject,
       limit: first,

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -141,6 +141,7 @@ export default {
     })
     return await ActionManager.fetchActions(
       models,
+      null,
       filter,
       orderBy,
       orderDirection,
@@ -176,10 +177,10 @@ export default {
         validateActionInputs(actions, network.networkMonitor, logger),
     )
 
-    const alreadyQueuedActions = await ActionManager.fetchActions(models, {
+    const alreadyQueuedActions = await ActionManager.fetchActions(models, null, {
       status: ActionStatus.QUEUED,
     })
-    const alreadyApprovedActions = await ActionManager.fetchActions(models, {
+    const alreadyApprovedActions = await ActionManager.fetchActions(models, null, {
       status: ActionStatus.APPROVED,
     })
     const actionsAwaitingExecution = alreadyQueuedActions.concat(alreadyApprovedActions)
@@ -189,12 +190,12 @@ export default {
       [Op.gte]: literal("NOW() - INTERVAL '15m'"),
     }
 
-    const recentlyFailedActions = await ActionManager.fetchActions(models, {
+    const recentlyFailedActions = await ActionManager.fetchActions(models, null, {
       status: ActionStatus.FAILED,
       updatedAt: last15Minutes,
     })
 
-    const recentlySuccessfulActions = await ActionManager.fetchActions(models, {
+    const recentlySuccessfulActions = await ActionManager.fetchActions(models, null, {
       status: ActionStatus.SUCCESS,
       updatedAt: last15Minutes,
     })

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -177,42 +177,54 @@ export default {
         validateActionInputs(actions, network.networkMonitor, logger),
     )
 
-    const alreadyQueuedActions = await ActionManager.fetchActions(models, null, {
-      status: ActionStatus.QUEUED,
-    })
-    const alreadyApprovedActions = await ActionManager.fetchActions(models, null, {
-      status: ActionStatus.APPROVED,
-    })
-    const actionsAwaitingExecution = alreadyQueuedActions.concat(alreadyApprovedActions)
-
-    // Fetch recently attempted actions
-    const last15Minutes = {
-      [Op.gte]: literal("NOW() - INTERVAL '15m'"),
-    }
-
-    const recentlyFailedActions = await ActionManager.fetchActions(models, null, {
-      status: ActionStatus.FAILED,
-      updatedAt: last15Minutes,
-    })
-
-    const recentlySuccessfulActions = await ActionManager.fetchActions(models, null, {
-      status: ActionStatus.SUCCESS,
-      updatedAt: last15Minutes,
-    })
-
-    logger.trace('Recently attempted actions', {
-      recentlySuccessfulActions,
-      recentlyFailedActions,
-    })
-
-    const recentlyAttemptedActions = recentlyFailedActions.concat(
-      recentlySuccessfulActions,
-    )
-
     let results: ActionResult[] = []
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await models.Action.sequelize!.transaction(async (transaction) => {
+      const alreadyQueuedActions = await ActionManager.fetchActions(models, transaction, {
+        status: ActionStatus.QUEUED,
+      })
+      const alreadyApprovedActions = await ActionManager.fetchActions(
+        models,
+        transaction,
+        {
+          status: ActionStatus.APPROVED,
+        },
+      )
+      const actionsAwaitingExecution = alreadyQueuedActions.concat(alreadyApprovedActions)
+
+      // Fetch recently attempted actions
+      const last15Minutes = {
+        [Op.gte]: literal("NOW() - INTERVAL '15m'"),
+      }
+
+      const recentlyFailedActions = await ActionManager.fetchActions(
+        models,
+        transaction,
+        {
+          status: ActionStatus.FAILED,
+          updatedAt: last15Minutes,
+        },
+      )
+
+      const recentlySuccessfulActions = await ActionManager.fetchActions(
+        models,
+        transaction,
+        {
+          status: ActionStatus.SUCCESS,
+          updatedAt: last15Minutes,
+        },
+      )
+
+      logger.trace('Recently attempted actions', {
+        recentlySuccessfulActions,
+        recentlyFailedActions,
+      })
+
+      const recentlyAttemptedActions = recentlyFailedActions.concat(
+        recentlySuccessfulActions,
+      )
+
       for (const action of actions) {
         const result = await executeQueueOperation(
           logger,


### PR DESCRIPTION
I noticed that the existing actions that the new actions are compared against to check for duplicates are queried outside the Sequelize transaction that will eventually write the action to the db. We've noticed that duplicates happen when two actions are added to the database in quick succession (<2s). By performing both the existing action queries and the database write within the same transaction, this hopefully won't happen any more.

This hopefully fixes duplicate actions being added to the queue (#879).