### PR TITLE
Allow cost models in single network mode

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -43,6 +43,7 @@ const SUGGESTED_SUBGRAPH_MAX_BLOCK_DISTANCE_ON_L2 =
   50 + DEFAULT_SUBGRAPH_MAX_BLOCK_DISTANCE
 const DEFAULT_SUBGRAPH_FRESHNESS_SLEEP_MILLISECONDS = 5_000
 
+// NOTE: This is run only in single-network mode
 export const start = {
   command: 'start',
   describe: 'Start the agent',
@@ -237,7 +238,7 @@ export const start = {
         description:
           'Inject the GRT to DAI/USDC conversion rate into cost model variables',
         type: 'boolean',
-        default: true,
+        default: false,
         group: 'Cost Models',
       })
       .option('address-book', {
@@ -437,6 +438,12 @@ export async function createNetworkSpecification(
         },
       )
     }
+  }
+
+  if (chainId !== 1 && dai.inject) {
+    throw new Error(
+      `The DAI injection feature for cost models is only supported on Ethereum Mainnet`,
+    )
   }
 
   const tapAddressBook = loadFile(argv.tapAddressBook)

--- a/packages/indexer-cli/src/__tests__/cli.test.ts
+++ b/packages/indexer-cli/src/__tests__/cli.test.ts
@@ -1,10 +1,10 @@
-import { cliTest, setup, teardown } from './util'
+import { cliTest, setupMultiNetworks, teardown } from './util'
 import path from 'path'
 
 const baseDir = path.join(__dirname)
 
 describe('Indexer cli tests', () => {
-  beforeEach(setup)
+  beforeEach(setupMultiNetworks)
   afterEach(teardown)
 
   describe('General', () => {

--- a/packages/indexer-cli/src/__tests__/indexer/actions.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/actions.test.ts
@@ -1,10 +1,16 @@
-import { cliTest, deleteFromAllTables, seedActions, setup, teardown } from '../util'
+import {
+  cliTest,
+  deleteFromAllTables,
+  seedActions,
+  setupMultiNetworks,
+  teardown,
+} from '../util'
 import path from 'path'
 
 const baseDir = path.join(__dirname, '..')
 describe('Indexer actions tests', () => {
   describe('With indexer management server', () => {
-    beforeAll(setup)
+    beforeAll(setupMultiNetworks)
     afterAll(teardown)
     beforeEach(seedActions)
     afterEach(deleteFromAllTables)

--- a/packages/indexer-cli/src/__tests__/indexer/cost.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/cost.test.ts
@@ -1,18 +1,19 @@
 import {
   cliTest,
-  setup,
   teardown,
   connect,
   deleteFromAllTables,
   seedCostModels,
+  setupSingleNetwork,
+  setupMultiNetworks,
 } from '../util'
 import path from 'path'
 
 const baseDir = path.join(__dirname, '..')
 
-describe('Indexer cost tests', () => {
+describe('Indexer cost tests singleNetwork', () => {
   describe('With indexer management server', () => {
-    beforeAll(setup)
+    beforeAll(setupSingleNetwork)
     afterAll(teardown)
     beforeEach(seedCostModels)
     afterEach(deleteFromAllTables)
@@ -223,6 +224,50 @@ describe('Indexer cost tests', () => {
       'Indexer cost get - not connected',
       ['indexer', 'cost', 'get', 'QmXRpJW3qBuYaiBYHdhv8DF4bHDZhXBmh91MtrnhJfQ5Lk'],
       'references/indexer-not-connected',
+      {
+        expectedExitCode: 1,
+        cwd: baseDir,
+        timeout: 10000,
+      },
+    )
+  })
+})
+
+describe('Indexer cost tests multiNetworks', () => {
+  beforeAll(setupMultiNetworks)
+  afterAll(teardown)
+  beforeEach(seedCostModels)
+  afterEach(deleteFromAllTables)
+
+  describe('Cost set...', () => {
+    cliTest(
+      'Indexer cost set model deployment id - reject multinetwork mode',
+      [
+        'indexer',
+        'cost',
+        'set',
+        'model',
+        'QmXRpJW3qBuYaiBYHdhv8DF4bHDZhXBmh91MtrnhJfQ5Lk',
+        'references/basic.agora',
+      ],
+      'references/indexer-cost-model-deployment-multinetworks',
+      {
+        expectedExitCode: 1,
+        cwd: baseDir,
+        timeout: 10000,
+      },
+    )
+    cliTest(
+      'Indexer cost set variable deployment id - reject multinetwork mode',
+      [
+        'indexer',
+        'cost',
+        'set',
+        'variables',
+        'QmQ44hgrWWt3Qf2X9XEX2fPyTbmQbChxwNm5c1t4mhKpGt',
+        `'{"DAI": "0.5"}'`,
+      ],
+      'references/indexer-cost-variables-deployment-multinetworks',
       {
         expectedExitCode: 1,
         cwd: baseDir,

--- a/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexer/rules.test.ts
@@ -1,10 +1,10 @@
 import {
   cliTest,
   connect,
-  setup,
   teardown,
   deleteFromAllTables,
   seedIndexingRules,
+  setupMultiNetworks,
 } from '../util'
 import path from 'path'
 
@@ -12,7 +12,7 @@ const baseDir = path.join(__dirname, '..')
 
 describe('Indexer rules tests', () => {
   describe('With indexer management server', () => {
-    beforeAll(setup)
+    beforeAll(setupMultiNetworks)
     afterAll(teardown)
     beforeEach(seedIndexingRules)
     afterEach(deleteFromAllTables)

--- a/packages/indexer-cli/src/__tests__/references/indexer-cost-model-deployment-multinetworks.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-cost-model-deployment-multinetworks.stdout
@@ -1,0 +1,1 @@
+[GraphQL] Must be in single network mode to set cost models

--- a/packages/indexer-cli/src/__tests__/references/indexer-cost-variables-deployment-multinetworks.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-cost-variables-deployment-multinetworks.stdout
@@ -1,0 +1,1 @@
+[GraphQL] Must be in single network mode to set cost models

--- a/packages/indexer-cli/src/__tests__/util.ts
+++ b/packages/indexer-cli/src/__tests__/util.ts
@@ -103,7 +103,15 @@ export const testNetworkSpecification = specification.NetworkSpecification.parse
   },
 })
 
-export const setup = async () => {
+export const setupMultiNetworks = async () => {
+  return await setup(true)
+}
+
+export const setupSingleNetwork = async () => {
+  return await setup(false)
+}
+
+export const setup = async (multiNetworksEnabled: boolean) => {
   logger = createLogger({
     name: 'Setup',
     async: false,
@@ -141,10 +149,12 @@ export const setup = async () => {
   const fakeMainnetNetwork = cloneDeep(network) as Network
   fakeMainnetNetwork.specification.networkIdentifier = 'eip155:1'
 
-  const multiNetworks = new MultiNetworks(
-    [network, fakeMainnetNetwork],
-    (n: Network) => n.specification.networkIdentifier,
-  )
+  const multiNetworks = multiNetworksEnabled
+    ? new MultiNetworks(
+        [network, fakeMainnetNetwork],
+        (n: Network) => n.specification.networkIdentifier,
+      )
+    : new MultiNetworks([network], (n: Network) => n.specification.networkIdentifier)
 
   const defaults: IndexerManagementDefaults = {
     globalIndexingRule: {

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -23,7 +23,7 @@ export interface IndexerManagementResolverContext {
   logger: Logger
   defaults: IndexerManagementDefaults
   actionManager: ActionManager | undefined
-  multiNetworks: MultiNetworks<Network> | undefined
+  multiNetworks: MultiNetworks<Network>
   dai: WritableEventual<string>
 }
 
@@ -457,7 +457,7 @@ export interface IndexerManagementClientOptions {
   // on availability.
   // Ford: there were some edge cases where the GraphNode was not able to auto handle it on its own
   indexNodeIDs: string[]
-  multiNetworks: MultiNetworks<Network> | undefined
+  multiNetworks: MultiNetworks<Network>
   defaults: IndexerManagementDefaults
 }
 

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -23,7 +23,7 @@ export interface IndexerManagementResolverContext {
   logger: Logger
   defaults: IndexerManagementDefaults
   actionManager: ActionManager | undefined
-  multiNetworks: MultiNetworks<Network>
+  multiNetworks: MultiNetworks<Network> | undefined
   dai: WritableEventual<string>
 }
 
@@ -457,7 +457,7 @@ export interface IndexerManagementClientOptions {
   // on availability.
   // Ford: there were some edge cases where the GraphNode was not able to auto handle it on its own
   indexNodeIDs: string[]
-  multiNetworks: MultiNetworks<Network>
+  multiNetworks: MultiNetworks<Network> | undefined
   defaults: IndexerManagementDefaults
 }
 

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -97,8 +97,15 @@ export default {
     { costModel }: { deployment: string; costModel: GraphQLCostModel },
     { models, multiNetworks, dai }: IndexerManagementResolverContext,
   ): Promise<object> => {
-    if (Object.keys(multiNetworks.inner).length > 1) {
+    if (Object.keys(multiNetworks.inner).length !== 1) {
       throw Error('Must be in single network mode to set cost models')
+    }
+    const network = Object.values(multiNetworks.inner)[0]
+    const injectDai = network.specification.dai.inject
+    if (network.specification.networkIdentifier !== 'eip155:1' && injectDai) {
+      throw new Error(
+        `Can't set cost model: DAI injection enabled but not on Ethereum Mainnet`,
+      )
     }
 
     const update = parseGraphQLCostModel(costModel)
@@ -111,13 +118,6 @@ export default {
     } catch (err) {
       throw new Error(`Invalid cost model or variables: ${err.message}`)
     }
-    const network = multiNetworks.inner['eip155:1']
-    if (!network) {
-      throw new Error(
-        `Can't set cost model: Indexer Agent does not have Ethereum Mainnet network configured.`,
-      )
-    }
-    const injectDai = !!network.specification.dai.inject
     const [model] = await models.CostModel.findOrBuild({
       where: { deployment: update.deployment },
     })

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -97,8 +97,8 @@ export default {
     { costModel }: { deployment: string; costModel: GraphQLCostModel },
     { models, multiNetworks, dai }: IndexerManagementResolverContext,
   ): Promise<object> => {
-    if (!multiNetworks) {
-      throw Error('IndexerManagementClient must be in `network` mode to set cost models')
+    if (Object.keys(multiNetworks.inner).length > 1) {
+      throw Error('Must be in single network mode to set cost models')
     }
 
     const update = parseGraphQLCostModel(costModel)

--- a/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/cost-models.ts
@@ -97,6 +97,9 @@ export default {
     { costModel }: { deployment: string; costModel: GraphQLCostModel },
     { models, multiNetworks, dai }: IndexerManagementResolverContext,
   ): Promise<object> => {
+    if (!multiNetworks) {
+      throw new Error('No network configuration available')
+    }
     if (Object.keys(multiNetworks.inner).length !== 1) {
       throw Error('Must be in single network mode to set cost models')
     }


### PR DESCRIPTION
- `multiNetworks` was erroneously typed as possibly `undefined`, and `undefined` was used as a way to determine if we are in multi or single network mode in `cost-models.ts`.
However, the code doesn't actually allow for `multiNetworks` to be undefined, be it in multi or single network mode.
- The inject DAI setting now defaults to false
- Cost models are allowed only *if in single network mode* and:
  - On Ethereum mainnet
  - On any other network **and** "inject DAI" off

Some of these changes should be inconsequential considering the impending deprecation of Ethereum mainnet, as well as the fact that most indexers stopped using cost models due in part to #789.

Fixes #789 