### PR TITLE
common: also add chain aliases stripped of their -mainnet suffix

### DIFF
--- a/packages/indexer-common/src/indexer-management/types.ts
+++ b/packages/indexer-common/src/indexer-management/types.ts
@@ -235,6 +235,10 @@ async function buildCaip2MappingsFromRegistry() {
     }
     for (const alias of network.aliases) {
       caip2ByChainAlias[alias] = network.caip2Id
+      if (alias.endsWith('-mainnet')) {
+        const aliasWithoutSuffix = alias.replace('-mainnet', '')
+        caip2ByChainAlias[aliasWithoutSuffix] = network.caip2Id
+      }
     }
     const chainId = parseInt(network.caip2Id.split(':')[1])
     if (


### PR DESCRIPTION
This supports shorter network aliases stripped of their -mainnet suffix, if it's present.