### PR TITLE
indexer-agent: align cli args behaviour with network specification behaviour

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -69,6 +69,7 @@ export const start = {
           'Time (in seconds) after which transactions will be resubmitted with a higher gas price',
         type: 'number',
         default: 240,
+        coerce: x => x * 10 ** 3,
         group: 'Ethereum',
       })
       .option('gas-increase-factor', {
@@ -82,6 +83,7 @@ export const start = {
         description: 'The maximum gas price (gwei) to use for transactions',
         type: 'number',
         default: 100,
+        coerce: x => x * 10 ** 9,
         deprecated: true,
         group: 'Ethereum',
       })
@@ -90,6 +92,7 @@ export const start = {
           'The maximum base fee per gas (gwei) to use for transactions, for legacy transactions this will be treated as the max gas price',
         type: 'number',
         required: false,
+        coerce: x => x * 10 ** 9,
         group: 'Ethereum',
       })
       .option('transaction-attempts', {
@@ -358,7 +361,7 @@ export async function createNetworkSpecification(
     gasIncreaseTimeout: argv.gasIncreaseTimeout,
     gasIncreaseFactor: argv.gasIncreaseFactor,
     gasPriceMax: argv.gasPriceMax,
-    baseFeePerGasMax: argv.baseFeeGasMax,
+    baseFeePerGasMax: argv.baseFeePerGasMax,
     maxTransactionAttempts: argv.maxTransactionAttempts,
   }
 
@@ -682,13 +685,13 @@ export function reviewArgumentsForWarnings(argv: AgentOptions, logger: Logger) {
   if (gasIncreaseTimeout < advisedGasIncreaseTimeout) {
     logger.warn(
       `Gas increase timeout is set to less than ${
-        gasIncreaseTimeout / 1000
-      } seconds. This may lead to high gas usage`,
-      { gasIncreaseTimeout: gasIncreaseTimeout / 1000.0 },
+        advisedGasIncreaseTimeout
+      } milliseconds. This may lead to high gas usage`,
+      { gasIncreaseTimeout: gasIncreaseTimeout },
     )
   }
 
-  if (gasIncreaseFactor > advisedGasIncreaseTimeout) {
+  if (gasIncreaseFactor > advisedGasIncreaseFactor) {
     logger.warn(
       `Gas increase factor is set to > ${advisedGasIncreaseFactor}. ` +
         'This may lead to high gas usage',

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -685,8 +685,8 @@ export function reviewArgumentsForWarnings(argv: AgentOptions, logger: Logger) {
   if (gasIncreaseTimeout < advisedGasIncreaseTimeout) {
     logger.warn(
       `Gas increase timeout is set to less than ${
-        advisedGasIncreaseTimeout
-      } milliseconds. This may lead to high gas usage`,
+        advisedGasIncreaseTimeout / 1000
+      } seconds. This may lead to high gas usage`,
       { gasIncreaseTimeout: gasIncreaseTimeout },
     )
   }


### PR DESCRIPTION
This PR aims to align CLI arg behaviour for indexer-agent transaction settings with that of the same settings when using the network specification config:

https://github.com/graphprotocol/indexer/blob/main/packages/indexer-common/src/network-specification.ts#L66-L80

Specifically, the CLI args, despite the descriptions indicating they are in seconds, are in fact in milliseconds. The same arguments in the network specification are in seconds (because they have the transforms). The same is true for wei vs gwei.

There were also a couple of bugs:

https://github.com/graphprotocol/indexer/compare/chriswessels-patch-2?expand=1#diff-99c7c045e392890d684d7b8eeebc28aff6f48770fbc468722f04b8482719c74aR694

https://github.com/graphprotocol/indexer/compare/chriswessels-patch-2?expand=1#diff-99c7c045e392890d684d7b8eeebc28aff6f48770fbc468722f04b8482719c74aR364