### PR TITLE
Update feature-support-matrix.md

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -43,7 +43,7 @@ The accepted `graph-node` version range must always be specified; it always comp
 The latest for the feature matrix above:
 
 ```
-graph-node: >=0.35.0 <0.36.0
+graph-node: >=0.35.0 <=0.36.0
 ```
 
 ### Latest Council snapshot


### PR DESCRIPTION
Added support for Graph Node 0.36.0

Additional context:
* Subgraphs on Moonbeam are not working on 0.35.1, the previous max supported Graph Node version. 