### PR TITLE
fix: optimize the round trips when reconciling the subgraph deployments 

### DIFF
--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -652,7 +652,7 @@ export class NetworkMonitor {
     const deployments: SubgraphDeployment[] = []
     const queryProgress = {
       lastId: '',
-      first: 10,
+      first: 1000,
       fetched: 0,
       exhausted: false,
       retriesRemaining: 10,


### PR DESCRIPTION
## Issue

I was running the Indexer Agent and after a few days I realized the amount of queries it sent to the network subgraphs was out of proportion and quickly draining my api key.

## **Investigation**

The Indexer Agent performs a number of “housekeeping” queries at regular periods of time to sync with the latest network status.

One of those queries gets the entire set of subgraphs on the network but it does so paginating by 10 items batches. With the current number of subgraphs over 10,000, it takes more than 1,000 queries to get them all.

The eventual runs every 120 seconds, that means it's sending about 720,000 queries a day.

## Resolution

Set the `first` parameter to `1000` for the query within `subgraphDeployments` function of the `NetworkMonitor.`