### PR TITLE
docs: remove stale index node ids refs

### DIFF
--- a/k8s/base/indexer-agent/statefulset.yaml
+++ b/k8s/base/indexer-agent/statefulset.yaml
@@ -54,8 +54,6 @@ spec:
                 secretKeyRef:
                   name: ethereum
                   key: url
-            - name: INDEXER_AGENT_INDEX_NODE_IDS
-              value: index-node-0
             - name: INDEXER_AGENT_GRAPH_NODE_QUERY_ENDPOINT
               value: http://query-node.default.svc.cluster.local/
             - name: INDEXER_AGENT_GRAPH_NODE_ADMIN_ENDPOINT

--- a/k8s/overlays/indexer_agent.yaml
+++ b/k8s/overlays/indexer_agent.yaml
@@ -8,10 +8,6 @@ spec:
       containers:
         - name: indexer-agent
           env:
-            # Set this so it matches the index node pods
-            - name: INDEXER_AGENT_INDEX_NODE_IDS
-              value: index_node_0,index_node_1
-
             # Set this to your indexer's lat, long coordinates
             - name: INDEXER_AGENT_INDEXER_GEO_COORDINATES
               value: "0.00 0.00"

--- a/packages/indexer-agent/README.md
+++ b/packages/indexer-agent/README.md
@@ -182,8 +182,6 @@ To use the Indexer Agent in Multi Network Mode, set the environment variable
 Start the Agent in multiple Protocol Networks
 
 Indexer Infrastructure
-  --index-node-ids                 Node IDs of Graph nodes to use for indexing
-                                   (separated by commas)      [array] [required]
   --indexer-management-port        Port to serve the indexer management API at
                                                         [number] [default: 8000]
   --metrics-port                   Port to serve Prometheus metrics at


### PR DESCRIPTION
## Summary

- Remove stale `INDEXER_AGENT_INDEX_NODE_IDS` environment variable from k8s base statefulset and overlays
- Remove outdated `--index-node-ids` documentation from `README` (was incorrectly marked as `[required]`)
- Cleans up references that should have been removed in `e8a76fa48` when node ID assignment was delegated to `graph-node`'s config file

---
Signed off by Joseph Livesey <joseph@semiotic.ai>