### PR TITLE
Indexer-common: Fix graph-node deployment rules; remove reassign command on initial deployment

### DIFF
--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -383,7 +383,6 @@ export class GraphNode {
           })[0].id
       await this.create(name)
       await this.deploy(name, deployment, targetNode)
-      await this.reassign(deployment, targetNode)
     } catch (error) {
       if (!(error instanceof IndexerError)) {
         const errorCode = IndexerErrorCode.IE020


### PR DESCRIPTION
Wanting to use the graph-node deployment rules (as shown [here](https://github.com/graphprotocol/graph-node/blob/master/docs/config.md#controlling-deployment)), I followed the logic path for the `subgraph_deploy` graph-node RPC method. I found that it already selects an initial deployment based on the deployment rules, ignoring any deployment target you pass with the RPC call. So I took a look at the indexer agent program, and I found that after it calls the `subgraph_deploy` RPC method, it calls the `subgraph_reassign` method, which doesn't ignore the target node you pass with the call.

Removing the redeploy call leaves the graph-node to decide the target deployment based on the deployment rules defined in your graph node config, as it should be.