### PR TITLE
common: 879 duplicate queued actions - composite index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ yalc.lock
 # IDE
 .idea/
 .envrc
+.vscode

--- a/packages/indexer-agent/src/db/migrations/12-add-actions-composite-constraint.ts
+++ b/packages/indexer-agent/src/db/migrations/12-add-actions-composite-constraint.ts
@@ -1,0 +1,32 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.info('Adding composite unique constraint to Actions table')
+  // Add the new composite primary key
+  await queryInterface.addConstraint('Actions', {
+    fields: ['deploymentID', 'source'],
+    type: 'unique',
+    name: 'Actions_ckey_unique_deploymentID_source',
+  })
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+  logger.info('Removing composite uniqie constraint from Actions table')
+  await queryInterface.removeConstraint(
+    'Actions',
+    'Actions_ckey_unique_deploymentID_source',
+  )
+}

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
@@ -532,6 +532,27 @@ describe('Actions', () => {
         .toPromise(),
     ).resolves.toHaveProperty('data.actions', [])
   })
+  
+  test('Rejects duplicate queued actions', async () => {
+    const inputAction = queuedAllocateAction
+    const mutations: Promise<any>[] = []
+    for (let i = 0; i < 50; i++) {
+      mutations.push(client.mutation(QUEUE_ACTIONS_MUTATION, { actions: [inputAction] }).toPromise())
+    }
+
+    const results = await Promise.all(mutations)
+    for (const result of results) {
+      expect(result.data).not.toBeNull()
+    }
+
+    const actions = await client
+      .query(ACTIONS_QUERY, { filter: { type: ActionType.ALLOCATE } })
+      .toPromise()
+
+    expect(actions.data.actions).toHaveLength(1)
+    console.log('actions.data.actions', actions.data.actions)
+  })
+
 
   test('Reject duplicate queued action from different source', async () => {
     const inputAction = queuedAllocateAction

--- a/packages/indexer-common/src/indexer-management/models/action.ts
+++ b/packages/indexer-common/src/indexer-management/models/action.ts
@@ -155,6 +155,13 @@ export const defineActionModels = (sequelize: Sequelize): ActionModels => {
     {
       modelName: 'Action',
       sequelize,
+      indexes: [
+        {
+          fields: ['deploymentID', 'source'],
+          unique: true,
+          name: 'Actions_ckey_unique_deploymentID_source',
+        },
+      ],
       validate: {
         requiredActionParams() {
           switch (this.type) {


### PR DESCRIPTION
Resolves #879

After testing seeing https://github.com/graphprotocol/indexer/pull/883, I set out to write a unit test that would prove if #879 were indeed resolved.

I ended up with a test that would sporadically fail, depending on timing.

My first approach here was to introduce an advisory lock, which I removed in favor of this PR's composite index and unique constraint on deploymentID and source. Now a GQL validation error occurs when the duplicate is about to be inserted.

Looking for feedback on this approach.