### PR TITLE
perf: optimize allocation rules evaluation from O(n²) to O(n)

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -47,6 +47,7 @@ import {
   encodeCollectIndexingRewardsData,
   encodePOIMetadata,
 } from '@graphprotocol/toolshed'
+import { preprocessRules } from '../subgraphs'
 
 import {
   BigNumberish,
@@ -1791,8 +1792,15 @@ export class AllocationManager {
         `SHOULD BE UNREACHABLE: No matching subgraphDeployment (${subgraphDeploymentID.ipfsHash}) found on the network`,
       )
     }
-    return isDeploymentWorthAllocatingTowards(logger, subgraphDeployment, indexingRules)
-      .toAllocate
+    const { deploymentRulesMap, globalRule } = preprocessRules(indexingRules)
+
+    return isDeploymentWorthAllocatingTowards(
+      logger,
+      subgraphDeployment,
+      indexingRules,
+      deploymentRulesMap,
+      globalRule,
+    ).toAllocate
   }
 
   // Calculates the balance (GRT delta) of a single Action.


### PR DESCRIPTION
Replace repeated Array.filter() + Array.find() with Map-based lookup for deployment rules.

- Add preprocessRules() function to create Map for O(1) rule lookups
- Update isDeploymentWorthAllocatingTowards() to use pre-processed rules Map
- Update evaluateDeployments() to preprocess rules once instead of per deployment
- Update AllocationManager.matchingRuleExists() to use optimized lookup

Performance improvement:
- Before: O(n²) - filter + find for each deployment evaluation
- After: O(n) - single preprocessing + O(1) lookups per deployment
- Significant speedup when evaluating many deployments against many rules

Fixes performance bottleneck in allocation rule evaluation where processing thousands of deployments with hundreds of rules resulted in quadratic complexity.