### PR TITLE
Fix documentation typos and broken link

### DIFF
--- a/docs/action-queue.md
+++ b/docs/action-queue.md
@@ -12,7 +12,7 @@ The action execution worker will only grab items from the action queue to execut
 - `oversight`: The indexer-agent will add run its reconciliation loop to make allocation decisions and when actions are identified it will queue them. These actions will then require approval before they can be executed.
 
 ## Actions CLI
-The indexer-cli provides an `actions` module for manually working with the action queue. It uses the #Graphql API hosted by the indexer management server to interact with the actions queue.
+The indexer-cli provides an `actions` module for manually working with the action queue. It uses the GraphQL API hosted by the indexer management server to interact with the actions queue.
 
 ```bash
 Manage indexer actions

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -162,7 +162,7 @@ defined in one of the following environment variables / command-line options:
 - `INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT` / `--network-subgraph-endpoint`
 - `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT` / `--network-subgraph-endpoint`
 
-There can be a nuber of reasons for this:
+There can be a number of reasons for this:
 
 - The endpoint is unhealthy or unreliable.
 - The endpoint is out of date.
@@ -450,7 +450,7 @@ Failing to process a paid query can have a number of reasons:
   likely cause for this is that the network subgraph endpoint specified via
   `INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT` or `--network-subgraph-endpoint`
   is unhealthy and failing repeatedly. This particular situation would manifest
-  itself in a `Unable to sign the query response attesattion` error message.
+  itself in a `Unable to sign the query response attestation` error message.
 - The indexer service either fails to forward queries to the graph/query node
   or nodes, or the graph/query node or nodes fail to execute the query.
 - The indexer service fails to push the payment or attestation into the

--- a/docs/testnet-setup.md
+++ b/docs/testnet-setup.md
@@ -2,7 +2,7 @@
 
 The Graph Network's testnet is on Arbitrum Sepolia, and network information can be found at https://testnet.thegraph.com/explorer/network.
 
-> See [networks/testnet.md](/networks/testnet.md) for the latest releases & configuration information.
+> See [Arbitrum Sepolia configuration](./networks/arbitrum-sepolia.md) for the latest releases & configuration information.
 
 ### Registration / Funding (GRT)
 

--- a/packages/indexer-cli/README.md
+++ b/packages/indexer-cli/README.md
@@ -177,7 +177,7 @@ outputs. In order to create new reference files it is recommended to use the fol
 - Install `strip-ansi` to strip ansi color codes from CLI command stdout and stderr output
   - `npm install --global strip-ansi-cli`
 - Produce reference output file by piping command output through stip-ansi before saving to file
-  - Ex: `./bin/graph-indexer indexer rules get | strip-ansi | src/__tests__/references/indexer-rules-command-no-args.stdout`
+  - Ex: `./bin/graph-indexer indexer rules get | strip-ansi > src/__tests__/references/indexer-rules-command-no-args.stdout`
 
 # Copyright
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -129,7 +129,7 @@ network_subgraph_endpoint = "https://gateway.network.thegraph.com/network"
 vector_admin_token = "<secret token, keep to yourself>"
 vector_router = "<Vector router identifier, depends on the network>"
 
-database_password = "<database passowrd>"
+database_password = "<database password>"
 EOF
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes several typos and a broken link found in the documentation:

- Fix typo nuber to number in docs/errors.md (IE009 section)
- Fix typo attesattion to attestation in docs/errors.md (IE032 section)
- Fix typo Graphql to GraphQL in docs/action-queue.md
- Fix typo passowrd to password in terraform/README.md
- Fix broken link /networks/testnet.md to ./networks/arbitrum-sepolia.md in docs/testnet-setup.md
- Fix missing redirect operator in CLI README shell command example

## Test plan

- [x] Verify all typo corrections are accurate
- [x] Verify the broken link now points to the correct file
- [x] Verify the shell command example in CLI README is syntactically correct