### PR TITLE
fix: Remove failed subgraph check

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -371,7 +371,6 @@ export class AllocationManager {
     // Check that the subgraph is syncing and healthy before allocating
     // Throw error if:
     //    - subgraph deployment is not syncing,
-    //    - subgraph deployment is failed
     const status = context.indexingStatuses.find(
       (status) => status.subgraphDeployment.ipfsHash == deployment.ipfsHash,
     )
@@ -379,12 +378,6 @@ export class AllocationManager {
       throw indexerError(
         IndexerErrorCode.IE077,
         `Subgraph deployment, '${deployment.ipfsHash}', is not syncing`,
-      )
-    }
-    if (status?.health == 'failed') {
-      throw indexerError(
-        IndexerErrorCode.IE077,
-        `Subgraph deployment, '${deployment.ipfsHash}', has failed`,
       )
     }
 


### PR DESCRIPTION
Failed subgraphs still need to be allocated to in order to support historical data queries until the subgraph can be fixed and upgraded. Please remove this check.