### PR TITLE
agent: Allow configuring polling interval for data collection

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -34,6 +34,7 @@ import { NetworkSpecification } from '@graphprotocol/indexer-common/dist/network
 import { BigNumber } from 'ethers'
 import { displayZodParsingError } from '@graphprotocol/indexer-common'
 import { readFileSync } from 'fs'
+import { AgentConfigs } from '../types'
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export type AgentOptions = { [key: string]: any } & Argv['argv']
@@ -296,6 +297,13 @@ export const start = {
         type: 'string',
         required: false,
         default: 'auto',
+        group: 'Indexer Infrastructure',
+      })
+      .option('polling-interval', {
+        description: 'Polling interval for data collection',
+        type: 'number',
+        required: false,
+        default: 120_000,
         group: 'Indexer Infrastructure',
       })
       .option('auto-allocation-min-batch-size', {
@@ -667,17 +675,21 @@ export async function run(
   // --------------------------------------------------------------------------------
   // * The Agent itself
   // --------------------------------------------------------------------------------
-  const agent = new Agent(
+  const agentConfigs: AgentConfigs = {
     logger,
     metrics,
     graphNode,
     operators,
-    indexerManagementClient,
+    indexerManagement: indexerManagementClient,
     networks,
-    argv.offchainSubgraphs.map((s: string) => new SubgraphDeploymentID(s)),
-    argv.enableAutoMigrationSupport,
-    argv.deploymentManagement,
-  )
+    deploymentManagement: argv.deploymentManagement,
+    autoMigrationSupport: argv.enableAutoMigrationSupport,
+    offchainSubgraphs: argv.offchainSubgraphs.map(
+      (s: string) => new SubgraphDeploymentID(s),
+    ),
+    pollingInterval: argv.pollingInterval,
+  }
+  const agent = new Agent(agentConfigs)
   await agent.start()
 }
 

--- a/packages/indexer-agent/src/types.ts
+++ b/packages/indexer-agent/src/types.ts
@@ -1,21 +1,28 @@
 import { Logger, Metrics, SubgraphDeploymentID } from '@graphprotocol/common-ts'
 import {
   Network,
-  NetworkSubgraph,
-  ReceiptCollector,
   GraphNode,
+  DeploymentManagementMode,
+  IndexerManagementClient,
+  Operator,
 } from '@graphprotocol/indexer-common'
-import { NetworkMonitor } from '@graphprotocol/indexer-common'
 
-export interface AgentConfig {
+// Represents a pair of Network and Operator instances belonging to the same protocol
+// network. Used when mapping over multiple protocol networks.
+export type NetworkAndOperator = {
+  network: Network
+  operator: Operator
+}
+
+export interface AgentConfigs {
   logger: Logger
   metrics: Metrics
-  indexer: GraphNode
-  network: Network
-  networkMonitor: NetworkMonitor
-  networkSubgraph: NetworkSubgraph
-  allocateOnNetworkSubgraph: boolean
-  registerIndexer: boolean
+  graphNode: GraphNode
+  operators: Operator[]
+  indexerManagement: IndexerManagementClient
+  networks: Network[]
+  deploymentManagement: DeploymentManagementMode
+  autoMigrationSupport: boolean
   offchainSubgraphs: SubgraphDeploymentID[]
-  receiptCollector: ReceiptCollector
+  pollingInterval: number
 }


### PR DESCRIPTION
## Background 
Indexers should be able to control the frequency of data polling and decision making depending on their business strategy and backend saturation.

## Changes
- Add startup parameter for configuring data collection polling intervals, `--polling-interval`. 
- Make polling intervals (Eventuals timers) more consistent.

## Details

The polling interval sets the request intervals for data as follows:
`pollingInterval` defaults to 120_000 ms (2 minutes).
- **indexingRules**:
    - **interval**: pollingInterval
    - **source**: indexer DB
- **activeDeployments**:
    - **interval**: pollingInterval
    - **source**: graph-node
- **networkDeployments**:
    - **interval**: pollingInterval
    - **source**: network subgraph
- **activeAllocations**:
    - **interval**: pollingInterval
    - **source**: network subgraph
- **eligibleTransferDeployments**:
    - **interval**: pollingInterval * 5
    - **source**: graph-node & network subgraph
- **currentEpoch**: 
    - **interval**: pollingInterval * 5
    - **source**: network subgraph
- **maxAllocationsEpoch**: 
    - **interval**: pollingInterval * 5
    - **source**: contracts (EVM request)