### PR TITLE
fix: remove queryInterface reference

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -593,14 +593,7 @@ export async function run(
   const networks: Network[] = await pMap(
     networkSpecifications,
     async (spec: NetworkSpecification) =>
-      Network.create(
-        logger,
-        spec,
-        queryFeeModels,
-        graphNode,
-        metrics,
-        sequelize.getQueryInterface(),
-      ),
+      Network.create(logger, spec, queryFeeModels, graphNode, metrics),
   )
 
   // --------------------------------------------------------------------------------

--- a/packages/indexer-common/src/allocations/__tests__/tap.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap.test.ts
@@ -60,7 +60,6 @@ const setup = async () => {
     queryFeeModels,
     graphNode,
     metrics,
-    sequelize.getQueryInterface(),
   )
   receiptCollector = network.receiptCollector
 }

--- a/packages/indexer-common/src/allocations/query-fees.ts
+++ b/packages/indexer-common/src/allocations/query-fees.ts
@@ -35,7 +35,6 @@ import pReduce from 'p-reduce'
 import { TAPSubgraph } from '../tap-subgraph'
 import { NetworkSubgraph } from '../network-subgraph'
 import gql from 'graphql-tag'
-import { QueryInterface } from 'sequelize'
 
 // Receipts are collected with a delay of 20 minutes after
 // the corresponding allocation was closed
@@ -89,7 +88,6 @@ export interface AllocationReceiptCollectorOptions {
   networkSpecification: spec.NetworkSpecification
   tapSubgraph: TAPSubgraph | undefined
   networkSubgraph: NetworkSubgraph
-  queryInterface: QueryInterface
 }
 
 export interface ReceiptCollector {
@@ -127,7 +125,6 @@ export class AllocationReceiptCollector implements ReceiptCollector {
   declare tapSubgraph: TAPSubgraph | undefined
   declare networkSubgraph: NetworkSubgraph
   declare finalityTime: number
-  declare queryInterface: QueryInterface
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function -- Private constructor to prevent direct instantiation
   private constructor() {}
@@ -143,7 +140,6 @@ export class AllocationReceiptCollector implements ReceiptCollector {
     networkSpecification,
     tapSubgraph,
     networkSubgraph,
-    queryInterface,
   }: AllocationReceiptCollectorOptions): Promise<AllocationReceiptCollector> {
     const collector = new AllocationReceiptCollector()
     collector.logger = logger.child({ component: 'AllocationReceiptCollector' })
@@ -159,7 +155,6 @@ export class AllocationReceiptCollector implements ReceiptCollector {
     collector.protocolNetwork = networkSpecification.networkIdentifier
     collector.tapSubgraph = tapSubgraph
     collector.networkSubgraph = networkSubgraph
-    collector.queryInterface = queryInterface
 
     // Process Gateway routes
     const gatewayUrls = processGatewayRoutes(networkSpecification.gateway.url)
@@ -619,7 +614,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         SET redeemed_at = NULL
         WHERE allocation_id IN ('${nonRedeemedAllocationIDsTrunc.join("', '")}')
       `
-      await this.queryInterface.sequelize.query(query)
+      await this.models.receiptAggregateVouchers.sequelize?.query(query)
 
       // // Update those that redeemed_at is older than 60 minutes and mark as final
       query = `
@@ -629,7 +624,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
         AND redeemed_at < NOW() - INTERVAL '${this.finalityTime} second'
         AND redeemed_at IS NOT NULL
       `
-      await this.queryInterface.sequelize.query(query)
+      await this.models.receiptAggregateVouchers.sequelize?.query(query)
 
       return await this.models.receiptAggregateVouchers.findAll({
         where: { redeemedAt: null, final: false, last: true },
@@ -955,7 +950,7 @@ export class AllocationReceiptCollector implements ReceiptCollector {
             SET redeemed_at = NOW()
             WHERE allocation_id = '${addressWithoutPrefix}'
           `
-          await this.queryInterface.sequelize.query(query)
+          await this.models.receiptAggregateVouchers.sequelize?.query(query)
 
           logger.info(
             `Updated receipt aggregate vouchers table with redeemed_at for allocation ${addressWithoutPrefix}`,

--- a/packages/indexer-common/src/network.ts
+++ b/packages/indexer-common/src/network.ts
@@ -34,7 +34,6 @@ import { QueryFeeModels } from './query-fees'
 import { readFileSync } from 'fs'
 
 import { TAPSubgraph } from './tap-subgraph'
-import { QueryInterface } from 'sequelize'
 
 export class Network {
   logger: Logger
@@ -48,7 +47,6 @@ export class Network {
   specification: spec.NetworkSpecification
   paused: Eventual<boolean>
   isOperator: Eventual<boolean>
-  queryInterface: QueryInterface | undefined
 
   private constructor(
     logger: Logger,
@@ -62,7 +60,6 @@ export class Network {
     specification: spec.NetworkSpecification,
     paused: Eventual<boolean>,
     isOperator: Eventual<boolean>,
-    queryInterface?: QueryInterface,
   ) {
     this.logger = logger
     this.contracts = contracts
@@ -75,7 +72,6 @@ export class Network {
     this.specification = specification
     this.paused = paused
     this.isOperator = isOperator
-    this.queryInterface = queryInterface
   }
 
   static async create(
@@ -84,7 +80,6 @@ export class Network {
     queryFeeModels: QueryFeeModels,
     graphNode: GraphNode,
     metrics: Metrics,
-    queryInterface?: QueryInterface,
   ): Promise<Network> {
     // Incomplete logger for initial operations, will be replaced as new labels emerge.
     let logger = parentLogger.child({
@@ -280,7 +275,6 @@ export class Network {
       networkSpecification: specification,
       tapSubgraph,
       networkSubgraph,
-      queryInterface: queryInterface!,
     })
 
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
Regarding issue #946 
Instead of passing along a reference better to just use the sequelize reference inside the model object