### PR TITLE
docs: added base, bsc, scroll and linea to the feature support matrix

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -26,6 +26,7 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:8453                | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:534352              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:56                  | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -34,10 +34,6 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | File data sources: IPFS    |               | Yes         | Yes          | No                | Yes                  | Yes              |
 | Substreams: mainnet        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | Substreams: optimism       |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Substreams: base           |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Substreams: scroll         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Substreams: linea          |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Substreams: bsc            |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 
 The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
 The latest for the feature matrix above:

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -48,7 +48,7 @@ graph-node: >=0.35.0 <0.36.0
 
 ### Latest Council snapshot
 
-[GGP-0042: Updated Feature Matrix Support (base, scroll, linea)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x21cd2337c58bf680281c1b4d795d07fe35bb83cf7c1071190bb3ca8fc20088aa)
+[GGP-0042: Updated Feature Matrix Support (base, scroll, linea)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x229e88da4839f8ba7f349323dfc564f991f72e4faef84506a7205b1c5059f631)
 
 ### Other notes
 

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -23,6 +23,9 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:250                 | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:137                 | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:10                  | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:8453                | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:341690              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:243192              | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
@@ -30,6 +33,9 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | File data sources: IPFS    |               | Yes         | Yes          | No                | Yes                  | Yes              |
 | Substreams: mainnet        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | Substreams: optimism       |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Substreams: base           |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Substreams: scroll         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Substreams: linea          |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 
 The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
 The latest for the feature matrix above:

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -44,7 +44,7 @@ graph-node: >=0.35.0 <0.36.0
 
 ### Latest Council snapshot
 
-[GGP-0042: Updated Feature Matrix Support (base, scroll, linea)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x229e88da4839f8ba7f349323dfc564f991f72e4faef84506a7205b1c5059f631)
+[GGP-0043: Updated Feature Matrix Support (base, bsc, scroll, linea)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x4226f917346416b76f77369181881bebbc9b4e3f66e9681e5fc4e56d7460eba7)
 
 ### Other notes
 

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -46,7 +46,7 @@ graph-node: >=0.35.0 <0.36.0
 
 ### Latest Council snapshot
 
-[GGP-0040: Updated Feature Support (ens, arweave, 0.35.x)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x214ad88959a8e09e7341b21650699ab67345493d9386118dc524c827bd011090)
+[GGP-0042: Updated Feature Matrix Support (base, scroll, linea)](https://snapshot.org/#/council.graphprotocol.eth/proposal/0x21cd2337c58bf680281c1b4d795d07fe35bb83cf7c1071190bb3ca8fc20088aa)
 
 ### Other notes
 

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -24,8 +24,8 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:137                 | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:10                  | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:8453                | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:341690              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:243192              | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:534352              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -37,6 +37,7 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | Substreams: base           |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | Substreams: scroll         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | Substreams: linea          |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Substreams: bsc            |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
 
 The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
 The latest for the feature matrix above:


### PR DESCRIPTION
Adds full protocol support for base, bsc, scroll, and linea as data sources. The Council has already reviewed the CIP (Chain Integration Process) reports, and support for these chains was already verbally voted on.


Next steps:
- [x] Create a [GGP](https://snapshot.org/#/council.graphprotocol.eth) referencing this PR (Council approving full protocol support for these 3 chains)
- [x] Wait for the Council to vote
- [x] Add GGP to the feature matrix & merge PR


