### PR TITLE
indexer-cli: add type annotation for test util network specification

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/util.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/util.ts
@@ -16,7 +16,8 @@ import {
 import { connectDatabase, Metrics, Logger, parseGRT } from '@graphprotocol/common-ts'
 
 const yamlObj = loadTestYamlConfig()
-export const testNetworkSpecification = specification.NetworkSpecification.parse(yamlObj)
+export const testNetworkSpecification: specification.NetworkSpecification =
+  specification.NetworkSpecification.parse(yamlObj)
 
 export const createTestManagementClient = async (
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any


### PR DESCRIPTION
In release 0.23.1, some are encountering a type annotation issue building cli.

```
src/indexer-management/__tests__/util.ts(19,14): error TS2742: The inferred type of 'testNetworkSpecification' cannot be named without a reference to '@graphprotocol/indexer-cli/node_modules/ethers'. This is likely not portable. A type annotation is necessary.
```