### PR TITLE
common: Improve collision resistance of allocation ids

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -47,6 +47,7 @@ import pMap from 'p-map'
 
 export interface TransactionPreparationContext {
   activeAllocations: Allocation[]
+  recentlyClosedAllocations: Allocation[]
   currentEpoch: BigNumber
   indexingStatuses: IndexingStatus[]
 }
@@ -239,11 +240,17 @@ export class AllocationManager {
   }
 
   async prepareTransactions(actions: Action[]): Promise<PopulateTransactionResult[]> {
+    const currentEpoch = await this.network.contracts.epochManager.currentEpoch()
     const context: TransactionPreparationContext = {
       activeAllocations: await this.network.networkMonitor.allocations(
         AllocationStatus.ACTIVE,
       ),
-      currentEpoch: await this.network.contracts.epochManager.currentEpoch(),
+      recentlyClosedAllocations:
+        await this.network.networkMonitor.recentlyClosedAllocations(
+          currentEpoch.toNumber(),
+          2,
+        ),
+      currentEpoch,
       indexingStatuses: await this.graphNode.indexingStatus([]),
     }
     return await pMap(
@@ -389,11 +396,15 @@ export class AllocationManager {
     }
 
     logger.debug('Obtain a unique Allocation ID')
+    const activeAndRecentlyClosedAllocations: Allocation[] = [
+      ...context.recentlyClosedAllocations,
+      ...context.activeAllocations,
+    ]
     const { allocationSigner, allocationId } = uniqueAllocationID(
       this.network.transactionManager.wallet.mnemonic.phrase,
       context.currentEpoch.toNumber(),
       deployment,
-      context.activeAllocations.map((allocation) => allocation.id),
+      activeAndRecentlyClosedAllocations.map((allocation) => allocation.id),
     )
 
     // Double-check whether the allocationID already exists on chain, to


### PR DESCRIPTION
Allow user to allocate multiple times to a deployment within the same epoch.

## Change
- Pass ids of recently closed allocations into `uniqueAllocationID()` to avoid collisions with allocations open earlier in the same epoch for the same deployment. 