### PR TITLE
Add concept of syncing-network and use to filter actions resolvers and commands

### DIFF
--- a/packages/indexer-agent/src/db/migrations/17-actions-add-syncing-network.ts
+++ b/packages/indexer-agent/src/db/migrations/17-actions-add-syncing-network.ts
@@ -1,0 +1,53 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { DataTypes, QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.debug(`Checking if actions table exists`)
+  const tables = await queryInterface.showAllTables()
+  if (!tables.includes('Actions')) {
+    logger.info(`Actions table does not exist, migration not necessary`)
+    return
+  }
+
+  logger.debug(`Checking if 'Actions' table needs to be migrated`)
+  const table = await queryInterface.describeTable('Actions')
+  const syncingNetworkColumn = table.syncingNetwork
+  if (syncingNetworkColumn) {
+    logger.info(
+      `'syncingNetwork' columns already exist, migration not necessary`,
+    )
+    return
+  }
+
+  logger.info(`Add 'syncingNetwork' column to 'Actions' table`)
+  await queryInterface.addColumn('Actions', 'syncingNetwork', {
+    type: DataTypes.BOOLEAN,
+    defaultValue: false,
+  })
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  return await queryInterface.sequelize.transaction({}, async transaction => {
+    const tables = await queryInterface.showAllTables()
+
+    if (tables.includes('Actions')) {
+      logger.info(`Remove 'syncingNetwork' column`)
+      await context.queryInterface.removeColumn('Actions', 'syncingNetwork', {
+        transaction,
+      })
+    }
+  })
+}

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -47,6 +47,7 @@ export async function buildActionInput(
         status,
         priority,
         protocolNetwork,
+        syncingNetwork: 'unknown',
       }
     case ActionType.UNALLOCATE: {
       let poi = actionParams.param2
@@ -64,6 +65,7 @@ export async function buildActionInput(
         status,
         priority,
         protocolNetwork,
+        syncingNetwork: 'unknown',
       }
     }
     case ActionType.REALLOCATE: {
@@ -83,6 +85,7 @@ export async function buildActionInput(
         status,
         priority,
         protocolNetwork,
+        syncingNetwork: 'unknown',
       }
     }
   }
@@ -399,6 +402,7 @@ export async function fetchActions(
           ) {
             id
             protocolNetwork
+            syncingNetwork
             type
             allocationID
             deploymentID

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -10,7 +10,7 @@ import {
   nullPassThrough,
   OrderDirection,
   parseBoolean,
-  validateNetworkIdentifier,
+  validateSupportedNetworkIdentifier,
 } from '@graphprotocol/indexer-common'
 import { validatePOI, validateRequiredParams } from './command-helpers'
 import gql from 'graphql-tag'
@@ -215,7 +215,7 @@ const ACTION_PARAMS_PARSERS: Record<keyof ActionUpdateInput, (x: never) => any> 
   type: x => validateActionType(x),
   status: x => validateActionStatus(x),
   reason: nullPassThrough,
-  protocolNetwork: x => validateNetworkIdentifier(x),
+  protocolNetwork: x => validateSupportedNetworkIdentifier(x),
 }
 
 /**

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -145,6 +145,8 @@ export function buildActionFilter(
   status: string | undefined,
   source: string | undefined,
   reason: string | undefined,
+  protocolNetwork: string | undefined,
+  syncingNetwork: string | undefined,
 ): ActionFilter {
   const filter: ActionFilter = {}
   if (id) {
@@ -161,6 +163,12 @@ export function buildActionFilter(
   }
   if (reason) {
     filter.reason = reason
+  }
+  if (protocolNetwork) {
+    filter.protocolNetwork = protocolNetwork
+  }
+  if (syncingNetwork) {
+    filter.syncingNetwork = syncingNetwork
   }
   if (Object.keys(filter).length === 0) {
     throw Error(

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -36,7 +36,10 @@ export enum OutputFormat {
 import yaml from 'yaml'
 import { GluegunParameters, GluegunPrint } from 'gluegun'
 import { utils } from 'ethers'
-import { validateNetworkIdentifier } from '@graphprotocol/indexer-common'
+import {
+  validateNetworkIdentifier,
+  validateSupportedNetworkIdentifier,
+} from '@graphprotocol/indexer-common'
 
 export const fixParameters = (
   parameters: GluegunParameters,
@@ -237,7 +240,7 @@ export function extractProtocolNetworkOption(
   const input = (network ?? n) as string
 
   try {
-    return validateNetworkIdentifier(input)
+    return validateSupportedNetworkIdentifier(input)
   } catch (parseError) {
     throw new Error(`Invalid value for the option '--network'. ${parseError}`)
   }
@@ -250,4 +253,38 @@ export function requireProtocolNetworkOption(options: { [key: string]: any }): s
     throw new Error("The option '--network' is required")
   }
   return protocolNetwork
+}
+
+export function extractSyncingNetworkOption(
+  options: {
+    [key: string]: any
+  },
+  required = false,
+): string | undefined {
+  const { s, syncing } = options
+
+  // Tries to extract the --network option from Gluegun options.
+  // Throws if required is set to true and the option is not found.
+  if (!s && !syncing) {
+    if (required) {
+      throw new Error("The option '--syncing' is required")
+    } else {
+      return undefined
+    }
+  }
+
+  // Check for invalid usage
+  const allowedUsages =
+    (s === undefined && typeof syncing === 'string') ||
+    (syncing === undefined && typeof s === 'string')
+  if (!allowedUsages) {
+    throw new Error("Invalid usage of the option '--network'")
+  }
+  const input = (syncing ?? s) as string
+
+  try {
+    return validateNetworkIdentifier(input)
+  } catch (parseError) {
+    throw new Error(`Invalid value for the option '--syncing'. ${parseError}`)
+  }
 }

--- a/packages/indexer-cli/src/commands/indexer/actions/delete.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/delete.ts
@@ -3,19 +3,29 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { fixParameters } from '../../../command-helpers'
+import {
+  extractProtocolNetworkOption,
+  extractSyncingNetworkOption,
+  fixParameters,
+} from '../../../command-helpers'
 import { deleteActions, fetchActions } from '../../../actions'
 
 const HELP = `
 ${chalk.bold('graph indexer actions delete')} [options] all
 ${chalk.bold('graph indexer actions delete')} [options] [<actionID1> ...]
+${chalk.bold('graph indexer actions delete')} [options]
 
 ${chalk.dim('Options:')}
 
   -h, --help                                                        Show usage information
+  -n, --network <networkName>                                       Filter by protocol network (mainnet, arbitrum-one, sepolia, arbitrum-sepolia)
+  -s, --syncing <networkName>                                       Filter by the syncing network (see https://thegraph.com/networks/ for supported networks)
       --status  queued|approved|pending|success|failed|canceled     Filter by status
   -o, --output table|json|yaml                                      Choose the output format: table (default), JSON, or YAML 
 `
+function isNumber(value?: string | number): boolean {
+  return value != null && value !== '' && !isNaN(Number(value.toString()))
+}
 
 module.exports = {
   name: 'delete',
@@ -32,15 +42,34 @@ module.exports = {
     const outputFormat = o || output || 'table'
     const toHelp = help || h || undefined
 
+    let protocolNetwork: string | undefined = undefined
+    let syncingNetwork: string | undefined = undefined
+    let deleteType: 'ids' | 'all' | 'filter' = 'filter'
+
     if (toHelp) {
       inputSpinner.stopAndPersist({ symbol: '💁', text: HELP })
       return
     }
 
     try {
+      protocolNetwork = extractProtocolNetworkOption(parameters.options)
+
+      syncingNetwork = extractSyncingNetworkOption(parameters.options)
+
       if (!['json', 'yaml', 'table'].includes(outputFormat)) {
         throw Error(
           `Invalid output format "${outputFormat}", must be one of ['json', 'yaml', 'table']`,
+        )
+      }
+
+      if (
+        !status &&
+        !syncingNetwork &&
+        !protocolNetwork &&
+        (!actionIDs || actionIDs.length === 0)
+      ) {
+        throw Error(
+          `Required at least one argument: actionID(s), 'all', '--status' filter, '--network' filter, or '--syncing' filter`,
         )
       }
 
@@ -55,18 +84,22 @@ module.exports = {
         )
       }
 
-      if (actionIDs[0] == 'all') {
-        if (status || actionIDs.length > 1) {
+      if (actionIDs && actionIDs[0] == 'all') {
+        deleteType = 'all'
+        if (status || protocolNetwork || syncingNetwork || actionIDs.length > 1) {
           throw Error(
-            `Invalid query, cannot specify '--status' filter or multiple ids in addition to 'action = all'`,
+            `Invalid query, cannot specify '--status'|'--network'|'--syncing' filters or action ids in addition to 'action = all'`,
           )
         }
       }
 
-      if (!status && (!actionIDs || actionIDs.length === 0)) {
-        throw Error(
-          `Required at least one argument: actionID(s), 'all', or '--status' filter`,
-        )
+      if (actionIDs && isNumber(actionIDs[0])) {
+        deleteType = 'ids'
+        if (status || protocolNetwork || syncingNetwork || actionIDs.length > 1) {
+          throw Error(
+            `Invalid query, cannot specify '--status'|'--network'|'--syncing' filters or action ids in addition to 'action = all'`,
+          )
+        }
       }
 
       inputSpinner.succeed('Processed input parameters')
@@ -81,13 +114,17 @@ module.exports = {
     try {
       const config = loadValidatedConfig()
       const client = await createIndexerManagementClient({ url: config.api })
+      let numericActionIDs: number[] = []
 
-      const numericActionIDs: number[] =
-        actionIDs[0] == 'all'
-          ? (await fetchActions(client, {})).map(action => action.id)
-          : status
-          ? (await fetchActions(client, { status })).map(action => action.id)
-          : actionIDs.map(action => +action)
+      if (deleteType === 'all') {
+        numericActionIDs = (await fetchActions(client, {})).map(action => action.id)
+      } else if (deleteType === 'filter') {
+        numericActionIDs = (
+          await fetchActions(client, { status, protocolNetwork, syncingNetwork })
+        ).map(action => action.id)
+      } else if (deleteType === 'ids') {
+        numericActionIDs = actionIDs.map(action => +action)
+      }
 
       const numDeleted = await deleteActions(client, numericActionIDs)
 

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -5,7 +5,7 @@ import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { closeAllocation } from '../../../allocations'
 import { validatePOI, printObjectOrArray } from '../../../command-helpers'
-import { validateNetworkIdentifier } from '@graphprotocol/indexer-common'
+import { validateSupportedNetworkIdentifier } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold('graph indexer allocations close')} [options] <network> <id> <poi>
@@ -63,7 +63,7 @@ module.exports = {
       return
     } else {
       try {
-        protocolNetwork = validateNetworkIdentifier(network)
+        protocolNetwork = validateSupportedNetworkIdentifier(network)
       } catch (error) {
         spinner.fail(`Invalid value for argument 'network': '${network}' `)
         process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { submitCollectReceiptsJob } from '../../../allocations'
-import { validateNetworkIdentifier } from '@graphprotocol/indexer-common'
+import { validateSupportedNetworkIdentifier } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold('graph indexer allocations collect')} [options] <network> <id>
@@ -60,7 +60,7 @@ module.exports = {
       return
     } else {
       try {
-        protocolNetwork = validateNetworkIdentifier(network)
+        protocolNetwork = validateSupportedNetworkIdentifier(network)
       } catch (error) {
         spinner.fail(`Invalid value for argument 'network': '${network}' `)
         process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/allocations/create.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/create.ts
@@ -8,7 +8,7 @@ import { createAllocation } from '../../../allocations'
 import {
   processIdentifier,
   SubgraphIdentifierType,
-  validateNetworkIdentifier,
+  validateSupportedNetworkIdentifier,
 } from '@graphprotocol/indexer-common'
 import { printObjectOrArray } from '../../../command-helpers'
 
@@ -64,7 +64,7 @@ module.exports = {
 
       // This nested try block is necessary to complement the parsing error with the 'network' field.
       try {
-        validateNetworkIdentifier(protocolNetwork)
+        validateSupportedNetworkIdentifier(protocolNetwork)
       } catch (parsingError) {
         throw new Error(`Invalid 'network' provided. ${parsingError}`)
       }

--- a/packages/indexer-common/src/errors.ts
+++ b/packages/indexer-common/src/errors.ts
@@ -88,6 +88,7 @@ export enum IndexerErrorCode {
   IE075 = 'IE075',
   IE076 = 'IE076',
   IE077 = 'IE077',
+  IE078 = 'IE078',
 }
 
 export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
@@ -169,6 +170,7 @@ export const INDEXER_ERROR_MESSAGES: Record<IndexerErrorCode, string> = {
   IE075: 'Failed to connect to network contracts',
   IE076: 'Failed to resume subgraph deployment',
   IE077: 'Failed to allocate: subgraph not healthily syncing',
+  IE078: 'Failed to query subgraph features from network subgraph',
 }
 
 export type IndexerErrorCause = unknown

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -236,6 +236,7 @@ describe('Actions', () => {
       priority: 0,
       //  When writing directly to the database, `protocolNetwork` must be in the CAIP2-ID format.
       protocolNetwork: 'eip155:421614',
+      syncingNetwork: 'eip155:1',
     }
 
     await models.Action.upsert(action)

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -135,6 +135,7 @@ const SCHEMA_SDL = gql`
     createdAt: BigInt!
     updatedAt: BigInt
     protocolNetwork: String!
+    syncingNetwork: String!
   }
 
   input ActionInput {
@@ -149,6 +150,7 @@ const SCHEMA_SDL = gql`
     reason: String!
     priority: Int!
     protocolNetwork: String!
+    syncingNetwork: String!
   }
 
   input ActionUpdateInput {
@@ -201,6 +203,7 @@ const SCHEMA_SDL = gql`
   input ActionFilter {
     id: Int
     protocolNetwork: String
+    syncingNetwork: String
     type: ActionType
     status: String
     source: String

--- a/packages/indexer-common/src/indexer-management/models/action.ts
+++ b/packages/indexer-common/src/indexer-management/models/action.ts
@@ -36,6 +36,7 @@ export class Action extends Model<
   declare updatedAt: CreationOptional<Date>
 
   declare protocolNetwork: string
+  declare syncingNetwork: string
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   public toGraphQL(): object {
@@ -147,6 +148,14 @@ export const defineActionModels = (sequelize: Sequelize): ActionModels => {
       protocolNetwork: {
         type: DataTypes.STRING(50),
         primaryKey: true,
+        validate: {
+          is: caip2IdRegex,
+        },
+      },
+      syncingNetwork: {
+        type: DataTypes.STRING(50),
+        primaryKey: false,
+        allowNull: false,
         validate: {
           is: caip2IdRegex,
         },

--- a/packages/indexer-common/src/indexer-management/resolvers/actions.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/actions.ts
@@ -15,7 +15,6 @@ import {
   NetworkMapped,
   OrderDirection,
   validateActionInputs,
-  validateNetworkIdentifier,
 } from '@graphprotocol/indexer-common'
 import { literal, Op, Transaction } from 'sequelize'
 import { ActionManager } from '../actions'
@@ -160,15 +159,6 @@ export default {
     if (!actionManager || !multiNetworks) {
       throw Error('IndexerManagementClient must be in `network` mode to modify actions')
     }
-
-    // Sanitize protocol network identifier
-    actions.forEach((action) => {
-      try {
-        action.protocolNetwork = validateNetworkIdentifier(action.protocolNetwork)
-      } catch (e) {
-        throw Error(`Invalid value for the field 'protocolNetwork'. ${e}`)
-      }
-    })
 
     // Let Network Monitors validate actions based on their protocol networks
     await multiNetworks.mapNetworkMapped(

--- a/packages/indexer-common/src/operator.ts
+++ b/packages/indexer-common/src/operator.ts
@@ -278,6 +278,7 @@ export class Operator {
       reason: action.reason,
       priority: 0,
       protocolNetwork: action.protocolNetwork,
+      syncingNetork: 'unknown',
     }
     this.logger.trace(`Queueing action input`, {
       actionInput,

--- a/packages/indexer-common/src/parsers/basic-types.ts
+++ b/packages/indexer-common/src/parsers/basic-types.ts
@@ -20,13 +20,17 @@ export const url = P.regex(/^https?:.*/)
 
 // Source: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 export const caip2IdRegex = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/
-const caip2Id = P.regex(caip2IdRegex).chain(validateNetworkIdentifier)
+const caip2Id = P.regex(caip2IdRegex)
+const supportedCaip2Id = P.regex(caip2IdRegex).chain(validateNetworkIdentifier)
 
 // A valid human friendly network name / alias.
-const networkAlias = P.regex(/[a-z-]+/).chain(validateNetworkIdentifier)
+const networkAlias = P.regex(/[a-z-]+/)
+const supportedNetworkAlias = P.regex(/[a-z-]+/).chain(validateNetworkIdentifier)
 
 // Either a CAIP-2 or an alias.
 export const networkIdentifier = P.alt(caip2Id, networkAlias)
+
+export const supportedNetworkIdentifier = P.alt(supportedCaip2Id, supportedNetworkAlias)
 
 // A basic `base58btc` parser for CIDv0 (IPFS Hashes)
 export const base58 = P.regex(/^Qm[1-9A-HJ-NP-Za-km-z]{44,}$/).desc(

--- a/packages/indexer-common/src/parsers/validators.ts
+++ b/packages/indexer-common/src/parsers/validators.ts
@@ -3,7 +3,7 @@
 
 import P from 'parsimmon'
 
-import { networkIdentifier, base58 } from './basic-types'
+import { base58, networkIdentifier, supportedNetworkIdentifier } from './basic-types'
 export { caip2IdRegex } from './basic-types'
 
 // Generic function that takes a parser of type T and attempts to parse it from a string. If it
@@ -21,8 +21,13 @@ function parse<T>(parser: P.Parser<T>, input: string): T {
     `Failed to parse "${input}". Expected: ${expected}. Parsed up to: "${parsed}". Remaining: "${remaining}"`,
   )
 }
+
 export function validateNetworkIdentifier(input: string): string {
   return parse(networkIdentifier, input)
+}
+
+export function validateSupportedNetworkIdentifier(input: string): string {
+  return parse(supportedNetworkIdentifier, input)
 }
 
 export function validateIpfsHash(input: string): string {


### PR DESCRIPTION
## What's changed
- Added `syncingNetwork` column to the `Actions` table (and corresponding types and models)
- Updated indexer-cli actions module to use `syncingNetwork` by adding `--syncing` or `-s` parameter to commands. --syncing can now be used to filter the following commands: `actions get`, `actions update`, `actions delete`, and `actions approve`.

## Example usage
The newly support --syncing (-s) option for actions modules commands extends current functionality to provide more expressive filtering of actions commands. Here are a few examples of using it in commands:
- `graph indexer actions get --syncing arbitrum-one` - Get all actions for deployments syncing data from `arbitrum-one`.
- `graph indexer update --network arbitrum-one --syncing mainnet status queued` - Update the status for all actions for deployments syncing `mainnet` data on the `arbitrum-one` Graph Network. 
- `graph indexer actions approve --network arbitrum-one --syncing  base` - Approve all actions on the `arbitrum-one` network for deployments syncing data from the `base` network.
