### PR TITLE
feat: add error_log into scalar_tap_receipts_invalid

### DIFF
--- a/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
+++ b/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
@@ -115,6 +115,10 @@ export async function up({ context }: Context): Promise<void> {
         type: DataTypes.DECIMAL(39),
         allowNull: false,
       },
+      error_log:{
+        type: DataTypes.TEXT,
+        allowNull: false,
+      }
     })
   }
 

--- a/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
+++ b/packages/indexer-agent/src/db/migrations/12-add-scalar-tap-table.ts
@@ -115,10 +115,10 @@ export async function up({ context }: Context): Promise<void> {
         type: DataTypes.DECIMAL(39),
         allowNull: false,
       },
-      error_log:{
+      error_log: {
         type: DataTypes.TEXT,
         allowNull: false,
-      }
+      },
     })
   }
 

--- a/packages/indexer-common/src/query-fees/models.ts
+++ b/packages/indexer-common/src/query-fees/models.ts
@@ -11,6 +11,7 @@ export interface ScalarTapReceiptsAttributes {
   timestamp_ns: bigint
   nonce: bigint
   value: bigint
+  error_log?: string
 }
 export class ScalarTapReceipts
   extends Model<ScalarTapReceiptsAttributes>
@@ -39,6 +40,7 @@ export class ScalarTapReceiptsInvalid
   public nonce!: bigint
   public value!: bigint
   public signature!: Uint8Array
+  public error_log!: string
 
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
@@ -655,6 +657,10 @@ export function defineQueryFeeModels(sequelize: Sequelize): QueryFeeModels {
       },
       signature: {
         type: DataTypes.BLOB,
+        allowNull: false,
+      },
+      error_log: {
+        type: DataTypes.TEXT,
         allowNull: false,
       },
     },


### PR DESCRIPTION
WE currently have a `scalar_tap_receipts_invalid` table, but it lacks further purpose other than just having the invalid receipts listed without further information, so we are adding an extra column where the log defining the reason its invalid listed to have better logging info when an error arises