### PR TITLE
common: add moonbeam, fuse, blast to chain id lookups 

### DIFF
--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -184,6 +184,9 @@ export const Caip2ByChainAlias: { [key: string]: string } = {
   linea: 'eip155:59144',
   scroll: 'eip155:534352',
   base: 'eip155:8453',
+  moonbeam: 'eip155:1284',
+  fuse: 'eip155:122',
+  blast: 'eip155:81457',
 }
 
 export const Caip2ByChainId: { [key: number]: string } = {
@@ -204,6 +207,9 @@ export const Caip2ByChainId: { [key: number]: string } = {
   59144: 'eip155:59144',
   534352: 'eip155:534352',
   8453: 'eip155:8453',
+  1284: 'eip155:1284',
+  122: 'eip155:122',
+  81457: 'eip155:81457',
 }
 
 /// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)


### PR DESCRIPTION
## Changes
- Add `moonbeam`, `fuse`, and `blast`  to chain id lookups. (in preparation for https://github.com/graphprotocol/indexer/pull/979)