### PR TITLE
common, docs: Update subgraph maxBlockDistance default values

### DIFF
--- a/docs/subgraph-freshness.md
+++ b/docs/subgraph-freshness.md
@@ -26,20 +26,15 @@ Here is a snippet of an Arbitrum network specification file with the suggested o
 
 ```yaml
 subgraphs:
-  maxBlockDistance: 60
+  maxBlockDistance: 5000
   freshnessSleepMilliseconds: 10000
 ```
 
 ## Practical Implications
 
-The following default values have been established based on **Ethereum** observations:
+The following default values have been established based on **Arbitrum-One** observations:
 
-- **maxBlockDistance:** 0 blocks
-- **freshnessSleepMilliseconds:** 5000 (5 seconds)
-
-The recommended settings for **Arbitrum** networks are:
-
-- **maxBlockDistance:** 60 blocks
+- **maxBlockDistance:** 1000 blocks
 - **freshnessSleepMilliseconds:** 10000 (10 seconds)
 
 

--- a/packages/indexer-common/src/network-specification.ts
+++ b/packages/indexer-common/src/network-specification.ts
@@ -126,8 +126,8 @@ export type Subgraph = z.infer<typeof Subgraph>
 // All pertinent subgraphs in the protocol
 export const ProtocolSubgraphs = z
   .object({
-    maxBlockDistance: z.number().nonnegative().finite().default(0),
-    freshnessSleepMilliseconds: positiveNumber().default(5_000),
+    maxBlockDistance: z.number().nonnegative().finite().default(1000),
+    freshnessSleepMilliseconds: positiveNumber().default(10_000),
     networkSubgraph: Subgraph,
     epochSubgraph: Subgraph,
     tapSubgraph: OptionalSubgraph,


### PR DESCRIPTION
## Background
The default values were far too strict, leading to the agent operations halting.

## Changes
- Update default `maxBlockDistance`:  0 --> 1000.
- Update default `freshnessSleepMilliseconds`: 5,000 --> 10,000
- Update subgraph-freshness feature docs to reflect change in defaults.