### PR TITLE
chore: add package manager for corepack to detect

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
     "transformIgnorePatterns": [
       "node_modules/(?!@thi.ng)"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
Using [corepack](https://nodejs.org/api/packages.html#packagemanager) so it is easier to manage pacakge manager used in the project.

