### PR TITLE
Update deprecated testnet references to Arbitrum

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -309,7 +309,7 @@ graph/index node or nodes.
 Typical reasons that can cause this:
 
 - The indexer agent fails to connect to the graph/index node or nodes.
-- The subgraph deployment is for a network (e.g. Ropsten) that is not
+- The subgraph deployment is for a network that is not
   supported by the graph/index node or nodes.
 
 **Solution**

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -116,12 +116,12 @@ indexer_mnemonic = "<operator Ethereum mnemonic>"
 indexer_address = "<indexer Ethereum address>"
 
 ethereum_chain_name = "mainnet"
-# testnet: ethereum_chain_name = "rinkeby"
+# testnet: ethereum_chain_name = "arbitrum-sepolia"
 
-ethereum_chain_id = 1
-# testnet: ethereum_chain_id = 4
+ethereum_chain_id = 42161
+# testnet: ethereum_chain_id = 421614
 
-ethereum_provider = "<mainnet or rinkeby Ethereum node/provider>"
+ethereum_provider = "<Arbitrum One or Arbitrum Sepolia node/provider>"
 
 network_subgraph_endpoint = "https://gateway.network.thegraph.com/network"
 # testnet: network_subgraph_endpoint = "https://gateway.testnet.thegraph.com/network"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,12 +83,12 @@ variable "indexer_address" {
 
 variable "ethereum_chain_name" {
   type        = string
-  description = "Name of the Ethereum network (mainnet for mainnet, rinkeby for testnet)"
+  description = "Name of the Ethereum network (e.g. mainnet, arbitrum-one, arbitrum-sepolia)"
 }
 
 variable "ethereum_chain_id" {
   type        = number
-  description = "Numeric chain ID of the Ethereum network (1 for mainnet, 4 for testnet)"
+  description = "Numeric chain ID of the Ethereum network (e.g. 1 for mainnet, 42161 for Arbitrum One)"
 }
 
 variable "ethereum_provider" {


### PR DESCRIPTION
## Summary

The Graph Network has moved from Ethereum mainnet to Arbitrum One. This PR updates outdated testnet references in the documentation and terraform configuration:

- Replace Rinkeby (deprecated) with Arbitrum Sepolia as the testnet
- Update chain IDs from Ethereum (1, 4) to Arbitrum (42161, 421614)
- Remove Ropsten example from errors.md (Ropsten was deprecated in 2022)
- Update Ethereum provider description to reference Arbitrum networks

## Test plan

- [x] Verify chain IDs are correct for Arbitrum One and Arbitrum Sepolia
- [x] Verify the changes align with current network documentation