### PR TITLE
fix: disable stakeUsageSummary test

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
@@ -126,7 +126,7 @@ describe('Allocation Manager', () => {
   // @ts-ignore: Mocking the Action type for this test
   const actions = [queuedAllocateAction, unallocateAction, reallocateAction] as Action[]
 
-  test('stakeUsageSummary() correctly calculates token balances for array of actions', async () => {
+  test.skip('stakeUsageSummary() correctly calculates token balances for array of actions', async () => {
     const balances = await Promise.all(
       actions.map((action: Action) => allocationManager.stakeUsageSummary(action)),
     )


### PR DESCRIPTION
Disables the stakeUsageSummary test, as it's relying on an allocation which is not producing rewards anymore.