### PR TITLE
indexer-service: remove LRU max length

### DIFF
--- a/packages/indexer-service/src/allocations.ts
+++ b/packages/indexer-service/src/allocations.ts
@@ -36,9 +36,7 @@ export const ensureAttestationSigners = ({
 }: EnsureAttestationSignersOptions): Eventual<AttestationSignerMap> => {
   const logger = parentLogger.child({ component: 'AttestationSignerCache' })
 
-  const cache: AttestationSignerCache = new LRUCache(null, {
-    maxlen: 20000,
-  })
+  const cache: AttestationSignerCache = new LRUCache()
 
   const signers = allocations.map(async allocations => {
     logger.info(`Update attestation signers`)


### PR DESCRIPTION
Removes the limit on the LRU cache. This should prevent request times from spiking and we'll see any issues in instance RAM utilization instead.