### PR TITLE
agent: fix db migration for value_aggregate from 20 to 39 digits

### DIFF
--- a/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
+++ b/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
@@ -112,7 +112,7 @@ export async function up({ context }: Context): Promise<void> {
         allowNull: false,
       },
       value: {
-        type: DataTypes.DECIMAL(39),
+        type: DataTypes.DECIMAL(20),
         allowNull: false,
       },
     })
@@ -140,7 +140,7 @@ export async function up({ context }: Context): Promise<void> {
         allowNull: false,
       },
       value_aggregate: {
-        type: DataTypes.DECIMAL(20),
+        type: DataTypes.DECIMAL(39),
         allowNull: false,
       },
       final: {

--- a/packages/indexer-agent/src/db/migrations/15-modify-scalar-tap-tables.ts
+++ b/packages/indexer-agent/src/db/migrations/15-modify-scalar-tap-tables.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { QueryInterface, DataTypes } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  const tables = await queryInterface.showAllTables()
+  logger.debug(
+    `Modifying tables scalar_Tap_Ravs, scalar_tap_receipts and scalar_tap_receipts_invalid with correct value types`,
+  )
+
+  if (tables.includes('scalar_tap_ravs')) {
+    await queryInterface.changeColumn('scalar_tap_ravs', 'value_aggregate', {
+      type: DataTypes.DECIMAL(39),
+      allowNull: false,
+    })
+  }
+  if (tables.includes('scalar_tap_receipts')) {
+    await queryInterface.changeColumn('scalar_tap_receipts', 'nonce', {
+      type: DataTypes.DECIMAL(20),
+      allowNull: false,
+    })
+  }
+
+  if (tables.includes('scalar_tap_receipts_invalid')) {
+    await queryInterface.changeColumn('scalar_tap_receipts_invalid', 'nonce', {
+      type: DataTypes.DECIMAL(20),
+      allowNull: false,
+    })
+  }
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+  // Drop the scalar_tap_ravs table
+  logger.info(`Drop table`)
+  await queryInterface.dropTable('scalar_tap_ravs')
+
+  logger.info(`Drop function, trigger, indices, and table`)
+  await queryInterface.sequelize.query(
+    'DROP TRIGGER IF EXISTS receipt_update ON scalar_tap_receipts',
+  )
+  await queryInterface.sequelize.query(
+    'DROP FUNCTION IF EXISTS scalar_tap_receipt_notify',
+  )
+  await queryInterface.removeIndex(
+    'scalar_tap_receipts',
+    'scalar_tap_receipts_allocation_id_idx',
+  )
+  await queryInterface.removeIndex(
+    'scalar_tap_receipts',
+    'scalar_tap_receipts_timestamp_ns_idx',
+  )
+  await queryInterface.dropTable('scalar_tap_receipts')
+}


### PR DESCRIPTION
Migrations from the [indexer-rs](https://github.com/graphprotocol/indexer-rs/blob/ead4ac2afa4de1740de0eb395cb8168ef2b8a74b/migrations/20230912220523_tap_receipts.up.sql#L9-L10) side are using the correct value at `scalar_tap_ravs > value_aggregate` since it uses unsigned 128bits numbers (39 digits)
We had at first in mind 64 (therefore the 20 digits) but we need to increase this to match indexer-rs
This also happens for the [nonce](https://github.com/graphprotocol/indexer-rs/blob/ead4ac2afa4de1740de0eb395cb8168ef2b8a74b/migrations/20230912220523_tap_receipts.up.sql#L9-L10) where it is defined as 20 digits so we are specifying it in the migrations
###  **WARNING!!!!!! do not ignore** 
After running this new migrations its necessary to restart  TAP-AGENT
<img src="https://github.com/user-attachments/assets/cb665483-0dd2-443b-8e57-2ee21d9c8299" width="150" height="150">

