### PR TITLE
common: Fix filtering when fetching active subgraphs

### DIFF
--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -183,7 +183,7 @@ export class GraphNode {
           if (subgraphStatus === SubgraphStatus.ACTIVE) {
             return (
               status.paused === false ||
-              (status.paused === undefined && status.node === 'removed')
+              (status.paused === undefined && status.node !== 'removed')
             )
           } else if (subgraphStatus === SubgraphStatus.PAUSED) {
             return status.node === 'removed' || status.paused === true


### PR DESCRIPTION
## Changes
- Subgraph deployment is active when `node != removed`.