### PR TITLE
add --auto-allocation-max-batch-size indexer-agent option

### DIFF
--- a/packages/indexer-agent/README.md
+++ b/packages/indexer-agent/README.md
@@ -50,6 +50,13 @@ Indexer Infrastructure
                                     inside a batch for auto allocation
                                     management. No obvious upperbound, with
                                     default of 1           [number] [default: 1]
+  --auto-allocation-max-batch-size  Maximum number of allocation transactions
+                                    inside a batch for auto allocation
+                                    management. Limits the number of actions
+                                    processed per batch to prevent multicall
+                                    failures when there are many allocations.
+                                    Remaining actions will be processed in
+                                    subsequent batches.                [number]
 
 Postgres
   --postgres-host        Postgres host                       [string] [required]

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -348,6 +348,12 @@ export const start = {
         default: 1,
         group: 'Indexer Infrastructure',
       })
+      .option('auto-allocation-max-batch-size', {
+        description: `Maximum number of allocation transactions inside a batch for auto allocation management. Limits the number of actions processed per batch to prevent multicall failures when there are many allocations. Remaining actions will be processed in subsequent batches.`,
+        type: 'number',
+        required: false,
+        group: 'Indexer Infrastructure',
+      })
       .check(argv => {
         if (
           !argv['network-subgraph-endpoint'] &&
@@ -408,6 +414,7 @@ export async function createNetworkSpecification(
     voucherRedemptionMaxBatchSize: argv.voucherRedemptionMaxBatchSize,
     allocationManagementMode: argv.allocationManagement,
     autoAllocationMinBatchSize: argv.autoAllocationMinBatchSize,
+    autoAllocationMaxBatchSize: argv.autoAllocationMaxBatchSize,
     allocateOnNetworkSubgraph: argv.allocateOnNetworkSubgraph,
     register: argv.register,
     maxProvisionInitialSize: argv.maxProvisionInitialSize,

--- a/packages/indexer-common/src/network-specification.ts
+++ b/packages/indexer-common/src/network-specification.ts
@@ -61,6 +61,7 @@ export const IndexerOptions = z
       .default('auto')
       .transform((x) => x as AllocationManagementMode),
     autoAllocationMinBatchSize: positiveNumber().default(1),
+    autoAllocationMaxBatchSize: positiveNumber().optional(),
     allocateOnNetworkSubgraph: z.boolean().default(false),
     register: z.boolean().default(true),
     maxProvisionInitialSize: GRT()


### PR DESCRIPTION
<img width="1239" height="243" alt="image" src="https://github.com/user-attachments/assets/3971a611-f962-4648-9308-d4901f4d91a8" />

I used this to work around errors I was getting when trying to close a large number of allocations (>200) in a single transaction, apparently hitting arbitrum's block gas limit