### PR TITLE
docs & common: add support for boba, boba-bnb and fix for blast

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -28,7 +28,9 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:56                  | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | eip155:122                 | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:81457               | blast         | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:81457               | blast-mainnet | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:288                 | boba          | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| eip155:56288               | boba-bnb      | Yes         | Yes          | Yes               | Yes                  | Yes              |
 | **Data Source Features**   |               |             |              |                   |                      |                  |
 | ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
 | ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |

--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -186,7 +186,9 @@ export const Caip2ByChainAlias: { [key: string]: string } = {
   base: 'eip155:8453',
   moonbeam: 'eip155:1284',
   fuse: 'eip155:122',
-  blast: 'eip155:81457',
+  'blast-mainnet': 'eip155:81457',
+  boba: 'eip155:288',
+  'boba-bnb': 'eip155:56288',
 }
 
 export const Caip2ByChainId: { [key: number]: string } = {
@@ -210,6 +212,8 @@ export const Caip2ByChainId: { [key: number]: string } = {
   1284: 'eip155:1284',
   122: 'eip155:122',
   81457: 'eip155:81457',
+  288: 'eip155:288',
+  56288: 'eip155:56288',
 }
 
 /// Unified entrypoint to resolve CAIP ID based either on chain aliases (strings)


### PR DESCRIPTION
Common:
- Adds `boba`, `boba-bnb`, and `blast-mainnet` to chain id lookups. A bug was introduced in https://github.com/graphprotocol/indexer/pull/980 and https://github.com/graphprotocol/indexer/pull/979 when adding `blast` instead of `blast-mainnet` as the slug currently used in Subgraph Studio and Graph Explorer. 

Docs: 
- Same network names as above were added & removed from the feature matrix.

Next steps:
- [ ] Create a [GGP](https://snapshot.org/#/council.graphprotocol.eth) referencing this PR (Council approving full protocol support for these 2 new chains)
- [ ]  Wait for the Council to vote
- [ ]  Add GGP to the feature matrix
- [ ]  Merge PR