### PR TITLE
Corrected typos

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -162,7 +162,7 @@ defined in one of the following environment variables / command-line options:
 - `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT` / `--network-subgraph-endpoint`
 - `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT` / `--network-subgraph-endpoint`
 
-There can be a nuber of reasons for this:
+There can be a number of reasons for this:
 
 - The endpoint is unhealthy or unreliable.
 - The endpoint is out of date.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -129,7 +129,7 @@ network_subgraph_endpoint = "https://gateway.network.thegraph.com/network"
 vector_admin_token = "<secret token, keep to yourself>"
 vector_router = "<Vector router identifier, depends on the network>"
 
-database_password = "<database passowrd>"
+database_password = "<database password>"
 EOF
 ```
 


### PR DESCRIPTION
Changes made in:

- /terraform/README.md ("passowrd" → "password")

- /docs/errors.md ("nuber" → "number")
