### PR TITLE
common, agent: use NetworksRegistry instead of hard-coded networks list

### DIFF
--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -11,6 +11,7 @@ import {
   SubgraphDeploymentID,
 } from '@graphprotocol/common-ts'
 import {
+  common_init,
   createIndexerManagementClient,
   createIndexerManagementServer,
   defineIndexerManagementModels,
@@ -467,6 +468,7 @@ export async function run(
   networkSpecification: spec.NetworkSpecification,
   logger: Logger,
 ): Promise<void> {
+  await common_init(logger)
   // --------------------------------------------------------------------------------
   // * Configure event  listeners for unhandled promise  rejections and uncaught
   // exceptions.

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -22,6 +22,7 @@
     "clean": "rm -rf ./node_modules ./dist ./tsconfig.tsbuildinfo"
   },
   "dependencies": {
+    "@pinax/graph-networks-registry": "0.6.7",
     "@graphprotocol/common-ts": "2.0.11",
     "@graphprotocol/cost-model": "0.1.18",
     "@semiotic-labs/tap-contracts-bindings": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,6 +2221,11 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
+"@pinax/graph-networks-registry@0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@pinax/graph-networks-registry/-/graph-networks-registry-0.6.7.tgz#ceb994f3b31e2943b9c9d9b09dd86eb00d067c0e"
+  integrity sha512-xogeCEZ50XRMxpBwE3TZjJ8RCO8Guv39gDRrrKtlpDEDEMLm0MzD3A0SQObgj7aF7qTZNRTWzsuvQdxgzw25wQ==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"


### PR DESCRIPTION
This PR adds the `@pinax/graph-networks-registry` dependency to service chains listed in it.