### PR TITLE
indexer-cli, indexer-common: Add CLI command to kick off receipt collection for an allocation

### DIFF
--- a/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
+++ b/packages/indexer-cli/src/__tests__/references/indexer-help.stdout
@@ -21,6 +21,7 @@ Manage indexer configuration
   indexer allocations reallocate     Reallocate to subgraph deployment                                
   indexer allocations get            List one or more allocations                                     
   indexer allocations create         Create an allocation                                             
+  indexer allocations collect        Collect receipts for an allocation                               
   indexer allocations close          Close an allocation                                              
   indexer allocations                Manage indexer allocations                                       
   indexer actions update             Update one or more actions                                       

--- a/packages/indexer-cli/src/allocations.ts
+++ b/packages/indexer-cli/src/allocations.ts
@@ -311,3 +311,33 @@ export const reallocateAllocation = async (
 
   return result.data.reallocateAllocation
 }
+
+export const submitCollectReceiptsJob = async (
+  client: IndexerManagementClient,
+  allocationID: string,
+  protocolNetwork: string,
+): Promise<void> => {
+  const result = await client
+    .mutation(
+      gql`
+        mutation submitCollectReceiptsJob(
+          $allocation: String!
+          $protocolNetwork: String!
+        ) {
+          submitCollectReceiptsJob(
+            allocation: $allocation
+            protocolNetwork: $protocolNetwork
+          )
+        }
+      `,
+      {
+        allocation: allocationID,
+        protocolNetwork,
+      },
+    )
+    .toPromise()
+
+  if (result.error) {
+    throw result.error
+  }
+}

--- a/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
@@ -1,0 +1,84 @@
+import { GluegunToolbox } from 'gluegun'
+import chalk from 'chalk'
+
+import { loadValidatedConfig } from '../../../config'
+import { createIndexerManagementClient } from '../../../client'
+import { submitCollectReceiptsJob } from '../../../allocations'
+import { validateNetworkIdentifier } from '@graphprotocol/indexer-common'
+
+const HELP = `
+${chalk.bold('graph indexer allocations collect')} [options] <network> <id>
+
+${chalk.dim('Options:')}
+
+  -h, --help                    Show usage information
+  -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
+
+${chalk.dim('Networks:')}
+  mainnet, arbitrum-one, sepolia or arbitrum sepolia
+`
+
+module.exports = {
+  name: 'collect',
+  alias: [],
+  description: 'Collect receipts for an allocation',
+  run: async (toolbox: GluegunToolbox) => {
+    const { print, parameters } = toolbox
+
+    const spinner = toolbox.print.spin('Processing inputs')
+
+    const { h, help, o, output } = parameters.options
+
+    const outputFormat = o || output || 'table'
+    const toHelp = help || h || undefined
+
+    if (toHelp) {
+      spinner.stopAndPersist({ symbol: '💁', text: HELP })
+      return
+    }
+
+    if (!['json', 'yaml', 'table'].includes(outputFormat)) {
+      spinner.fail(`Invalid output format "${outputFormat}"`)
+      process.exitCode = 1
+      return
+    }
+
+    const [network, id] = parameters.array || []
+
+    if (id === undefined) {
+      spinner.fail(`Missing required argument: 'id'`)
+      print.info(HELP)
+      process.exitCode = 1
+      return
+    }
+
+    let protocolNetwork: string
+    if (!network) {
+      spinner.fail(`Missing required argument: 'network'`)
+      print.info(HELP)
+      process.exitCode = 1
+      return
+    } else {
+      try {
+        protocolNetwork = validateNetworkIdentifier(network)
+      } catch (error) {
+        spinner.fail(`Invalid value for argument 'network': '${network}' `)
+        process.exitCode = 1
+        return
+      }
+    }
+
+    spinner.text = `Collecting receipts for allocation '${id}`
+    try {
+      const config = loadValidatedConfig()
+      const client = await createIndexerManagementClient({ url: config.api })
+      await submitCollectReceiptsJob(client, id, protocolNetwork)
+
+      spinner.succeed('Submitted collect receipts job')
+    } catch (error) {
+      spinner.fail(error.toString())
+      process.exitCode = 1
+      return
+    }
+  },
+}

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -431,6 +431,7 @@ const SCHEMA_SDL = gql`
       force: Boolean
       protocolNetwork: String!
     ): ReallocateAllocationResult!
+    submitCollectReceiptsJob(allocation: String!, protocolNetwork: String!): Boolean!
 
     updateAction(action: ActionInput!): Action!
     updateActions(filter: ActionFilter!, action: ActionUpdateInput!): [Action]!

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -1129,4 +1129,48 @@ export default {
       throw error
     }
   },
+
+  submitCollectReceiptsJob: async (
+    {
+      allocation,
+      protocolNetwork,
+    }: {
+      allocation: string
+      protocolNetwork: string
+    },
+    { logger, multiNetworks }: IndexerManagementResolverContext,
+  ): Promise<boolean> => {
+    logger.debug('Execute collectAllocationReceipts() mutation', {
+      allocationID: allocation,
+      protocolNetwork,
+    })
+    if (!multiNetworks) {
+      throw Error(
+        'IndexerManagementClient must be in `network` mode to collect receipts for an allocation',
+      )
+    }
+    const network = extractNetwork(protocolNetwork, multiNetworks)
+    const networkMonitor = network.networkMonitor
+    const receiptCollector = network.receiptCollector
+
+    const allocationData = await networkMonitor.allocation(allocation)
+
+    try {
+      logger.info('Identifying receipts worth collecting', {
+        allocation: allocation,
+      })
+
+      // Collect query fees for this allocation
+      const collecting = await receiptCollector.collectReceipts(0, allocationData)
+
+      logger.info(`Submitted allocation receipt collection job for execution`, {
+        allocationID: allocation,
+        protocolNetwork: network.specification.networkIdentifier,
+      })
+      return collecting
+    } catch (error) {
+      logger.error(error.toString())
+      throw error
+    }
+  },
 }


### PR DESCRIPTION
## Changes
- indexer-common: Add `submitCollectReceiptsJob` graphQL resolver for kicking off receipt collection
- indexer-cli: Add helper function for sending mutation to the `submitCollectReceiptsJob` resolver
- indexer-cli: Add `collect` command to `allocations` module that uses the new helper and graphQL resolver to submit a job to collect receipts for an allocation