### PR TITLE
fix: sequelize field shadowing in models

### DIFF
--- a/packages/indexer-common/src/indexer-management/models/cost-model.ts
+++ b/packages/indexer-common/src/indexer-management/models/cost-model.ts
@@ -39,13 +39,13 @@ export class CostModel
   extends Model<CostModelAttributes, CostModelCreationAttributes>
   implements CostModelAttributes
 {
-  public id!: number
-  public deployment!: string
-  public model!: string | null
+  declare id: number
+  declare deployment: string
+  declare model: string | null
   public variables!: CostModelVariables | null
 
-  public createdAt!: Date
-  public updatedAt!: Date
+  declare createdAt: Date
+  declare updatedAt: Date
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   public toGraphQL(): object {

--- a/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
+++ b/packages/indexer-common/src/indexer-management/models/indexing-rule.ts
@@ -66,26 +66,26 @@ export class IndexingRule
   extends Model<IndexingRuleAttributes, IndexingRuleCreationAttributes>
   implements IndexingRuleAttributes
 {
-  public id!: number
-  public identifier!: string
-  public identifierType!: SubgraphIdentifierType
-  public allocationAmount!: string | null
-  public allocationLifetime!: number | null
-  public autoRenewal!: boolean
-  public parallelAllocations!: number | null
-  public maxAllocationPercentage!: number | null
-  public minSignal!: string | null
-  public maxSignal!: string | null
-  public minStake!: string | null
-  public minAverageQueryFees!: string | null
-  public custom!: string | null
-  public decisionBasis!: IndexingDecisionBasis
-  public requireSupported!: boolean
-  public safety!: boolean
-  public protocolNetwork!: string
+  declare id: number
+  declare identifier: string
+  declare identifierType: SubgraphIdentifierType
+  declare allocationAmount: string | null
+  declare allocationLifetime: number | null
+  declare autoRenewal: boolean
+  declare parallelAllocations: number | null
+  declare maxAllocationPercentage: number | null
+  declare minSignal: string | null
+  declare maxSignal: string | null
+  declare minStake: string | null
+  declare minAverageQueryFees: string | null
+  declare custom: string | null
+  declare decisionBasis: IndexingDecisionBasis
+  declare requireSupported: boolean
+  declare safety: boolean
+  declare protocolNetwork: string
 
-  public createdAt!: Date
-  public updatedAt!: Date
+  declare createdAt: Date
+  declare updatedAt: Date
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   public toGraphQL(): object {

--- a/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
+++ b/packages/indexer-common/src/indexer-management/models/poi-dispute.ts
@@ -51,23 +51,23 @@ export class POIDispute
   extends Model<POIDisputeAttributes, POIDisputeCreationAttributes>
   implements POIDisputeAttributes
 {
-  public allocationID!: string
-  public subgraphDeploymentID!: string
-  public allocationIndexer!: string
-  public allocationAmount!: string
-  public allocationProof!: string
-  public closedEpoch!: number
-  public closedEpochReferenceProof!: string | null
-  public closedEpochStartBlockHash!: string
-  public closedEpochStartBlockNumber!: number
-  public previousEpochReferenceProof!: string | null
-  public previousEpochStartBlockHash!: string
-  public previousEpochStartBlockNumber!: number
-  public status!: string
-  public protocolNetwork!: string
+  declare allocationID: string
+  declare subgraphDeploymentID: string
+  declare allocationIndexer: string
+  declare allocationAmount: string
+  declare allocationProof: string
+  declare closedEpoch: number
+  declare closedEpochReferenceProof: string | null
+  declare closedEpochStartBlockHash: string
+  declare closedEpochStartBlockNumber: number
+  declare previousEpochReferenceProof: string | null
+  declare previousEpochStartBlockHash: string
+  declare previousEpochStartBlockNumber: number
+  declare status: string
+  declare protocolNetwork: string
 
-  public createdAt!: Date
-  public updatedAt!: Date
+  declare createdAt: Date
+  declare updatedAt: Date
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   public toGraphQL(): object {


### PR DESCRIPTION
This fixes an issue where model public fields shadow sequelize setters/getters making models's actual data undefined.

```
indexer-agent  | (sequelize) Warning: Model "IndexingRule" is declaring public class fields for attribute(s): "id", "identifier", "identifierType", "allocationAmount", "allocationLifetime", "autoRenewal", "parallelAllocations", "maxAllocationPercentage", "minSignal", "minStake", "maxSignal", "minAverageQueryFees", "custom", "decisionBasis", "requireSupported", "safety", "protocolNetwork", "createdAt", "updatedAt".
indexer-agent  | These class fields are shadowing Sequelize's attribute getters & setters.
indexer-agent  | See https://sequelize.org/main/manual/model-basics.html#caveat-with-public-class-fields
```

For details see https://sequelize.org/docs/v6/core-concepts/model-basics/#caveat-with-public-class-fields