### PR TITLE
common: skip tests that make rpc calls

### DIFF
--- a/packages/indexer-common/src/allocations/__tests__/tap-pagination.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap-pagination.test.ts
@@ -175,7 +175,9 @@ const setup = () => {
   }
 }
 
-describe('TAP Pagination', () => {
+// Skipped because it hits real RPC providers and uses up the API key.
+// Skipping it works around this issue for now but we should turn it back on once we have a better solution.
+describe.skip('TAP Pagination', () => {
   beforeAll(setup, timeout)
   test(
     'test `getAllocationsfromAllocationIds` pagination',

--- a/packages/indexer-common/src/allocations/__tests__/tap.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap.test.ts
@@ -505,7 +505,8 @@ describe('TAP', () => {
     timeout,
   )
 
-  test('test `submitRAVs` with escrow account lower on balance', async () => {
+  // Skipped until we can run with local-network in CI
+  test.skip('test `submitRAVs` with escrow account lower on balance', async () => {
     // mock redeemRav to not call the blockchain
     const redeemRavFunc = jest
       .spyOn(tapCollector, 'redeemRav')

--- a/packages/indexer-common/src/allocations/__tests__/validate-queries.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/validate-queries.test.ts
@@ -57,7 +57,10 @@ const setup = async () => {
 }
 
 jest.spyOn(TapCollector.prototype, 'startRAVProcessing').mockImplementation()
-describe('Validate TAP queries', () => {
+
+// Skipped because this hits real RPC endpoints.
+// This test should be re-enabled when we have a test environment that this can hit instead.
+describe.skip('Validate TAP queries', () => {
   beforeAll(setup, timeout)
 
   test(

--- a/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/allocations.test.ts
@@ -97,7 +97,9 @@ const teardownAll = async () => {
   await sequelize.drop({})
 }
 
-describe('Allocation Manager', () => {
+// These tests are skipped because they hit real RPC providers and use up the API key.
+// Skipping them works around this issue for now but we should turn them back on once we have a better solution.
+describe.skip('Allocation Manager', () => {
   beforeAll(setup)
   beforeEach(setupEach)
   afterEach(teardownEach)
@@ -126,7 +128,7 @@ describe('Allocation Manager', () => {
   // @ts-ignore: Mocking the Action type for this test
   const actions = [queuedAllocateAction, unallocateAction, reallocateAction] as Action[]
 
-  test.skip('stakeUsageSummary() correctly calculates token balances for array of actions', async () => {
+  test('stakeUsageSummary() correctly calculates token balances for array of actions', async () => {
     const balances = await Promise.all(
       actions.map((action: Action) => allocationManager.stakeUsageSummary(action)),
     )

--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -348,7 +348,8 @@ describe.skip('Monitor: local', () => {
   })
 })
 
-describe('Monitor: CI', () => {
+// Skipped until we can run on a local-network based stack.
+describe.skip('Monitor: CI', () => {
   beforeAll(setupMonitor)
 
   test('Fetch subgraphs', async () => {

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/actions.test.ts
@@ -224,7 +224,8 @@ const teardownAll = async () => {
   await sequelize.drop({})
 }
 
-describe('Actions', () => {
+// Skipped until we can run on local-network based stack.
+describe.skip('Actions', () => {
   jest.setTimeout(60_000)
   beforeAll(setup)
   beforeEach(setupEach)


### PR DESCRIPTION
For now, disabling tests that make RPC calls which are blocking up CI anytime that fails.