### PR TITLE
feat: Deployment tags to replace `indexer-agent` prefix in deployment names

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -738,11 +738,12 @@ export class Agent {
         switch (this.deploymentManagement) {
           case DeploymentManagementMode.AUTO:
             try {
+              const resolvedDeploymentTags = await deploymentTags.value()
               await this.reconcileDeployments(
                 activeDeployments,
                 targetDeployments,
                 eligibleAllocations,
-                deploymentTags,
+                resolvedDeploymentTags,
               )
             } catch (err) {
               logger.warn(

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -567,13 +567,13 @@ export class Agent {
       },
     )
 
-    const deploymentTags: Eventual<Map<SubgraphDeploymentID, string>> = join({
+    const deploymentTags: Eventual<Map<string, string>> = join({
       ticker: timer(120_000),
       indexingRules,
     }).tryMap(
       async ({ indexingRules }) => {
         logger.trace('Resolving deployment tags')
-        const deploymentTags: Map<SubgraphDeploymentID, string> = new Map()
+        const deploymentTags: Map<string, string> = new Map()
 
         // Add offchain subgraphs to the deployment list from rules
         Object.values(indexingRules)
@@ -583,7 +583,7 @@ export class Agent {
           )
           .forEach(rule => {
             deploymentTags.set(
-              new SubgraphDeploymentID(rule.identifier),
+              new SubgraphDeploymentID(rule.identifier).toString(),
               rule.tag,
             )
           })
@@ -936,7 +936,7 @@ export class Agent {
     activeDeployments: SubgraphDeploymentID[],
     targetDeployments: SubgraphDeploymentID[],
     eligibleAllocations: Allocation[],
-    deploymentTags: Map<SubgraphDeploymentID, string>,
+    deploymentTags: Map<string, string>,
   ): Promise<void> {
     const logger = this.logger.child({ function: 'reconcileDeployments' })
     logger.debug('Reconcile deployments')
@@ -1008,12 +1008,8 @@ export class Agent {
     await queue.addAll(
       deploy.map(deployment => async () => {
         const name = `${
-          deploymentTags.get(
-            new SubgraphDeploymentID(deployment.display.ipfsHash),
-          )
-            ? deploymentTags.get(
-                new SubgraphDeploymentID(deployment.display.ipfsHash),
-              )
+          deploymentTags.get(deployment.toString())
+            ? deploymentTags.get(deployment.toString())
             : 'indexer-agent'
         }/${deployment.ipfsHash.slice(-10)}`
 

--- a/packages/indexer-agent/src/db/migrations/14-indexing-rules-add-deployment-tag.ts
+++ b/packages/indexer-agent/src/db/migrations/14-indexing-rules-add-deployment-tag.ts
@@ -24,9 +24,7 @@ export async function up({ context }: Context): Promise<void> {
   const table = await queryInterface.describeTable('IndexingRules')
   const subgraphTagColumn = table.tag
   if (subgraphTagColumn) {
-    logger.info(
-      `'tag' column already exists, migration not necessary`,
-    )
+    logger.info(`'tag' column already exists, migration not necessary`)
     return
   }
 
@@ -36,7 +34,6 @@ export async function up({ context }: Context): Promise<void> {
     primaryKey: false,
     defaultValue: 'indexer-agent',
   })
-
 }
 
 export async function down({ context }: Context): Promise<void> {
@@ -47,11 +44,9 @@ export async function down({ context }: Context): Promise<void> {
 
     if (tables.includes('IndexingRules')) {
       logger.info(`Remove 'tag' column`)
-      await context.queryInterface.removeColumn(
-        'IndexingRules',
-        'tag',
-        { transaction },
-      )
+      await context.queryInterface.removeColumn('IndexingRules', 'tag', {
+        transaction,
+      })
     }
   })
 }

--- a/packages/indexer-agent/src/db/migrations/14-indexing-rules-add-deployment-tag.ts
+++ b/packages/indexer-agent/src/db/migrations/14-indexing-rules-add-deployment-tag.ts
@@ -1,0 +1,57 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { DataTypes, QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.debug(`Checking if indexing rules table exists`)
+  const tables = await queryInterface.showAllTables()
+  if (!tables.includes('IndexingRules')) {
+    logger.info(`Indexing rules table does not exist, migration not necessary`)
+    return
+  }
+
+  logger.debug(`Checking if 'IndexingRules' table needs to be migrated`)
+  const table = await queryInterface.describeTable('IndexingRules')
+  const subgraphTagColumn = table.tag
+  if (subgraphTagColumn) {
+    logger.info(
+      `'tag' column already exists, migration not necessary`,
+    )
+    return
+  }
+
+  logger.info(`Add 'tag' column to 'IndexingRules' table`)
+  await queryInterface.addColumn('IndexingRules', 'tag', {
+    type: DataTypes.STRING,
+    primaryKey: false,
+    defaultValue: 'indexer-agent',
+  })
+
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  return await queryInterface.sequelize.transaction({}, async transaction => {
+    const tables = await queryInterface.showAllTables()
+
+    if (tables.includes('IndexingRules')) {
+      logger.info(`Remove 'tag' column`)
+      await context.queryInterface.removeColumn(
+        'IndexingRules',
+        'tag',
+        { transaction },
+      )
+    }
+  })
+}

--- a/packages/indexer-cli/src/rules.ts
+++ b/packages/indexer-cli/src/rules.ts
@@ -37,6 +37,7 @@ const INDEXING_RULE_PARSERS: Record<keyof IndexingRuleAttributes, (x: never) => 
   requireSupported: x => parseBoolean(x),
   safety: x => parseBoolean(x),
   protocolNetwork: x => x,
+  tag: x => x,
 }
 
 const INDEXING_RULE_FORMATTERS: Record<
@@ -61,6 +62,7 @@ const INDEXING_RULE_FORMATTERS: Record<
   requireSupported: x => x,
   safety: x => x,
   protocolNetwork: resolveChainAlias,
+  tag: x => x,
 }
 
 const INDEXING_RULE_CONVERTERS_FROM_GRAPHQL: Record<
@@ -85,6 +87,7 @@ const INDEXING_RULE_CONVERTERS_FROM_GRAPHQL: Record<
   requireSupported: x => x,
   safety: x => x,
   protocolNetwork: x => x,
+  tag: x => x,
 }
 
 const INDEXING_RULE_CONVERTERS_TO_GRAPHQL: Record<
@@ -109,6 +112,7 @@ const INDEXING_RULE_CONVERTERS_TO_GRAPHQL: Record<
   requireSupported: x => x,
   safety: x => x,
   protocolNetwork: x => x,
+  tag: x => x,
 }
 
 /**
@@ -267,6 +271,7 @@ export const indexingRules = async (
             decisionBasis
             requireSupported
             safety
+            tag
           }
         }
       `,
@@ -307,6 +312,7 @@ export const indexingRule = async (
             requireSupported
             safety
             protocolNetwork
+            tag
           }
         }
       `,
@@ -350,6 +356,7 @@ export const setIndexingRule = async (
             requireSupported
             safety
             protocolNetwork
+            tag
           }
         }
       `,

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
@@ -45,6 +45,7 @@ const SET_INDEXING_RULE_MUTATION = gql`
       requireSupported
       safety
       protocolNetwork
+      tag
     }
   }
 `

--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -101,6 +101,7 @@ export const createTestManagementClient = async (
       requireSupported: true,
       safety: true,
       protocolNetwork: 'sepolia',
+      tag: 'indexer-agent',
     },
   }
 
@@ -137,6 +138,7 @@ export const defaults: IndexerManagementDefaults = {
     parallelAllocations: 1,
     requireSupported: true,
     safety: true,
+    tag: 'indexer-agent',
   },
 }
 

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -263,6 +263,7 @@ const SCHEMA_SDL = gql`
     requireSupported: Boolean!
     safety: Boolean!
     protocolNetwork: String!
+    tag: String
   }
 
   input IndexingRuleInput {
@@ -282,6 +283,7 @@ const SCHEMA_SDL = gql`
     requireSupported: Boolean
     safety: Boolean
     protocolNetwork: String!
+    tag: String
   }
 
   input IndexingRuleIdentifier {

--- a/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
+++ b/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
@@ -31,6 +31,7 @@ export interface IndexingRuleAttributes {
   requireSupported: boolean
   safety: boolean
   protocolNetwork: string
+  tag: string
 }
 
 // Unambiguously identify a Indexing Rule in the Database.

--- a/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
+++ b/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
@@ -61,6 +61,7 @@ export interface IndexingRuleCreationAttributes
     | 'requireSupported'
     | 'safety'
     | 'protocolNetwork'
+    | 'tag'
   > {}
 
 export class IndexingRule
@@ -84,6 +85,7 @@ export class IndexingRule
   public requireSupported!: boolean
   public safety!: boolean
   public protocolNetwork!: string
+  public tag!: string
 
   public createdAt!: Date
   public updatedAt!: Date
@@ -267,6 +269,12 @@ export const defineIndexingRuleModels = (sequelize: Sequelize): IndexingRuleMode
         validate: {
           is: caip2IdRegex,
         },
+      },
+      tag: {
+        type: DataTypes.STRING,
+        primaryKey: true,
+        allowNull: false,
+        defaultValue: 'indexer-agent',
       },
     },
     {

--- a/packages/indexer-common/src/operator.ts
+++ b/packages/indexer-common/src/operator.ts
@@ -109,6 +109,7 @@ export class Operator {
                 decisionBasis
                 requireSupported
                 protocolNetwork
+                tag
               }
             }
           `,

--- a/packages/indexer-common/src/rules.ts
+++ b/packages/indexer-common/src/rules.ts
@@ -36,6 +36,7 @@ const INDEXING_RULE_READABLE_TO_MODEL_PARSERS: Record<
   requireSupported: (x) => parseBoolean(x),
   safety: (x) => parseBoolean(x),
   protocolNetwork: (x: string) => validateNetworkIdentifier(x),
+  tag: (x: string) => x,
 }
 
 export const parseIndexingRule = (


### PR DESCRIPTION
Indexers need an easy way to deploy to different shards and graph-nodes. This is already possible with graph-node alone via deployment rules and deployment name regex matching, but the indexer-agent doesn't give any way to control the name that a deployment is given. With this PR, I've introduced a `tag` column for indexing rules, whose contents will replace the `indexer-agent` prefix for deployment names upon first deployment.

With a combination of a deployment rule like this:
```
[[deployment.rule]]
match = { name = "(vip|important)/.*", network = "arbitrum-one" }
shard = "arbitrum_vip"
indexers = [ "graph_node_vip_0", "graph_node_vip_1" ]
```
and a `tag` set like this:
```
graph indexer rules set QmHash decisionBasis offchain tag vip
```
You can now deploy VIP arbitrum subgraphs to your arbitrum VIP database directly.


Feel free to request or make changes. I'll do my best to satisfy any requirements so we can get this merged.