### PR TITLE
all: allow db ssl if configured (default: unchanged)

### DIFF
--- a/packages/indexer-agent/CHANGELOG.md
+++ b/packages/indexer-agent/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Upgraded `common-ts` dependency to v2.0.11
+- Add ability to enable SSL to database connection with `sslEnabled` (maintain default of `false`)
 
 ## [0.21.2] - 2024-01-18
 ### Changed

--- a/packages/indexer-agent/package.json
+++ b/packages/indexer-agent/package.json
@@ -29,7 +29,7 @@
     "graph-indexer-agent": "bin/graph-indexer-agent"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "2.0.10",
+    "@graphprotocol/common-ts": "2.0.11",
     "@graphprotocol/indexer-common": "^0.21.6-2",
     "@thi.ng/heaps": "^1.3.1",
     "@uniswap/sdk": "3.0.3",

--- a/packages/indexer-agent/src/commands/common-options.ts
+++ b/packages/indexer-agent/src/commands/common-options.ts
@@ -75,6 +75,13 @@ export function injectCommonStartupOptions(argv: Argv): Argv {
       required: false,
       group: 'Postgres',
     })
+    .option('postgres-sslenabled', {
+      description: 'Postgres SSL Enabled',
+      type: 'boolean',
+      default: 'false',
+      required: false,
+      group: 'Postgres',
+    })
     .option('postgres-database', {
       description: 'Postgres database name',
       type: 'string',

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -540,6 +540,7 @@ export async function run(
     username: argv.postgresUsername,
     password: argv.postgresPassword,
     database: argv.postgresDatabase,
+    sslEnabled: argv.postgresSslEnabled,
     poolMin: 0,
     poolMax: argv.postgresPoolSize,
   })

--- a/packages/indexer-cli/CHANGELOG.md
+++ b/packages/indexer-cli/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Upgraded `common-ts` dependency to v2.0.11
 
 ## [0.20.23] - 2023-09-29
 ### Changed

--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -26,7 +26,7 @@
     "test:watch": "jest --watch --detectOpenHandles --verbose"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "2.0.10",
+    "@graphprotocol/common-ts": "2.0.11",
     "@graphprotocol/indexer-common": "^0.21.6-2",
     "@iarna/toml": "2.2.5",
     "@thi.ng/iterators": "5.1.74",

--- a/packages/indexer-common/CHANGELOG.md
+++ b/packages/indexer-common/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Upgraded `common-ts` dependency to v2.0.11
 
 ## [0.21.2] - 2024-01-18
 ### Changed

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "2.0.10",
+    "@graphprotocol/common-ts": "2.0.11",
     "@graphprotocol/cost-model": "0.1.18",
     "@semiotic-labs/tap-contracts-bindings": "^1.2.1",
     "@thi.ng/heaps": "1.2.38",

--- a/packages/indexer-native/CHANGELOG.md
+++ b/packages/indexer-native/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Upgraded `common-ts` dependency to v2.0.11
 
 ## [0.20.6] - 2022-12-14
 ### Changed

--- a/packages/indexer-native/package.json
+++ b/packages/indexer-native/package.json
@@ -46,7 +46,7 @@
     "clean": "rm -rf ./node_modules ./binary ./build ./coverage ./native/target ./native/artifacts.json ./native/index.node"
   },
   "dependencies": {
-    "@graphprotocol/common-ts": "2.0.10",
+    "@graphprotocol/common-ts": "2.0.11",
     "@mapbox/node-pre-gyp": "1.0.11",
     "cargo-cp-artifact": "0.1.8",
     "node-pre-gyp-github": "1.4.4"

--- a/packages/indexer-service/CHANGELOG.md
+++ b/packages/indexer-service/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Upgraded `common-ts` dependency to v2.0.11
+- Add ability to enable SSL to database connection with `sslEnabled` (maintain default of `false`)
 
 ## [0.21.2] - 2024-01-18
 ### Changed

--- a/packages/indexer-service/package.json
+++ b/packages/indexer-service/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@google-cloud/profiler": "6.0.1",
-    "@graphprotocol/common-ts": "2.0.10",
+    "@graphprotocol/common-ts": "2.0.11",
     "@graphprotocol/indexer-common": "^0.21.6-2",
     "@graphprotocol/indexer-native": "0.21.6",
     "@graphql-tools/load": "8.0.0",

--- a/packages/indexer-service/src/commands/start.ts
+++ b/packages/indexer-service/src/commands/start.ts
@@ -126,6 +126,13 @@ export default {
         required: false,
         group: 'Postgres',
       })
+      .option('postgres-sslenabled', {
+        description: 'Postgres SSL Enabled',
+        type: 'boolean',
+        default: 'false',
+        required: false,
+        group: 'Postgres',
+      })
       .option('postgres-database', {
         description: 'Postgres database name',
         type: 'string',
@@ -300,6 +307,7 @@ export default {
       username: argv.postgresUsername,
       password: argv.postgresPassword,
       database: argv.postgresDatabase,
+      sslEnabled: argv.postgresSslEnabled,
     })
     const queryFeeModels = defineQueryFeeModels(sequelize)
     const models = defineIndexerManagementModels(sequelize)

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,10 +893,10 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
   integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
 
-"@graphprotocol/common-ts@2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/common-ts/-/common-ts-2.0.10.tgz#a2bd7810b6f2b41a5724bcd45b1320a2c6c316a9"
-  integrity sha512-7aAoskggNyMTr54es+7C6sXbSxEz0qxeqVeMqslYnLSAhUtO/TF0UOLdRa06A6RhaVZl5xKh4FUPC1Lr2NiBwQ==
+"@graphprotocol/common-ts@2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/common-ts/-/common-ts-2.0.11.tgz#29f92e7a9666a6b8baccd15e51281d87658978c9"
+  integrity sha512-WtQGYMGVwaXDIli+OCAZUSqh8+ql9THzjztqvLGeSbAIPKxysvej9vua0voMguqEkI/RyEEMBajelodMzzZlEw==
   dependencies:
     "@graphprotocol/contracts" "5.3.3"
     "@graphprotocol/pino-sentry-simple" "0.7.1"


### PR DESCRIPTION
Moving #1038 to the main fork, also squashed and reworded to match our commit guidelines.