### PR TITLE
agent: defend against graph-node bug #5550 (null paused)

### DIFF
--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -149,16 +149,45 @@ export class GraphNode {
   ): Promise<SubgraphDeploymentAssignment[]> {
     try {
       this.logger.debug('Fetch subgraph deployment assignments')
-      const result = await this.status
+
+      // FIXME: remove this initial check for just node when graph-node releases
+      // https://github.com/graphprotocol/graph-node/pull/5551
+      const nodeOnlyResult = await this.status
         .query(gql`
           {
             indexingStatuses {
               subgraphDeployment: subgraph
               node
-              paused
             }
           }
         `)
+        .toPromise()
+
+      if (nodeOnlyResult.error) {
+        throw nodeOnlyResult.error
+      }
+
+      const withAssignments: string[] = nodeOnlyResult.data.indexingStatuses
+        .filter((result: QueryResult) => {
+          return result.node !== undefined
+        })
+        .map((result: QueryResult) => {
+          return result.subgraphDeployment
+        })
+
+      const result = await this.status
+        .query(
+          gql`
+          {
+            indexingStatuses($subgraphs) {
+              subgraphDeployment: subgraph
+              node
+              paused
+            }
+          }
+        `,
+          { subgraphs: withAssignments },
+        )
         .toPromise()
 
       if (result.error) {
@@ -174,7 +203,7 @@ export class GraphNode {
 
       type QueryResult = {
         subgraphDeployment: string
-        node: string
+        node: string | undefined
         paused: boolean | undefined
       }
 


### PR DESCRIPTION
Resolves an issue where graph-node returns an error when querying deployment assignment statuses and the `paused` value is null. 

https://github.com/graphprotocol/graph-node/issues/5550