### PR TITLE
Update feature support (ens, arweave, 0.35.x)

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -4,49 +4,47 @@ As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/prop
 
 The matrix below reflects the canonical Council-ratified version. As outlined in GIP-00008, Council ratification is currently required for each update, which may happen at different stages of feature development and testing lifecycle.
 
+| Subgraph Feature           | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
+| -------------------------- | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- |
+| **Core Features**          |               |             |              |                   |                      |                  |
+| Full-text Search           |               | Yes         | No           | No                | Yes                  | Yes              |
+| Non-Fatal Errors           |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Grafting                   |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Types**      |               |             |              |                   |                      |                  |
+| eip155:\*                  | \*            | Yes         | No           | No                | No                   | No               |
+| eip155:1                   | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |
+| eip155:100                 | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| near:\*                    | \*            | Yes         | Yes          | No                | No                   | No               |
+| cosmos:\*                  | \*            | Yes         | Yes          | No                | No                   | No               |
+| arweave:\*                 | \*            | Yes         | Yes          | No                | No                   | No               |
+| eip155:42161               | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:42220               | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:43114               | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:250                 | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:137                 | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:10                  | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| **Data Source Features**   |               |             |              |                   |                      |                  |
+| ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
+| ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| File data sources: Arweave |               | Yes         | Yes          | No                | Yes                  | Yes              |
+| File data sources: IPFS    |               | Yes         | Yes          | No                | Yes                  | Yes              |
+| Substreams: mainnet        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Substreams: optimism       |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 
-| Subgraph Feature         | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-| ------------------------ | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- |
-| **Core Features**        |               |             |              |                   |                      |                  |
-| Full-text Search         |               | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                 |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**    |               |             |              |                   |                      |                  |
-| eip155:*                 | *             | Yes         | No           | No                | No                   | No               |
-| eip155:1                 | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100               | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| near:*                   | *             | Yes         | Yes          | No                | No                   | No               |
-| cosmos:*                 | *             | Yes         | Yes          | No                | No                   | No               |
-| arweave:*                | *             | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161             | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220             | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114             | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:250               | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:137               | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:10                | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features** |               |             |              |                   |                      |                  |
-| ipfs.cat in mappings     |               | Yes         | Yes          | No                | No                   | No               |
-| ENS                      |               | Yes         | Yes          | No                | No                   | No               |
-| File data sources: IPFS  |               | Yes         | Yes          | No                | Yes                  | Yes              |
-| Substreams: mainnet      |               | Yes         | Yes          | Yes               | Yes                  | Yes              | 
-| Substreams: optimism     |               | Yes         | Yes          | Yes               | Yes                  | Yes              | 
-
-
-The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it. 
+The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
 The latest for the feature matrix above:
 
 ```
-graph-node: >=0.34.1 <0.35.0
+graph-node: >=0.35.0 <0.36.0
 ```
 
 ### Latest Council snapshot
+
 [GPP-0037 Update Feature Support Matrix (Graph Node v0.34.1)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x840a7de34b1dac9c7ef03d3170540abc5957ffd00564777aac9b253068a93723)
 
-
-
-
 ### Other notes
-- Currently, one single matrix is used to reflect protocol behaviour for both Ethereum mainnet and Arbitrum One. 
+
+- Currently, one single matrix is used to reflect protocol behaviour for both Ethereum mainnet and Arbitrum One.
 - Aliases can be used in subgraph manifest files to refer to specific networks.
 - Experimental features are generally not fully supported for indexing rewards and arbitration, and usage of experimental features will be considered during any arbitration that does occur.
 - Query fees apply to all queries, regardless of the underlying features used by a subgraph.

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -40,7 +40,7 @@ graph-node: >=0.35.0 <0.36.0
 
 ### Latest Council snapshot
 
-[GPP-0037 Update Feature Support Matrix (Graph Node v0.34.1)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x840a7de34b1dac9c7ef03d3170540abc5957ffd00564777aac9b253068a93723)
+[GGP-0040: Updated Feature Support (ens, arweave, 0.35.x)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x214ad88959a8e09e7341b21650699ab67345493d9386118dc524c827bd011090)
 
 ### Other notes
 


### PR DESCRIPTION
- Updates the supported Graph Node version to [0.35.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.35.0)
- Adds support for Arweave File Data Sources (at same level as IPFS, given identical implementation and data isolation), supported as of Graph Node [0.33.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.33.0)
- Adds support for ENS (as of [0.32.0](https://github.com/graphprotocol/graph-node/releases/tag/v0.32.0), this functionality was undeprecated, as the failure in the absence of the table was non-deterministic, until indexers import the [ENS rainbow tables](https://github.com/graphprotocol/ens-rainbow))

TODO: create and link to GGP