### PR TITLE
indexer-common: Avoid using createdAt field for pagination

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -86,7 +86,7 @@ const setupMonitor = async () => {
   const INDEXER_TEST_API_KEY: string = process.env['INDEXER_TEST_API_KEY'] || ''
   networkSubgraph = await NetworkSubgraph.create({
     logger,
-    endpoint: `https://gateway-arbitrum.network.thegraph.com/api/${INDEXER_TEST_API_KEY}/subgraphs/name/graphprotocol/graph-network-arbitrum-sepolia`,
+    endpoint: `https://gateway-arbitrum.network.thegraph.com/api/${INDEXER_TEST_API_KEY}/subgraphs/id/3xQHhMudr1oh69ut36G2mbzpYmYxwqCeU6wwqyCDCnqV`,
     deployment: undefined,
     subgraphFreshnessChecker,
   })
@@ -304,7 +304,7 @@ describe('Types', () => {
 
 // This test suite requires a graph-node instance connected to Sepolia, so we're skipping it for now
 // Use this test suite locally to test changes to the NetworkMonitor class
-describe.skip('Monitor', () => {
+describe.skip('Monitor: local', () => {
   beforeAll(setupMonitor)
 
   test('Fetch currentEpoch for `sepolia`', async () => {
@@ -347,6 +347,134 @@ describe.skip('Monitor', () => {
       networkMonitor.resolvePOI(mockAllocation, undefined, false),
     ).rejects.toEqual(indexerError(IndexerErrorCode.IE018, `Could not resolve POI`))
   })
+})
+
+describe('Monitor: CI', () => {
+  beforeAll(setupMonitor)
+
+  test('Fetch subgraphs', async () => {
+    const subgraphs = await networkMonitor.subgraphs([
+      'HvYz9828kSW9vhDef42agWaJVEifgYh8qQ1vUTy1aiYB',
+      'BgGaFXhu17ikYBjezuyYXGgaDtP6nVhnk3FmEw7rVDPH',
+      'Dtopx26mi8QZUz8TQGeEk8ranuVGUnmPgi7qAZbGtsFi',
+      'DRc8dd1ugk7To99Q51UG3PrJppneR3XtbWu5xkQFCqh7',
+      '7gEARKTwgN8xbTnaDBmfSuxi2s5dWRpqGEKjc7gx1znW',
+      '5bSJRNJFjMJy87v2uwuo82GQyyGAps2u96x2UQyN8Uhc',
+      'JBZfGX5pWpya4HJHkY54EcjQe1tJhNfszDTbjZGjgGjV',
+      'Gj5g62GNwRdAjRcGj9qh7M3iwR5SULVYDqAk8wsi1XJq',
+      '3XKjubSDj6pzn8BasduK6kJGNkAVg3fWUuCBzP5jzCCM',
+      '66CJq5efooGv6Zu2tE8t2xWiGF1cMZqLQxVLBF3SquKR',
+      'A5iZuVkBbxU2GwJcQKN35JvUSaUcLJeygwwnpukhPvjG',
+      'CdJLdxVQPigWi3LJoDdwf8r6mXBL8nzn1kdVWp2HeLBN',
+      '6qMkvRupvTRuHbYHaSRgP6ebjqM1ELjCHrkQoH9eJQcA',
+      'ELxt8ANmxY7i1EXEnP3tv8tYi8S5rTwt9WDP4yYJkwyR',
+      'ASB13Eew3Td483LX8A5G6wTiApvySgvYLqrFM3yJiG6E',
+      '5etifdh5PjGTAx4hwS2baYDEwZMzvPDXFXmAT5kVKk4E',
+      'HzfmvtAPCTmrmiupvWYUdesW21UeDZXgN3oVdTGhV57J',
+      '2a9q1MCYJw5HHc9n87uUr9dvRcQd16ghd55cZRGSzGa2',
+      'EiJPdVWJYtZKdtQjwDdfMahHc5aNncQMXVK2JZACFuFV',
+      '8ScER3UC5cP12BDpxX6a5WyW41LcUkCZtbXfF31zdrXS',
+      'GLRGaAVXu3qHs3h6GKmEV6kpVFiN7VS2fwcfPvBJPUbq',
+      'CBirSH123kAM7eEVJ1WRYUm8RDwnKPn96zakbDPLoKjV',
+      'BzV6inHQyfYh3Gtd8WWSJ3YY5ghmAHd7aT3Eu84ZfHTK',
+      'EgPkp3cJm3J3wHdkJBN9kbgW5e3ZTMTnR6aKs81mCp39',
+      '8vZCBf6XcYDGS6XxvhNbenT71qwn6SYwti6KwdoKNzn6',
+      'HfWJgc9Xg2APHKTqCi3VnvrtbPHPwXZEvdmShaFSdyCL',
+      'Ayqu513Ky67HJP5uednpdRwPSTXj1vftCqF7t3dZCrZ2',
+      '7a4xK25hdSygHSjiZfhgcqJLmP28XwYUJLaK77w55h8V',
+      'ANCYpT6k2rBVC72cQH4M9w3nPhMGxNDvibFQjjDqAbaY',
+      'Bo8SSPTVT6S9aUSMfMMtQxeLvWHpwfyVBoN1m5WbQAyf',
+      'DybNNj1H5Yo9JV4zQTSZTrWdWLWGdYPM84LCL53uCyjS',
+      'ADkZT6CyyfV2xCE7GHhD592E4UMy7DBA8vKR4maTSHJo',
+      'CgA4yPyXkTLNQTj8vqTahEe4xvsNRjfQ4YuF22qhir4u',
+      '4C7iR2BKUYPsPADBiKqBZ9iYnhVrcqbrCSsLhFHCYqxS',
+      '6vQd7Sw4pQHyB6rkPW6s9j3ir6jQeHjqXtnGr4tRVuFz',
+      'EtDixXg72aFinnVSoLewXyuGd7ZG1wJ3E1Z8h7W1bRLK',
+      '5AcdpucdAigyCCw7dYnY9UkWFQusmD3bMW7Q6M5MLyiM',
+      'CJu2REP2NFdaGnUhENbLm4mLu3Zwggf574ZEaqBoRN9Y',
+      'Nvgja9qFMA4XteMWrXqwDiJae1VgwVnC9KtEK9bV3F7',
+      '2ggc5UTwzsUaYe3EFmo5vp8Jek7KeHxxZjaLfYvSXFP8',
+      '9NkN2mq5PbFEjYHMH2L77Udsesux3JL7fnYqMrcveMku',
+      '7wZkJrw56S8kcJ67VsYCvxQPu72GGyCLZPPz86DCRqCe',
+      'AN8YMdsAwwh6uCJgPmpVxzoyL391QjX9tmU7GWzRKxdA',
+      'HW8LumeFnPGGZfBSM4NuZ7yp9PALYAUErLT2b8CssHUc',
+      '6HJctiD7icf3W9HcYHUx4WrZBpkMnJxDKLBXgDeuipfz',
+      '6UhCCSzz8jMKnQtFjiVainFLDWKTCepRakvjGDsih46',
+      'J5s1Q5ECEuvcyr8hfCVJxdebmwiQTGWbNGXu8GLfnSBj',
+      'BcPHsbz9MxxnfX2BWNVAz8vbyJ8JAzr2TyMcUZxgbZPk',
+      'Dc5pZQFUtmMY4tqf37KhBxwSHoFDiWDWShdfpbjtYVqG',
+      '22W58bMNpfn5Nsf6ifvT4r8j622t3ez6cLNHP19DJN8i',
+      '69vjj2v5Ke56t1xiz3JEvWBvPxw6aCVdEfQyaiSxw5M1',
+      '6WWUQuethroETYkvjHwzK8SBsBrFXRU6N3r3wGGHhBNJ',
+      '7s8mN56GZAwv7xUsYG5NGJUY28zXRYfM2MC3adV8fzmS',
+      '36YoDeNb5vbzocAxrBFqs75DPwBHVVQyR1HE792rEZhU',
+      '8uaT7jBZeZquyCGZf2guEXT6qxRzJLRupWqNo7J9GVWC',
+      'HMwbgUHTSUByt1wn939V7ZmtkLmZzSwDrQF8g735Ke7b',
+      'Hz57mJ1hFHNKqedeSL2XKLCVUgZz4KrmhrBUpqaof7w2',
+      '2YKP9Gdvu8mZHTQ2gVs3GFhE6CFuPmzhKor9rWS2dNcb',
+      '2t356FsLEPcMRT7Nf6wCtYhxDGPqGk617h7H3QDTWadN',
+      '34eG1YjaeTuhAXRAgQ9iiALNBBANmc17M1r7EGsfiVSJ',
+      'GcfmCd2iTPW66ZmerMSJQGdF5BvMdsGdjeRr8jdgWJvc',
+      'oHHaActByLEv9ju6x6EieuTkw7yswf3cD8T6zL7d8Mp',
+      'XvVPwD5vksVYQFbn56ZkKCRptMkycPwYTKUWNB2Xh5f',
+      '8gqQ8Z2Voot9UVEUEvo95sbUSb5jRnTVFgh2fyJ1gpuW',
+      'H5skicpD6dtAy2KmbZMCPk4nL5xx8Ye26PZuoJLNDXkX',
+      '6CBsUzoznswJLacHuv5nbRExvdiTQo5MD4A4AMm2S5vc',
+      '6Fh1ibLTEukUKEsxHiomJRe1pyrJ9LWLiGhgg5huugHw',
+      'ARCYeKaxqU6gZhWCzYHeyFMPEAT87yVrQrnVESsm3NfW',
+      '9DQrJomnSKjakL9paTgMkFXazwHuRBg83kEj9K7jQxKq',
+      'BNJm3VSrZEvKsCpVA5h2Ya7Z6BHWMSnQWtShcHVWgQpL',
+      '6skFEGLGTjPDWbh384aA2MXLafNwDjAJoB7fFhgX8o7E',
+      'CMJsyibqSGLENXoCMR66fSQ1tSgoK9qBbao765CRy9i3',
+      '9D1KdYAmkeb9kav8rDLnqQ3SdxKjLxgjgV8yT8cPHPGP',
+      '6VB3T5xSpefLx6otMyN8SdCow54GSzibbBe8epdrreTk',
+      'CBJNRDCv8xKST8T5pQjTrhSMPNMfdFKyMMaoLbZd5CfZ',
+      '5h89RnR4SBk3ZJaDoCEZvrbpSozxQEvtR66DbGAiCWRh',
+      'AtMK1PwRJ9FWLJQwnJrWXSrS1e87RkXieVyxpGXNtTe3',
+      '6xCGdHHdtqN4BkaZ4CqXVjNXnhv9ig6iQmUgQFC5o4KA',
+      'Fb1eSwi1EaXDYJmMtDX6nESuzkJEPxgnaEa2Qy87hvnv',
+      '7HRYsuMBw3NGb7r7EhoukNfHWxgswRHA7MDFy6ynJ6Jd',
+      '2rNEuiiMbruTbBv1RTdhnLbV8XW2wpxZ2ToHW3pRZsyn',
+      '6tFRMbJ9r8D19PzHDzowFsANGz5zpJ7q68ve8sCtLhUK',
+      '2FxttPXDzPr3hp8th55jGwKQDK658eY9fAYgPS5BQsgG',
+      '9oSK1nvoTuP1w6jhEWuJcC9dQRDVrBaeih4SFcvhtd1D',
+      'AXmvC1aTytCFHK7gpLSwA4jmBDeboxP3ihMrZbneHrU8',
+      'Cy8qmbBqNt5s6iv7QMKaEaSSh42qcjdSHBX7f6MXLFqj',
+      '6C6sYnvJ8UAZ1uNgMbNeab8pM4emZn4zricGn16YZuX1',
+      'GwWgugJfPeu7t2eybUEuvJk454pWPngMvuK4VAs6YMoF',
+      '4z6tVjyfWGSvY413cSfQXaGhatfo81hnZwsWZiNtjnac',
+      'GSV9W7bhDtbyb8XTq4Dy5TUuWxRH69DEixmW38EdgJdM',
+      '9M5fLJZiYTUUmrK7kCqBfqDFLdmsTWeoU1s3bTGrB64t',
+      'HCDKJuiXenPM8e1Qaa268HTPDH8k6jdoBPBHWPfBHTfx',
+      '48U9e6UbwY59KcUUvEegyRBS54MLx4A24hjLxFonGkH4',
+      '7emAwR6QUXGehvZdeCHH7efkjCkDD1U95ksxQhrpxAqg',
+      '5y4rHLyv4C9Y8YBDyBex9fanCggE5vSLUJgYsCyWpX2w',
+      '9nQ3a8fFGjT3Z1U2Fn3hzvXmG5jGQ3AXpchAE1LQSJ7y',
+      '2wP9kvh3Uwm4Y3Zprsx2PxFPxMxZw5mePWwp7ukBQtms',
+      'HZG6KXnzP7ZgWYabSAUvHcyxG85DVUkQf2UBUcCEEdTy',
+      'Fm7cMpTzBwyNybmEu67mU29FpKJZXCz38VuHiCh3MA3Z',
+      '6HJutXDqXLUo3otxnLWtC7FiXkxePbLZoa84TYaJ4qg7',
+      'DtXURXnabk5EsPAQhivDYhZWYYQScLGDVyZdfmfGiTWA',
+      'E3CpBTZ2ZprQ5XKprw5TBQkbJ3DzYGJQx1AhyApyKvch',
+      'CupTKerusECgKEqYzuSMk7wtKYnmo5WXZ2gtJtKreS6R',
+      'DTBkMR3i697w7JPwcvCdrcqtxRhS8FtgoHZqp87Sodqf',
+      '5fRc469U46WVkH9WWYQ2wUuS3cdrX14WNmHGyaqg87Fe',
+      'HGZgSEpRbwY3H54vyrUfqn8RXqDA23qT9yLqyxZXZTNW',
+    ])
+    await expect(subgraphs.length).toEqual(106)
+  })
+
+  //TODO: Setup constrained subraphDeployments query that works both against graph-node and the gateway
+
+  // test('Fetch subgraph deployments (constrained)', async () => {
+  //   const deployments = await networkMonitor.subgraphDeployments(59022843)
+  //   await expect(deployments.length).toEqual(589)
+  // }, 30000)
+
+  test('Fetch subgraph deployments (unconstrained block)', async () => {
+    const deployments = await networkMonitor.subgraphDeployments()
+    await expect(deployments.length).toBeGreaterThan(500)
+  }, 30000)
 })
 
 describe('Network layer detection', () => {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -595,10 +595,7 @@ export class NetworkMonitor {
       try {
         const result = await this.networkSubgraph.checkedQuery(
           gql`
-            query subgraphDeployments(
-              $first: Int!
-              $lastId: String!
-            ) {
+            query subgraphDeployments($first: Int!, $lastId: String!) {
               subgraphDeployments(
                 where: { id_gt: $lastId }
                 orderBy: id


### PR DESCRIPTION
## Changes
- Update several `NetworkMonitor` functions to paginate by `id` instead of by `createdAt`. Functions updated: subgraphs(), subgraphDeployments() and disputableAllocations(). 

## Background
On L2 networks, like arbitrum-one, `createdAt` is not necessarily unique, so paginating based on `createdAt` can lead to missing items.