### PR TITLE
agent: Fix polling-interval arg setting

### DIFF
--- a/packages/indexer-agent/src/commands/common-options.ts
+++ b/packages/indexer-agent/src/commands/common-options.ts
@@ -35,6 +35,13 @@ export function injectCommonStartupOptions(argv: Argv): Argv {
       default: 'debug',
       group: 'Indexer Infrastructure',
     })
+    .option('polling-interval', {
+      description: 'Polling interval for data collection',
+      type: 'number',
+      required: false,
+      default: 120_000,
+      group: 'Indexer Infrastructure',
+    })
     .option('offchain-subgraphs', {
       description: 'Subgraphs to index that are not on chain (comma-separated)',
       type: 'string',

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -299,13 +299,6 @@ export const start = {
         default: 'auto',
         group: 'Indexer Infrastructure',
       })
-      .option('polling-interval', {
-        description: 'Polling interval for data collection',
-        type: 'number',
-        required: false,
-        default: 120_000,
-        group: 'Indexer Infrastructure',
-      })
       .option('auto-allocation-min-batch-size', {
         description: `Minimum number of allocation transactions inside a batch for auto allocation management. No obvious upperbound, with default of 1`,
         type: 'number',


### PR DESCRIPTION
## Changes
- Move polling-interval args option to common-options so it is set/used in both single-network and multi-network modes.  This fixes its usage in multi-network mode, previously it was being read in as undefined which leads to it being parsed as a 0 number, so the polling loop was going crazy with a 0 polling interval.