### PR TITLE
Bump graph-node in feature support matrix

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -4,49 +4,51 @@ As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/prop
 
 The matrix below reflects the canonical Council-ratified version. As outlined in GIP-00008, Council ratification is currently required for each update, which may happen at different stages of feature development and testing lifecycle.
 
-| Subgraph Feature           | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards |
-| -------------------------- | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- |
-| **Core Features**          |               |             |              |                   |                      |                  |
-| Full-text Search           |               | Yes         | No           | No                | Yes                  | Yes              |
-| Non-Fatal Errors           |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Grafting                   |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Types**      |               |             |              |                   |                      |                  |
-| eip155:\*                  | \*            | Yes         | No           | No                | No                   | No               |
-| eip155:1                   | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |
-| eip155:100                 | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| near:\*                    | \*            | Yes         | Yes          | No                | No                   | No               |
-| arweave:\*                 | \*            | Yes         | Yes          | No                | No                   | No               |
-| eip155:42161               | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:42220               | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:43114               | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:250                 | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:137                 | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:10                  | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:8453                | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:534352              | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:59144               | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:56                  | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:122                 | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:81457               | blast-mainnet | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:288                 | boba          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:56288               | boba-bnb      | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:7777777             | zora          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:34443               | mode          | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:1284                | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| eip155:30                  | rootstock     | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| **Data Source Features**   |               |             |              |                   |                      |                  |
-| ipfs.cat in mappings       |               | Yes         | Yes          | No                | No                   | No               |
-| ENS                        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| File data sources: Arweave |               | Yes         | Yes          | No                | Yes                  | Yes              |
-| File data sources: IPFS    |               | Yes         | Yes          | No                | Yes                  | Yes              |
-| Substreams: mainnet        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
-| Substreams: optimism       |               | Yes         | Yes          | Yes               | Yes                  | Yes              |
+| Subgraph Feature            | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards | Deprecated   |
+| --------------------------- | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- | ------------ |
+| **Core Features**           |               |             |              |                   |                      |                  |              |
+| Full-text Search            |               | Yes         | No           | No                | Yes                  | Yes              |              |
+| Non-Fatal Errors            |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| Grafting                    |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| **Data Source Types**       |               |             |              |                   |                      |                  |              |
+| eip155:\*                   | \*            | Yes         | No           | No                | No                   | No               |              |
+| eip155:1                    | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |              |
+| eip155:100                  | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| near:\*                     | \*            | Yes         | Yes          | No                | No                   | No               |              |
+| ~~arweave:\*~~ (deprecated) | \*            | Yes         | Yes          | No                | No                   | No               | v0.39.0      |
+| eip155:42161                | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:42220                | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:43114                | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:250                  | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:137                  | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:10                   | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:8453                 | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:534352               | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:59144                | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:56                   | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:122                  | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:81457                | blast-mainnet | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:288                  | boba          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:56288                | boba-bnb      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:7777777              | zora          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:34443                | mode          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:1284                 | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:30                   | rootstock     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| **Data Source Features**    |               |             |              |                   |                      |                  |              |
+| ipfs.cat in mappings        |               | Yes         | Yes          | No                | No                   | No               |              |
+| ENS                         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| File data sources: Arweave  |               | Yes         | Yes          | No                | Yes                  | Yes              |              |
+| File data sources: IPFS     |               | Yes         | Yes          | No                | Yes                  | Yes              |              |
+| Substreams: mainnet         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| Substreams: optimism        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+
+Note: Items marked as deprecated are no longer supported in the specified version or later of `graph-node`.
 
 The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
 The latest for the feature matrix above:
 
 ```
-graph-node: >=0.35.0 <=0.36.1
+graph-node: >=0.38.0 <=0.39.1
 ```
 
 ### Latest Council snapshot

--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -16,7 +16,7 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:100                  | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | near:\*                     | \*            | Yes         | Yes          | No                | No                   | No               |              |
 | ~~arweave:\*~~ (deprecated) | \*            | Yes         | Yes          | No                | No                   | No               | v0.39.0      |
-| eip155:42161                | artbitrum-one | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+| eip155:42161                | arbitrum-one  | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:42220                | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:43114                | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:250                  | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |


### PR DESCRIPTION
With the release of `graph-node 0.39.0`, arweave support was deprecated, so we add a new `Deprecated` column for tracking purposes.

Additionally, a typo was fixed (`artbitrum -> arbitrum`)