### PR TITLE
docs: Add 2 chains to feature matrix: fuse & blast

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -27,7 +27,6 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:534352              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:56                  | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:1284                | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:122                 | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:81457               | blast         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -27,6 +27,9 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:534352              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:56                  | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:1284                | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:122                 | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:81457               | blast         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |


### PR DESCRIPTION
Adds full protocol support for ~`moonbeam`,~ `fuse`, and `blast` data sources. 

The Council will be reviewing the CIP reports for these chains this Thursday. 

Next steps:
- [x]  Create a [GGP](https://snapshot.org/#/council.graphprotocol.eth) referencing this PR (Council approving full protocol support for these 3 chains)
- [x]  Wait for the Council to vote
- [x]  Add GGP to the feature matrix 
- [x]   Merge PR

EDIT: removed `moonbeam` from the list.