### PR TITLE
[DIPS] add `pending_rca_proposals` migration

### DIFF
--- a/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
+++ b/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
@@ -16,7 +16,9 @@ export async function up({ context }: Context): Promise<void> {
   const tables = await queryInterface.showAllTables()
 
   if (tables.includes('pending_rca_proposals')) {
-    logger.debug('pending_rca_proposals already exists, migration not necessary')
+    logger.debug(
+      'pending_rca_proposals already exists, migration not necessary',
+    )
     return
   }
 
@@ -52,9 +54,13 @@ export async function up({ context }: Context): Promise<void> {
     },
   })
 
-  await queryInterface.addIndex('pending_rca_proposals', ['status', 'created_at'], {
-    name: 'idx_pending_rca_status',
-  })
+  await queryInterface.addIndex(
+    'pending_rca_proposals',
+    ['status', 'created_at'],
+    {
+      name: 'idx_pending_rca_status',
+    },
+  )
 
   await queryInterface.sequelize.query(
     'CREATE INDEX idx_pending_rca_created ON pending_rca_proposals(created_at DESC)',

--- a/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
+++ b/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
@@ -1,0 +1,73 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { QueryInterface, DataTypes } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  const tables = await queryInterface.showAllTables()
+
+  if (tables.includes('pending_rca_proposals')) {
+    logger.debug('pending_rca_proposals already exists, migration not necessary')
+    return
+  }
+
+  logger.info('Create pending_rca_proposals table')
+  await queryInterface.createTable('pending_rca_proposals', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+    },
+    signed_payload: {
+      type: DataTypes.BLOB,
+      allowNull: false,
+    },
+    version: {
+      type: DataTypes.SMALLINT,
+      allowNull: false,
+      defaultValue: 2,
+    },
+    status: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  })
+
+  await queryInterface.addIndex('pending_rca_proposals', ['status', 'created_at'], {
+    name: 'idx_pending_rca_status',
+  })
+
+  await queryInterface.sequelize.query(
+    'CREATE INDEX idx_pending_rca_created ON pending_rca_proposals(created_at DESC)',
+  )
+
+  logger.info('Migration completed')
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.info('Drop pending_rca_proposals table')
+  await queryInterface.dropTable('pending_rca_proposals')
+
+  logger.info('Migration completed')
+}

--- a/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
+++ b/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
@@ -62,9 +62,10 @@ export async function up({ context }: Context): Promise<void> {
     },
   )
 
-  await queryInterface.sequelize.query(
-    'CREATE INDEX idx_pending_rca_created ON pending_rca_proposals(created_at DESC)',
-  )
+  await queryInterface.addIndex('pending_rca_proposals', {
+    name: 'idx_pending_rca_created',
+    fields: [{ name: 'created_at', order: 'DESC' }],
+  })
 
   logger.info('Migration completed')
 }


### PR DESCRIPTION
## Motivation

The indexer-rs DIPs flow stores validated RCA proposals in a `pending_rca_proposals` table for the agent to later pick up and accept on-chain. By convention in this codebase, the indexer-service does not run database migrations -- it defers to the agent to avoid DDL conflicts from two processes sharing a database. Without this migration, indexer-service rejects every valid proposal with `relation "pending_rca_proposals" does not exist`.

## Summary

- Adds Umzug migration `23-add-pending-rca-proposals.ts` that creates the `pending_rca_proposals` table with the schema defined in `indexer-rs/migrations/20260302000000_dips_pending_proposals.up.sql`
- The table is intentionally minimal (6 columns): `id`, `signed_payload`, `version`, `status`, `created_at`, `updated_at`. The signed payload blob is the source of truth -- the agent decodes it when accepting on-chain
- Does **not** drop the old `indexing_agreements` / `dips_receipts` tables (the existing agent DIPs code still references them; updating that code is a separate piece of work)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>