### PR TITLE
Fix typo in test comment: subraphDeployments to subgraphDeployments

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/helpers.test.ts
@@ -492,7 +492,7 @@ describe.skip('Monitor: CI', () => {
     await expect(subgraphs.length).toEqual(106)
   })
 
-  //TODO: Setup constrained subraphDeployments query that works both against graph-node and the gateway
+  //TODO: Setup constrained subgraphDeployments query that works both against graph-node and the gateway
 
   // test('Fetch subgraph deployments (constrained)', async () => {
   //   const deployments = await networkMonitor.subgraphDeployments(59022843)


### PR DESCRIPTION
## Summary

Fix typo in TODO comment in test file:
- subraphDeployments -> subgraphDeployments

## Test plan

- [x] Verify typo correction is accurate