### PR TITLE
Simplify feature support matrix - remove network duplication (reference the new registry)

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -1,59 +1,129 @@
-# Feature support matrix
+# Feature Support Matrix
 
-As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xbdd884654a393620a7e8665b4289201b7542c3ee62becfad133e951b0c408444), the Feature support matrix defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration.
+As described in [GIP-0008](https://snapshot.org/#/council.graphprotocol.eth/proposal/0xbdd884654a393620a7e8665b4289201b7542c3ee62becfad133e951b0c408444), the Feature Support Matrix defines indexing & querying features which are experimental or not fully supported for indexing & query rewards and arbitration.
 
-The matrix below reflects the canonical Council-ratified version. As outlined in GIP-00008, Council ratification is currently required for each update, which may happen at different stages of feature development and testing lifecycle.
+---
 
-| Subgraph Feature            | Aliases       | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Indexing Rewards | Deprecated   |
-| --------------------------- | ------------- | ----------- | ------------ | ----------------- | -------------------- | ---------------- | ------------ |
-| **Core Features**           |               |             |              |                   |                      |                  |              |
-| Full-text Search            |               | Yes         | No           | No                | Yes                  | Yes              |              |
-| Non-Fatal Errors            |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| Grafting                    |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| **Data Source Types**       |               |             |              |                   |                      |                  |              |
-| eip155:\*                   | \*            | Yes         | No           | No                | No                   | No               |              |
-| eip155:1                    | mainnet       | Yes         | No           | Yes               | Yes                  | Yes              |              |
-| eip155:100                  | gnosis        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| near:\*                     | \*            | Yes         | Yes          | No                | No                   | No               |              |
-| ~~arweave:\*~~ (deprecated) | \*            | Yes         | Yes          | No                | No                   | No               | v0.39.0      |
-| eip155:42161                | arbitrum-one  | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:42220                | celo          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:43114                | avalanche     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:250                  | fantom        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:137                  | polygon       | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:10                   | optimism      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:8453                 | base          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:534352               | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:59144                | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:56                   | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:7777777              | zora          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:1284                 | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:30                   | rootstock     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:11155111             | sepolia       | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:97                   | chapel        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:130                  | unichain      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| **Data Source Features**    |               |             |              |                   |                      |                  |              |
-| ipfs.cat in mappings        |               | Yes         | Yes          | No                | No                   | No               |              |
-| ENS                         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| File data sources: Arweave  |               | Yes         | Yes          | No                | Yes                  | Yes              |              |
-| File data sources: IPFS     |               | Yes         | Yes          | No                | Yes                  | Yes              |              |
-| Substreams: mainnet         |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| Substreams: optimism        |               | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
+## Governance
 
-Note: Items marked as deprecated are no longer supported in the specified version or later of `graph-node`.
+As of [GGP-0057](https://snapshot.box/#/s:council.graphprotocol.eth/proposal/0x4eff14202f6204c0927860a9adff865fce33c32b6cbe7054227457631ee261b9), the Feature Support Matrix is maintained by The Graph core protocol developers, and indexing rewards for networks are managed by The Graph Foundation (with review by the Technical Advisory Board).
 
-The accepted `graph-node` version range must always be specified; it always comprises the latest available version and the one immediately preceding it.
-The latest for the feature matrix above:
+### Responsibilities
+
+**The Graph Foundation** (with TAB review):
+- Adding or removing indexing rewards for networks
+- Since indexing rewards determine arbitration support, this also controls which networks have arbitration enabled
+
+**Core Protocol Developers**:
+- Graph-node version requirements
+- Core feature support and experimental status
+- Data source feature support
+- Technical implementation details
+
+**Council Approval Required For**:
+- Changes to arbitration eligibility for **existing features** or data sources
+- Determining which **new features** or **new data source types** are eligible for indexing rewards
+- Changes to arbitration policy that affect dispute resolution
+
+**No Council Approval Required For**:
+- Adding/removing networks with indexing rewards (Foundation + TAB authority)
+- Adding new experimental features (not yet eligible for rewards)
+- Graph-node version updates
+- Documentation improvements and clarifications
+
+---
+
+## Graph Node Version Requirements
+
+For arbitration to function fairly and consistently, indexers must run compatible versions of graph-node. As specified in the [Arbitration Charter (Section 10)](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0009-arbitration-charter.md#10-subgraph-api-and-indexer-software-versioning), a defined version window ensures that:
+
+1. **Consistent behavior**: All indexers subject to arbitration run compatible software
+2. **Fair disputes**: Fishermen and indexers are evaluated against the same implementation
+3. **Reasonable upgrade window**: Indexers have time to upgrade without being out of compliance
+
+The accepted `graph-node` version range for indexers:
 
 ```
-graph-node: >=0.38.0 <=0.44.0
+graph-node: >=0.38.0 <=0.45.0
 ```
-### Other notes
 
-- Currently, one single matrix is used to reflect protocol behaviour for both Ethereum mainnet and Arbitrum One.
-- Aliases can be used in subgraph manifest files to refer to specific networks.
-- Experimental features are generally not fully supported for indexing rewards and arbitration, and usage of experimental features will be considered during any arbitration that does occur.
-- Query fees apply to all queries, regardless of the underlying features used by a subgraph.
-- Subgraph features not named in the matrix are assumed to be fully supported for indexing & query rewards and arbitration
-- [GGP-0057](https://snapshot.box/#/s:council.graphprotocol.eth/proposal/0x4eff14202f6204c0927860a9adff865fce33c32b6cbe7054227457631ee261b9) : Delegation of Chain Integration & Deprecation Authority to The Graph Foundation (with TAB Approval Requirement). 
-This proposal delegates responsibility for approving new chain integrations (indexing rewards) and deprecating chains to The Graph Foundation, contingent upon receiving approval from the Technical Advisory Board (TAB). This change is intended to streamline operations while maintaining technical oversight. The Council retains override authority.
+**Policy**: This range must always comprise the latest available version and one immediately preceding it, providing indexers with a reasonable window to upgrade while ensuring the network runs on recent, well-tested software.
+
+**Last Updated**: 2026-08-03
+
+---
+
+## Network Support & Arbitration
+
+### Default Policy
+
+**Networks with indexing rewards have full arbitration support (both query and indexing).**
+
+This is a bidirectional relationship:
+- **Indexing rewards enabled** → Arbitration support enabled
+- **Arbitration support enabled** → Indexing rewards enabled
+
+### How to Check Network Support
+
+To verify if a network supports arbitration:
+
+1. Check the [Networks Registry - Networks Table](https://github.com/graphprotocol/networks-registry/blob/main/docs/networks-table.md)
+2. Look for ✅ in the **"Indexing Rewards"** column
+3. If ✅ present → Network has full arbitration support
+4. If no ✅ → Network does not have arbitration support
+
+For complete network information (RPC endpoints, services, deprecation status, etc.), see the [Networks Registry](https://github.com/graphprotocol/networks-registry).
+
+### Arbitration Policy Documentation
+
+For detailed information about the arbitration policy and how it relates to indexing rewards, see [Network Arbitration Policy](https://github.com/graphprotocol/networks-registry/blob/main/docs/arbitration-policy.md).
+
+### Exception Networks
+
+Only networks that deviate from the default policy are listed here:
+
+_Currently, all networks follow the default policy. This table will list exceptions if they arise._
+
+| Network (CAIP-2) | Aliases | Query Arbitration | Indexing Arbitration | Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+---
+
+## Core Subgraph Features
+
+| Feature | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Deprecated |
+| --- | --- | --- | --- | --- | --- |
+| Full-text Search | Yes | No | No | Yes | |
+| Non-Fatal Errors | Yes | Yes | Yes | Yes | |
+| Grafting | Yes | Yes | Yes | Yes | |
+
+---
+
+## Data Source Features
+
+| Feature | Implemented | Experimental | Query Arbitration | Indexing Arbitration | Deprecated |
+| --- | --- | --- | --- | --- | --- |
+| ipfs.cat in mappings | Yes | Yes | No | No | |
+| ENS | Yes | Yes | Yes | Yes | |
+| File data sources: Arweave | Yes | Yes | No | Yes | |
+| File data sources: IPFS | Yes | Yes | No | Yes | |
+| Substreams: mainnet | Yes | Yes | Yes | Yes | |
+| Substreams: optimism | Yes | Yes | Yes | Yes | |
+
+---
+
+## Deprecated Features and Networks
+
+For information about deprecated networks and features, including which graph-node version deprecated them, see the [Networks Registry](https://github.com/graphprotocol/networks-registry).
+
+Networks with a `deprecatedAt` timestamp in their `graphNode` section are no longer supported for subgraph deployments.
+
+---
+
+## Notes
+
+- Currently, one single matrix reflects protocol behaviour for both Ethereum mainnet and Arbitrum One.
+- Experimental features are generally not fully supported for indexing rewards and arbitration.
+- Query fees apply to all queries, regardless of features used.
+- Features not named in the matrix are assumed fully supported for indexing & query rewards and arbitration.


### PR DESCRIPTION
## Simplify Feature Support Matrix - Eliminate Network Duplication

### Problem

Network information, particularly indexing rewards and deprecation status, is duplicated between the Feature Support Matrix and the [Networks Registry](https://github.com/graphprotocol/networks-registry), creating unnecessary maintenance burden and potential for drift.

### Solution

Implement exception-based documentation with clear default policy:

**Default Rule**: Indexing rewards ⟺ Arbitration support (bidirectional)

### Changes

- ✅ Remove "Indexing Rewards" column (now exclusively in Networks Registry)
- ✅ Remove all ~30 standard network rows (exception-based approach)
- ✅ Remove deprecated networks table (now exclusively in Networks Registry)
- ✅ Add governance section per GGP-0062 with clear responsibilities
- ✅ Add graph-node version rationale per Arbitration Charter
- ✅ Add "Default Policy" section explaining indexing rewards ⟺ arbitration
- ✅ Keep empty "Exception Networks" table for future use
- ✅ Keep all core features and data source features unchanged

### Benefits

1. **Single source of truth**: Networks Registry owns all network-level data
2. **Less maintenance**: Adding networks requires zero feature matrix changes (in standard cases)
3. **Clearer for indexers**: Simple rule - check registry for network support
4. **No duplication**: Indexing rewards and deprecations live in one place
5. **Future-proof**: Exception table ready if needed

### Migration Notes

**No protocol changes** - this is purely documentation restructuring:
- All networks previously listed with rewards still have full arbitration support
- Indexers should check Networks Registry for current network support
- Feature matrix remains authoritative for graph-node features and version requirements

### Governance

Per [GGP-0062](https://snapshot.org/#/s:council.graphprotocol.eth/proposal/0x4eff14202f6204c0927860a9adff865fce33c32b6cbe7054227457631ee261b9), this change does not require Council approval as it:
- Does not modify arbitration eligibility for existing networks (maintains same policy)
- Is a documentation improvement
- Makes the default policy explicit rather than implicit

**Council approval would be required** for future changes that add networks to the exceptions table or modify arbitration columns for existing features.

### Other notes
- Dependent on [ https://github.com/graphprotocol/networks-registry (dependency)](https://github.com/graphprotocol/networks-registry/pull/173)
- Part 2 of 2 for eliminating indexing rewards duplication
