### PR TITLE
common: Improve gas fee and price logging in TransactionManager

### DIFF
--- a/packages/indexer-common/src/transactions.ts
+++ b/packages/indexer-common/src/transactions.ts
@@ -271,7 +271,7 @@ export class TransactionManager {
           .sub(feeData.maxPriorityFeePerGas!)
           .div(2)
         if (baseFeePerGas.toNumber() >= this.adjustedBaseFeePerGasMax) {
-          if (attempt == 1) {
+          if (attempt === 1) {
             logger.warning(
               `Max base fee per gas has been reached, waiting until the base fee falls below to resume transaction execution.`,
               { maxBaseFeePerGas: this.specification.baseFeePerGasMax, baseFeePerGas },
@@ -279,7 +279,7 @@ export class TransactionManager {
           } else {
             logger.info(`Base gas fee per gas estimation still above max threshold`, {
               maxBaseFeePerGas: this.specification.baseFeePerGasMax,
-              baseFeePerGas,
+              baseFeePerGas: baseFeePerGas.toNumber(),
               priceEstimateAttempt: attempt,
             })
           }
@@ -293,18 +293,18 @@ export class TransactionManager {
         // Legacy transaction type
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (feeData.gasPrice!.toNumber() >= this.adjustedBaseFeePerGasMax) {
-          if (attempt == 1) {
+          if (attempt === 1) {
             logger.warning(
               `Max gas price has been reached, waiting until gas price estimates fall below to resume transaction execution.`,
               {
                 baseFeePerGasMax: this.specification.baseFeePerGasMax,
-                currentGasPriceEstimate: feeData.gasPrice,
+                currentGasPriceEstimate: feeData.gasPrice!.toNumber(),
               },
             )
           } else {
             logger.info(`Gas price estimation still above max threshold`, {
               baseFeePerGasMax: this.specification.baseFeePerGasMax,
-              currentGasPriceEstimate: feeData.gasPrice,
+              currentGasPriceEstimate: feeData.gasPrice!.toNumber(),
               priceEstimateAttempt: attempt,
             })
           }


### PR DESCRIPTION
## Changes
- Improve attempt count comparison
- Improve logging of BigNumber gas price and gas fee values


HT to @chriswessels for these changes which were pulled almost wholesale from https://github.com/graphprotocol/indexer/pull/392