### PR TITLE
typo fix in the README.md

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -129,7 +129,7 @@ network_subgraph_endpoint = "https://gateway.network.thegraph.com/network"
 vector_admin_token = "<secret token, keep to yourself>"
 vector_router = "<Vector router identifier, depends on the network>"
 
-database_password = "<database passowrd>"
+database_password = "<database password>"
 EOF
 ```
 


### PR DESCRIPTION
# Pull Request: Fix Typo in `README.md`

## Description

This PR corrects a typographical error in the `README.md` file:
- Replaced **"passowrd"** with **"password"** for better accuracy and readability.

### Changes
- **File:** `README.md`
- **Details:**
  - Corrected "passowrd" to "password."


