### PR TITLE
ci: create builds for node versions and arm64 mac

### DIFF
--- a/.github/workflows/publish-native-binaries.yml
+++ b/.github/workflows/publish-native-binaries.yml
@@ -17,21 +17,17 @@ jobs:
       # (https://github.com/bchr02/node-pre-gyp-github/issues/42)
       fail-fast: false
       matrix:
-        node_version: [18, 19, 20]
+        node-version: [18, 20, 22]
         system:
-          - os: macos-12
+          - os: macos-13-xlarge # ARM https://github.com/actions/runner-images/blob/main/images/macos/macos-13-arm64-Readme.md
             target: x86_64-apple-darwin
+          - os: macos-14 # ARM https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+            target: x86_64-apple-darwin
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-        include:
-          - node_version: 17
-            system:
-              os: ubuntu-20.04
-              target: x86_64-unknown-linux-gnu
-          - node_version: 17
-            system:
-              os: macos-11
-              target: x86_64-apple-darwin
+
     runs-on: ${{ matrix.system.os }}
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
Run across multiple node js versions we maintain and across CPU configurations for Mac and linux

see https://github.com/graphprotocol/indexer/actions/runs/9880379378?pr=947

