### PR TITLE
common,agent: fix tsconfig, error-handling export

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -32,7 +32,7 @@ import { injectCommonStartupOptions } from './common-options'
 import pMap from 'p-map'
 import { NetworkSpecification } from '@graphprotocol/indexer-common/dist/network-specification'
 import { BigNumber } from 'ethers'
-import { displayZodParsingError } from '@graphprotocol/indexer-common/src/parsers/error-handling'
+import { displayZodParsingError } from '@graphprotocol/indexer-common'
 import { readFileSync } from 'fs'
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/packages/indexer-agent/tsconfig.json
+++ b/packages/indexer-agent/tsconfig.json
@@ -12,7 +12,7 @@
     "composite": true,
     "lib": ["es2015", "es6", "esnext.asynciterable", "dom", "ES2020.Promise"]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "../indexer-common/src/parsers/error-handling.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["src/**/__tests__/*.ts"],
   "references": [{ "path": "../indexer-common" }]
 }

--- a/packages/indexer-common/src/parsers/index.ts
+++ b/packages/indexer-common/src/parsers/index.ts
@@ -1,2 +1,3 @@
 export * from './validators'
 export * from './test-utils'
+export * from './error-handling'


### PR DESCRIPTION
## Changed

- Properly exported error-handling module.
- Removed tsconfig workaround.


`error-handling` is not being properly exported for use in other packages where it's now used.

```
Error: Cannot find module '@graphprotocol/indexer-common/src/parsers/error-handling'
Require stack:
- /opt/indexer/packages/indexer-agent/dist/commands/start.js
- /opt/indexer/packages/indexer-agent/dist/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/opt/indexer/packages/indexer-agent/dist/commands/start.js:18:26)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/indexer/packages/indexer-agent/dist/commands/start.js',
    '/opt/indexer/packages/indexer-agent/dist/index.js'
  ]
}

Node.js v20.11.1
```