### PR TITLE
Remove Boba, Blast, Mode & Fuse

### DIFF
--- a/docs/feature-support-matrix.md
+++ b/docs/feature-support-matrix.md
@@ -26,11 +26,7 @@ The matrix below reflects the canonical Council-ratified version. As outlined in
 | eip155:534352               | scroll        | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:59144                | linea         | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:56                   | bsc           | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:122                  | fuse          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:81457                | blast-mainnet | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:288                  | boba          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:7777777              | zora          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
-| eip155:34443                | mode          | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:1284                 | moonbeam      | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:30                   | rootstock     | Yes         | Yes          | Yes               | Yes                  | Yes              |              |
 | eip155:11155111             | sepolia       | Yes         | Yes          | Yes               | Yes                  | Yes              |              |


### PR DESCRIPTION
Remove Boba, Blast, Mode & Fuse

[GGP-0057](https://snapshot.box/#/s:council.graphprotocol.eth/proposal/0x4eff14202f6204c0927860a9adff865fce33c32b6cbe7054227457631ee261b9) This proposal delegates responsibility for approving new chain integrations (indexing rewards) and deprecating chains to The Graph Foundation, contingent upon receiving approval from the Technical Advisory Board (TAB). This change is intended to streamline operations while maintaining technical oversight. The Council retains override authority.

These chains have been approved by the TAB:
Remove: [Boba, Blast, Mode and Fuse](https://www.notion.so/thegraphfoundation/TAB-Workspace-15f604c167f045999295c3db0d2ea6aa?p=284b6eecd57980128a2eefdf3a789bfb&pm=s)



Do not merge until 📅**Nov 28th 2025**