### PR TITLE
indexer-common: fix paused mechanism

### DIFF
--- a/packages/indexer-common/src/graph-node.ts
+++ b/packages/indexer-common/src/graph-node.ts
@@ -182,14 +182,14 @@ export class GraphNode {
       const result = await this.status
         .query(
           gql`
-          {
-            indexingStatuses($subgraphs) {
-              subgraphDeployment: subgraph
-              node
-              paused
+            query indexingStatuses($subgraphs: [String!]!) {
+              indexingStatuses(subgraphs: $subgraphs) {
+                subgraphDeployment: subgraph
+                node
+                paused
+              }
             }
-          }
-        `,
+          `,
           { subgraphs: withAssignments },
         )
         .toPromise()


### PR DESCRIPTION
Corrects the query responsible for checking the graph-node indexingStatus.