### PR TITLE
feat: add pending RCA proposal consumer and migration

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -716,6 +716,11 @@ export class Agent {
               if (!operator.dipsManager) {
                 throw new Error('DipsManager is not available')
               }
+
+              await operator.dipsManager.acceptPendingProposals(
+                activeAllocations,
+              )
+
               this.logger.debug(
                 `Matching agreement allocations for network ${network.specification.networkIdentifier}`,
               )

--- a/packages/indexer-agent/src/commands/start.ts
+++ b/packages/indexer-agent/src/commands/start.ts
@@ -15,6 +15,7 @@ import {
   createIndexerManagementClient,
   createIndexerManagementServer,
   defineIndexerManagementModels,
+  definePendingRcaProposalModel,
   defineQueryFeeModels,
   GraphNode,
   indexerError,
@@ -670,6 +671,9 @@ export async function run(
   await sequelize.sync()
   logger.info(`Successfully synced database models`)
 
+  // Define after sync so Sequelize won't try to create/alter this indexer-rs-owned table
+  const pendingRcaModel = definePendingRcaProposalModel(sequelize)
+
   // --------------------------------------------------------------------------------
   // * Networks
   // --------------------------------------------------------------------------------
@@ -710,6 +714,7 @@ export async function run(
       },
     },
     multiNetworks,
+    pendingRcaModel,
   })
 
   // --------------------------------------------------------------------------------

--- a/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
+++ b/packages/indexer-agent/src/db/migrations/23-add-pending-rca-proposals.ts
@@ -1,0 +1,74 @@
+import { Logger } from '@graphprotocol/common-ts'
+
+import { QueryInterface, DataTypes } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  const tables = await queryInterface.showAllTables()
+  logger.debug('Checking if pending_rca_proposals table exists', { tables })
+
+  if (tables.includes('pending_rca_proposals')) {
+    logger.debug(
+      'pending_rca_proposals already exists, migration not necessary',
+    )
+    return
+  }
+
+  logger.info('Create pending_rca_proposals')
+  await queryInterface.createTable('pending_rca_proposals', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+    },
+    signed_payload: {
+      type: DataTypes.BLOB,
+      allowNull: false,
+    },
+    version: {
+      type: DataTypes.SMALLINT,
+      allowNull: false,
+      defaultValue: 2,
+    },
+    status: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+  })
+
+  await queryInterface.addIndex(
+    'pending_rca_proposals',
+    ['status', 'created_at'],
+    {
+      name: 'idx_pending_rca_status',
+    },
+  )
+  await queryInterface.addIndex('pending_rca_proposals', {
+    fields: [{ name: 'created_at', order: 'DESC' }],
+    name: 'idx_pending_rca_created',
+  })
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+  logger.info('Drop pending_rca_proposals')
+  await queryInterface.dropTable('pending_rca_proposals')
+}

--- a/packages/indexer-common/src/indexer-management/actions.ts
+++ b/packages/indexer-common/src/indexer-management/actions.ts
@@ -24,6 +24,7 @@ import {
 import { Order, Transaction } from 'sequelize'
 import { Eventual, join, Logger } from '@graphprotocol/common-ts'
 import groupBy from 'lodash.groupby'
+import { PendingRcaProposal } from './models/pending-rca-proposal'
 
 export class ActionManager {
   declare multiNetworks: MultiNetworks<Network>
@@ -38,6 +39,7 @@ export class ActionManager {
     logger: Logger,
     models: IndexerManagementModels,
     graphNode: GraphNode,
+    pendingRcaModel?: typeof PendingRcaProposal,
   ): Promise<ActionManager> {
     const actionManager = new ActionManager()
     actionManager.multiNetworks = multiNetworks
@@ -52,6 +54,7 @@ export class ActionManager {
         models,
         graphNode,
         network,
+        pendingRcaModel,
       )
     })
 

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -47,6 +47,7 @@ import {
   encodeStopServiceData,
   PaymentTypes,
 } from '@graphprotocol/toolshed'
+import { PendingRcaProposal } from './models/pending-rca-proposal'
 import {
   encodeCollectIndexingRewardsData,
   encodePOIMetadata,
@@ -166,9 +167,16 @@ export class AllocationManager {
     private models: IndexerManagementModels,
     private graphNode: GraphNode,
     private network: Network,
+    private pendingRcaModel?: typeof PendingRcaProposal,
   ) {
     if (this.network.specification.indexerOptions.dipperEndpoint) {
-      this.dipsManager = new DipsManager(this.logger, this.models, this.network, this)
+      this.dipsManager = new DipsManager(
+        this.logger,
+        this.models,
+        this.network,
+        this,
+        this.pendingRcaModel,
+      )
     }
   }
 

--- a/packages/indexer-common/src/indexer-management/client.ts
+++ b/packages/indexer-common/src/indexer-management/client.ts
@@ -20,6 +20,7 @@ import {
   Network,
   RulesManager,
 } from '@graphprotocol/indexer-common'
+import { PendingRcaProposal } from './models/pending-rca-proposal'
 
 export interface IndexerManagementResolverContext {
   models: IndexerManagementModels
@@ -574,6 +575,7 @@ export interface IndexerManagementClientOptions {
   multiNetworks: MultiNetworks<Network> | undefined
   defaults: IndexerManagementDefaults
   actionManager?: ActionManager | undefined
+  pendingRcaModel?: typeof PendingRcaProposal
 }
 
 export class IndexerManagementClient extends Client {
@@ -595,7 +597,7 @@ export class IndexerManagementClient extends Client {
 export const createIndexerManagementClient = async (
   options: IndexerManagementClientOptions,
 ): Promise<IndexerManagementClient> => {
-  const { models, graphNode, logger, defaults, multiNetworks } = options
+  const { models, graphNode, logger, defaults, multiNetworks, pendingRcaModel } = options
   const schema = buildSchema(print(SCHEMA_SDL))
   const resolvers = {
     ...indexingRuleResolvers,
@@ -608,7 +610,13 @@ export const createIndexerManagementClient = async (
   }
 
   const actionManager = multiNetworks
-    ? await ActionManager.create(multiNetworks, logger, models, graphNode)
+    ? await ActionManager.create(
+        multiNetworks,
+        logger,
+        models,
+        graphNode,
+        pendingRcaModel,
+      )
     : undefined
 
   const rulesManager = multiNetworks

--- a/packages/indexer-common/src/indexer-management/models/index.ts
+++ b/packages/indexer-common/src/indexer-management/models/index.ts
@@ -11,6 +11,7 @@ export * from './indexing-rule'
 export * from './poi-dispute'
 export * from './action'
 export * from './indexing-agreement'
+export * from './pending-rca-proposal'
 
 export type IndexerManagementModels = IndexingRuleModels &
   CostModelModels &

--- a/packages/indexer-common/src/indexer-management/models/pending-rca-proposal.ts
+++ b/packages/indexer-common/src/indexer-management/models/pending-rca-proposal.ts
@@ -1,0 +1,55 @@
+import { DataTypes, Sequelize, Model, InferAttributes } from 'sequelize'
+
+export class PendingRcaProposal extends Model<InferAttributes<PendingRcaProposal>> {
+  declare id: string
+  declare signed_payload: Buffer
+  declare version: number
+  declare status: string
+  declare created_at: Date
+  declare updated_at: Date
+}
+
+export const definePendingRcaProposalModel = (
+  sequelize: Sequelize,
+): typeof PendingRcaProposal => {
+  PendingRcaProposal.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+      },
+      signed_payload: {
+        type: DataTypes.BLOB,
+        allowNull: false,
+      },
+      version: {
+        type: DataTypes.SMALLINT,
+        allowNull: false,
+        defaultValue: 2,
+      },
+      status: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+    },
+    {
+      modelName: 'PendingRcaProposal',
+      sequelize,
+      tableName: 'pending_rca_proposals',
+      timestamps: true,
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+    },
+  )
+
+  return PendingRcaProposal
+}

--- a/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
@@ -1,0 +1,593 @@
+import { createLogger, Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { DipsManager } from '../dips'
+import { PendingRcaConsumer } from '../pending-rca-consumer'
+import { DecodedRcaProposal } from '../types'
+import {
+  Allocation,
+  AllocationStatus,
+  IndexerManagementModels,
+  Network,
+} from '@graphprotocol/indexer-common'
+
+let logger: Logger
+
+beforeAll(() => {
+  logger = createLogger({
+    name: 'AcceptProposals Test',
+    async: false,
+    level: 'error',
+  })
+})
+
+const TEST_DEPLOYMENT_BYTES32 =
+  '0x0100000000000000000000000000000000000000000000000000000000000000'
+
+function createMockProposal(
+  overrides: Partial<DecodedRcaProposal> = {},
+): DecodedRcaProposal {
+  const deployment = new SubgraphDeploymentID(
+    overrides.subgraphDeploymentId?.bytes32 ?? TEST_DEPLOYMENT_BYTES32,
+  )
+  return {
+    id: 'proposal-1',
+    status: 'pending',
+    createdAt: new Date(),
+    signedRca: {
+      rca: {
+        deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+        endsAt: BigInt(Math.floor(Date.now() / 1000) + 86400),
+        payer: '0x1111111111111111111111111111111111111111',
+        dataService: '0x2222222222222222222222222222222222222222',
+        serviceProvider: '0x3333333333333333333333333333333333333333',
+        maxInitialTokens: 10000n,
+        maxOngoingTokensPerSecond: 100n,
+        minSecondsPerCollection: 3600n,
+        maxSecondsPerCollection: 86400n,
+        nonce: 42n,
+        metadata: '0x',
+      },
+      signature: '0xaabbccdd',
+    },
+    signedPayload: new Uint8Array(),
+    payer: '0x1111111111111111111111111111111111111111',
+    serviceProvider: '0x3333333333333333333333333333333333333333',
+    dataService: '0x2222222222222222222222222222222222222222',
+    deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    endsAt: BigInt(Math.floor(Date.now() / 1000) + 86400),
+    maxInitialTokens: 10000n,
+    maxOngoingTokensPerSecond: 100n,
+    minSecondsPerCollection: 3600n,
+    maxSecondsPerCollection: 86400n,
+    nonce: 42n,
+    subgraphDeploymentId: deployment,
+    tokensPerSecond: 1000n,
+    tokensPerEntityPerSecond: 50n,
+    ...overrides,
+  }
+}
+
+function createMockAllocation(
+  deploymentBytes32: string = TEST_DEPLOYMENT_BYTES32,
+): Allocation {
+  return {
+    id: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    status: AllocationStatus.ACTIVE,
+    isLegacy: false,
+    subgraphDeployment: {
+      id: new SubgraphDeploymentID(deploymentBytes32),
+    },
+    indexer: '0x5555555555555555555555555555555555555555',
+    allocatedTokens: 1000000000000000000n,
+    createdAt: 0,
+    createdAtEpoch: 100,
+    createdAtBlockHash: '0x',
+    closedAt: 0,
+    closedAtEpoch: 0,
+    closedAtEpochStartBlockHash: undefined,
+    previousEpochStartBlockHash: undefined,
+    closedAtBlockHash: '0x',
+    poi: undefined,
+    queryFeeRebates: 0n,
+    queryFeesCollected: 0n,
+  } as Allocation
+}
+
+function createMockConsumer(proposals: DecodedRcaProposal[] = []) {
+  return {
+    getPendingProposals: jest.fn().mockResolvedValue(proposals),
+    getPendingProposalsForDeployment: jest.fn().mockResolvedValue([]),
+    markAccepted: jest.fn().mockResolvedValue(undefined),
+    markRejected: jest.fn().mockResolvedValue(undefined),
+  } as unknown as PendingRcaConsumer
+}
+
+function createMockModels() {
+  return {
+    IndexingRule: {
+      findOne: jest.fn().mockResolvedValue(null),
+      findAll: jest.fn().mockResolvedValue([]),
+      destroy: jest.fn().mockResolvedValue(1),
+    },
+  } as unknown as IndexerManagementModels
+}
+
+function createMockNetwork() {
+  return {
+    contracts: {
+      SubgraphService: {
+        acceptIndexingAgreement: Object.assign(jest.fn(), {
+          estimateGas: jest.fn().mockResolvedValue(100000n),
+          populateTransaction: jest.fn().mockResolvedValue({ data: '0xaccept' }),
+        }),
+        startService: {
+          populateTransaction: jest.fn().mockResolvedValue({ data: '0xstart' }),
+        },
+        multicall: Object.assign(jest.fn(), {
+          estimateGas: jest.fn().mockResolvedValue(200000n),
+        }),
+        getAllocation: jest.fn().mockResolvedValue({ createdAt: 0n }),
+        getLegacyAllocation: jest
+          .fn()
+          .mockResolvedValue({ indexer: '0x0000000000000000000000000000000000000000' }),
+        target: '0x4444444444444444444444444444444444444444',
+        indexers: jest.fn().mockResolvedValue({ url: 'http://test' }),
+      },
+      EpochManager: {
+        currentEpoch: jest.fn().mockResolvedValue(100n),
+      },
+      RewardsManager: {
+        isDenied: jest.fn().mockResolvedValue(false),
+      },
+    },
+    transactionManager: {
+      executeTransaction: jest.fn(),
+      wallet: {
+        mnemonic: {
+          phrase: 'test test test test test test test test test test test junk',
+        },
+      },
+    },
+    networkMonitor: {
+      currentEpoch: jest.fn().mockResolvedValue(100n),
+    },
+    specification: {
+      indexerOptions: {
+        address: '0x5555555555555555555555555555555555555555',
+        enableDips: true,
+        dipsAllocationAmount: 0n,
+        defaultAllocationAmount: 10000000000000000000n, // 10 GRT
+      },
+      networkIdentifier: 'eip155:1337',
+    },
+    isHorizon: { value: jest.fn().mockResolvedValue(true) },
+  } as unknown as Network
+}
+
+function createDipsManager(
+  network: Network,
+  models: IndexerManagementModels,
+  consumer: PendingRcaConsumer,
+): DipsManager {
+  const dm = new DipsManager(logger, models, network, null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(dm as any).pendingRcaConsumer = consumer
+  return dm
+}
+
+describe('DipsManager.acceptPendingProposals', () => {
+  test('rejects proposals with expired deadlines', async () => {
+    const expiredProposal = createMockProposal({
+      deadline: BigInt(Math.floor(Date.now() / 1000) - 100), // expired
+    })
+    const consumer = createMockConsumer([expiredProposal])
+    const models = createMockModels()
+    const network = createMockNetwork()
+    const dm = createDipsManager(network, models, consumer)
+
+    await dm.acceptPendingProposals([])
+
+    expect(consumer.markRejected).toHaveBeenCalledWith(
+      expiredProposal.id,
+      'deadline_expired',
+    )
+    expect(consumer.markAccepted).not.toHaveBeenCalled()
+  })
+
+  test('cleans up DIPS rule when rejecting last proposal for a deployment', async () => {
+    const proposal = createMockProposal({
+      deadline: BigInt(Math.floor(Date.now() / 1000) - 100),
+    })
+    const consumer = createMockConsumer([proposal])
+    // After rejection, no other proposals for this deployment
+    ;(consumer.getPendingProposalsForDeployment as jest.Mock).mockResolvedValue([])
+    const mockRule = { id: 42 }
+    const models = createMockModels()
+    ;(models.IndexingRule.findOne as jest.Mock).mockResolvedValue(mockRule)
+
+    const network = createMockNetwork()
+    const dm = createDipsManager(network, models, consumer)
+
+    await dm.acceptPendingProposals([])
+
+    expect(models.IndexingRule.destroy).toHaveBeenCalledWith({ where: { id: 42 } })
+  })
+
+  test('does not clean up DIPS rule when other proposals exist for deployment', async () => {
+    const proposal = createMockProposal({
+      deadline: BigInt(Math.floor(Date.now() / 1000) - 100),
+    })
+    const otherProposal = createMockProposal({ id: 'proposal-2' })
+    const consumer = createMockConsumer([proposal])
+    // Another proposal exists for same deployment
+    ;(consumer.getPendingProposalsForDeployment as jest.Mock).mockResolvedValue([
+      otherProposal,
+    ])
+    const models = createMockModels()
+    const network = createMockNetwork()
+    const dm = createDipsManager(network, models, consumer)
+
+    await dm.acceptPendingProposals([])
+
+    expect(models.IndexingRule.destroy).not.toHaveBeenCalled()
+  })
+
+  test('returns early when no pending proposals', async () => {
+    const consumer = createMockConsumer([])
+    const models = createMockModels()
+    const network = createMockNetwork()
+    const dm = createDipsManager(network, models, consumer)
+
+    await dm.acceptPendingProposals([])
+
+    expect(consumer.markAccepted).not.toHaveBeenCalled()
+    expect(consumer.markRejected).not.toHaveBeenCalled()
+  })
+
+  test('returns early when pendingRcaConsumer is null', async () => {
+    const models = createMockModels()
+    const network = createMockNetwork()
+    const dm = new DipsManager(logger, models, network, null)
+
+    // Should not throw
+    await dm.acceptPendingProposals([])
+  })
+
+  describe('with existing allocation', () => {
+    test('accepts proposal on-chain and marks accepted', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      const mockReceipt = { hash: '0xtxhash', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(network.transactionManager.executeTransaction).toHaveBeenCalled()
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+
+    test('skips acceptance when network is paused', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        'paused',
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(consumer.markAccepted).not.toHaveBeenCalled()
+      expect(consumer.markRejected).not.toHaveBeenCalled()
+    })
+
+    test('skips acceptance when unauthorized', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        'unauthorized',
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(consumer.markAccepted).not.toHaveBeenCalled()
+      expect(consumer.markRejected).not.toHaveBeenCalled()
+    })
+
+    test('uses multicall path when allocation is for different deployment', async () => {
+      const proposal = createMockProposal()
+      const differentDeployment =
+        '0x0200000000000000000000000000000000000000000000000000000000000000'
+      const allocation = createMockAllocation(differentDeployment)
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      const mockReceipt = { hash: '0xmulticall', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      // Should go to acceptWithNewAllocation (multicall) path, not existing allocation
+      expect(
+        network.contracts.SubgraphService.startService.populateTransaction,
+      ).toHaveBeenCalled()
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+  })
+
+  describe('with new allocation (multicall)', () => {
+    test('creates allocation and accepts in single multicall', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      const mockReceipt = { hash: '0xmulticallhash', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([]) // no active allocations
+
+      expect(network.transactionManager.executeTransaction).toHaveBeenCalled()
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+
+    test('skips when allocation already exists on-chain', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      // Allocation exists on-chain
+      ;(
+        network.contracts.SubgraphService.getAllocation as unknown as jest.Mock
+      ).mockResolvedValue({
+        createdAt: 100n,
+      })
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      expect(consumer.markAccepted).not.toHaveBeenCalled()
+      expect(network.transactionManager.executeTransaction).not.toHaveBeenCalled()
+    })
+
+    test('uses dipsAllocationAmount for token amount', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      // Verify startService was called with the configured allocation amount
+      expect(
+        network.contracts.SubgraphService.startService.populateTransaction,
+      ).toHaveBeenCalled()
+    })
+
+    test('handles paused network during multicall', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        'paused',
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      expect(consumer.markAccepted).not.toHaveBeenCalled()
+      expect(consumer.markRejected).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('error handling', () => {
+    test('rejects proposal on deterministic CALL_EXCEPTION error', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      // After rejection, no remaining proposals for cleanup
+      ;(consumer.getPendingProposalsForDeployment as jest.Mock).mockResolvedValue([])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockRejectedValue({
+        code: 'CALL_EXCEPTION',
+        data: '0x',
+      })
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(consumer.markRejected).toHaveBeenCalledWith(proposal.id, expect.any(String))
+    })
+
+    test('leaves proposal pending on transient network error', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockRejectedValue(
+        new Error('ECONNRESET'),
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(consumer.markRejected).not.toHaveBeenCalled()
+      expect(consumer.markAccepted).not.toHaveBeenCalled()
+    })
+
+    test('continues processing other proposals after error', async () => {
+      const failProposal = createMockProposal({ id: 'fail-1' })
+      const okDeployment =
+        '0x0200000000000000000000000000000000000000000000000000000000000000'
+      const okProposal = createMockProposal({
+        id: 'ok-1',
+        subgraphDeploymentId: new SubgraphDeploymentID(okDeployment),
+      })
+      const consumer = createMockConsumer([failProposal, okProposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      const failAllocation = {
+        id: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        status: AllocationStatus.ACTIVE,
+        isLegacy: false,
+        subgraphDeployment: {
+          id: new SubgraphDeploymentID(TEST_DEPLOYMENT_BYTES32),
+        },
+      } as Allocation
+      const okAllocation = {
+        id: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        status: AllocationStatus.ACTIVE,
+        isLegacy: false,
+        subgraphDeployment: {
+          id: new SubgraphDeploymentID(okDeployment),
+        },
+      } as Allocation
+
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock)
+        .mockRejectedValueOnce(new Error('first fails'))
+        .mockResolvedValueOnce(mockReceipt) // second succeeds
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([failAllocation, okAllocation])
+
+      // Second proposal should still be processed and accepted
+      expect(consumer.markAccepted).toHaveBeenCalledWith('ok-1')
+    })
+  })
+
+  describe('allocation amount selection', () => {
+    test('uses defaultAllocationAmount for rewarded (not denied) subgraph', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(
+        network.contracts.RewardsManager.isDenied as unknown as jest.Mock
+      ).mockResolvedValue(false)
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      // Should check isDenied
+      expect(network.contracts.RewardsManager.isDenied).toHaveBeenCalledWith(
+        proposal.subgraphDeploymentId.bytes32,
+      )
+      // startService should be called (new allocation path)
+      expect(
+        network.contracts.SubgraphService.startService.populateTransaction,
+      ).toHaveBeenCalled()
+    })
+
+    test('uses dipsAllocationAmount (0) for denied subgraph', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(
+        network.contracts.RewardsManager.isDenied as unknown as jest.Mock
+      ).mockResolvedValue(true)
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      expect(network.contracts.RewardsManager.isDenied).toHaveBeenCalledWith(
+        proposal.subgraphDeploymentId.bytes32,
+      )
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+
+    test('uses per-deployment rule amount for rewarded subgraph with existing rule', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const ruleAmount = 5000000000000000000n // 5 GRT
+      ;(models.IndexingRule.findOne as jest.Mock).mockResolvedValue({
+        allocationAmount: ruleAmount.toString(),
+      })
+      const network = createMockNetwork()
+      ;(
+        network.contracts.RewardsManager.isDenied as unknown as jest.Mock
+      ).mockResolvedValue(false)
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+
+    test('uses custom dipsAllocationAmount for denied subgraph with override', async () => {
+      const proposal = createMockProposal()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      // Override dipsAllocationAmount to non-zero
+      ;(
+        network.specification.indexerOptions as { dipsAllocationAmount: bigint }
+      ).dipsAllocationAmount = 1000000000000000000n // 1 GRT
+      ;(
+        network.contracts.RewardsManager.isDenied as unknown as jest.Mock
+      ).mockResolvedValue(true)
+      const mockReceipt = { hash: '0x', status: 1 }
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue(
+        mockReceipt,
+      )
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([])
+
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+  })
+})

--- a/packages/indexer-common/src/indexing-fees/__tests__/dips.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/dips.test.ts
@@ -179,7 +179,7 @@ describe('DipsManager', () => {
       expect(dipsManager).toBeDefined()
     })
 
-    test('throws error when dipperEndpoint is not configured', async () => {
+    test('creates DipsManager without gRPC client when dipperEndpoint is not configured', async () => {
       const specWithoutDipper = {
         ...testNetworkSpecification,
         indexerOptions: {
@@ -197,9 +197,14 @@ describe('DipsManager', () => {
         graphNode,
         metrics,
       )
-      expect(
-        () => new DipsManager(logger, managementModels, networkWithoutDipper, null),
-      ).toThrow('dipperEndpoint is not set')
+      const dipsManager = new DipsManager(
+        logger,
+        managementModels,
+        networkWithoutDipper,
+        null,
+      )
+      expect(dipsManager).toBeDefined()
+      expect(dipsManager.gatewayDipsServiceClient).toBeUndefined()
     })
   })
 

--- a/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
@@ -1,0 +1,256 @@
+import { ethers } from 'ethers'
+import { createLogger, Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { PendingRcaConsumer } from '../pending-rca-consumer'
+import { PendingRcaProposal } from '../../indexer-management/models/pending-rca-proposal'
+
+// ABI tuple types matching toolshed's recurring-collector.js
+const RCA_TUPLE =
+  'tuple(uint64 deadline, uint64 endsAt, address payer, address dataService, address serviceProvider, uint256 maxInitialTokens, uint256 maxOngoingTokensPerSecond, uint32 minSecondsPerCollection, uint32 maxSecondsPerCollection, uint256 nonce, bytes metadata)'
+const SIGNED_RCA_TUPLE = `tuple(${RCA_TUPLE} rca, bytes signature)`
+const ACCEPT_METADATA_TUPLE =
+  'tuple(bytes32 subgraphDeploymentId, uint8 version, bytes terms)'
+const TERMS_V1_TUPLE = 'tuple(uint256 tokensPerSecond, uint256 tokensPerEntityPerSecond)'
+
+const coder = ethers.AbiCoder.defaultAbiCoder()
+
+// Test data
+const TEST_PAYER = '0x1234567890abcdef1234567890abcdef12345678'
+const TEST_DATA_SERVICE = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+const TEST_SERVICE_PROVIDER = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+const TEST_DEPLOYMENT_BYTES32 =
+  '0x0100000000000000000000000000000000000000000000000000000000000000'
+const TEST_SIGNATURE = '0xaabbccdd'
+
+function encodeTestPayload(overrides?: {
+  deadline?: bigint
+  endsAt?: bigint
+  tokensPerSecond?: bigint
+  tokensPerEntityPerSecond?: bigint
+  minSecondsPerCollection?: number
+  maxSecondsPerCollection?: number
+}): Buffer {
+  const tokensPerSecond = overrides?.tokensPerSecond ?? 1000n
+  const tokensPerEntityPerSecond = overrides?.tokensPerEntityPerSecond ?? 50n
+
+  const termsEncoded = coder.encode(
+    [TERMS_V1_TUPLE],
+    [{ tokensPerSecond, tokensPerEntityPerSecond }],
+  )
+
+  const metadataEncoded = coder.encode(
+    [ACCEPT_METADATA_TUPLE],
+    [
+      {
+        subgraphDeploymentId: TEST_DEPLOYMENT_BYTES32,
+        version: 1n,
+        terms: termsEncoded,
+      },
+    ],
+  )
+
+  const signedRcaEncoded = coder.encode(
+    [SIGNED_RCA_TUPLE],
+    [
+      {
+        rca: {
+          deadline: overrides?.deadline ?? 1700000000n,
+          endsAt: overrides?.endsAt ?? 1800000000n,
+          payer: TEST_PAYER,
+          dataService: TEST_DATA_SERVICE,
+          serviceProvider: TEST_SERVICE_PROVIDER,
+          maxInitialTokens: 10000n,
+          maxOngoingTokensPerSecond: 100n,
+          minSecondsPerCollection: overrides?.minSecondsPerCollection ?? 3600,
+          maxSecondsPerCollection: overrides?.maxSecondsPerCollection ?? 86400,
+          nonce: 42n,
+          metadata: metadataEncoded,
+        },
+        signature: TEST_SIGNATURE,
+      },
+    ],
+  )
+
+  return Buffer.from(ethers.getBytes(signedRcaEncoded))
+}
+
+let logger: Logger
+
+beforeAll(() => {
+  logger = createLogger({
+    name: 'PendingRcaConsumer Test',
+    async: false,
+    level: 'error',
+  })
+})
+
+function createMockModel(rows: Partial<PendingRcaProposal>[] = []) {
+  return {
+    findAll: jest.fn().mockResolvedValue(rows),
+    update: jest.fn().mockResolvedValue([1]),
+  } as unknown as typeof PendingRcaProposal
+}
+
+describe('PendingRcaConsumer', () => {
+  describe('getPendingProposals', () => {
+    test('decodes valid pending proposals', async () => {
+      const payload = encodeTestPayload()
+      const model = createMockModel([
+        {
+          id: 'test-uuid-1',
+          signed_payload: payload,
+          version: 2,
+          status: 'pending',
+          created_at: new Date('2024-01-01'),
+          updated_at: new Date('2024-01-01'),
+        },
+      ])
+
+      const consumer = new PendingRcaConsumer(logger, model)
+      const proposals = await consumer.getPendingProposals()
+
+      expect(proposals).toHaveLength(1)
+      const p = proposals[0]
+
+      expect(p.id).toBe('test-uuid-1')
+      expect(p.status).toBe('pending')
+      expect(p.payer.toLowerCase()).toBe(TEST_PAYER.toLowerCase())
+      expect(p.serviceProvider.toLowerCase()).toBe(TEST_SERVICE_PROVIDER.toLowerCase())
+      expect(p.dataService.toLowerCase()).toBe(TEST_DATA_SERVICE.toLowerCase())
+      expect(p.deadline).toBe(1700000000n)
+      expect(p.endsAt).toBe(1800000000n)
+      expect(p.maxInitialTokens).toBe(10000n)
+      expect(p.maxOngoingTokensPerSecond).toBe(100n)
+      expect(p.minSecondsPerCollection).toBe(3600n)
+      expect(p.maxSecondsPerCollection).toBe(86400n)
+      expect(p.nonce).toBe(42n)
+      expect(p.tokensPerSecond).toBe(1000n)
+      expect(p.tokensPerEntityPerSecond).toBe(50n)
+
+      expect(p.subgraphDeploymentId).toBeInstanceOf(SubgraphDeploymentID)
+      expect(p.subgraphDeploymentId.bytes32).toBe(TEST_DEPLOYMENT_BYTES32)
+
+      expect(p.signedRca).toBeDefined()
+      expect(p.signedRca.rca.payer.toLowerCase()).toBe(TEST_PAYER.toLowerCase())
+      expect(p.signedRca.signature).toBe(TEST_SIGNATURE)
+
+      expect(p.signedPayload).toBeInstanceOf(Uint8Array)
+    })
+
+    test('queries only pending rows', async () => {
+      const model = createMockModel([])
+      const consumer = new PendingRcaConsumer(logger, model)
+
+      await consumer.getPendingProposals()
+
+      expect(model.findAll).toHaveBeenCalledWith({
+        where: { status: 'pending' },
+      })
+    })
+
+    test('skips rows with corrupt payloads and logs warning', async () => {
+      const warnSpy = jest.fn()
+      const testLogger = {
+        ...logger,
+        warn: warnSpy,
+        child: () => testLogger,
+      } as unknown as Logger
+
+      const model = createMockModel([
+        {
+          id: 'good-uuid',
+          signed_payload: encodeTestPayload(),
+          version: 2,
+          status: 'pending',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 'bad-uuid',
+          signed_payload: Buffer.from('deadbeef', 'hex'),
+          version: 2,
+          status: 'pending',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ])
+
+      const consumer = new PendingRcaConsumer(testLogger, model)
+      const proposals = await consumer.getPendingProposals()
+
+      expect(proposals).toHaveLength(1)
+      expect(proposals[0].id).toBe('good-uuid')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('bad-uuid'),
+        expect.any(Object),
+      )
+    })
+
+    test('decodes multiple proposals', async () => {
+      const model = createMockModel([
+        {
+          id: 'uuid-1',
+          signed_payload: encodeTestPayload({ tokensPerSecond: 100n }),
+          version: 2,
+          status: 'pending',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 'uuid-2',
+          signed_payload: encodeTestPayload({ tokensPerSecond: 200n }),
+          version: 2,
+          status: 'pending',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ])
+
+      const consumer = new PendingRcaConsumer(logger, model)
+      const proposals = await consumer.getPendingProposals()
+
+      expect(proposals).toHaveLength(2)
+      expect(proposals[0].tokensPerSecond).toBe(100n)
+      expect(proposals[1].tokensPerSecond).toBe(200n)
+    })
+  })
+
+  describe('markAccepted', () => {
+    test('updates status to accepted', async () => {
+      const model = createMockModel()
+      const consumer = new PendingRcaConsumer(logger, model)
+
+      await consumer.markAccepted('test-uuid')
+
+      expect(model.update).toHaveBeenCalledWith(
+        { status: 'accepted' },
+        { where: { id: 'test-uuid' } },
+      )
+    })
+  })
+
+  describe('markRejected', () => {
+    test('updates status to rejected', async () => {
+      const model = createMockModel()
+      const consumer = new PendingRcaConsumer(logger, model)
+
+      await consumer.markRejected('test-uuid', 'deployment blocklisted')
+
+      expect(model.update).toHaveBeenCalledWith(
+        { status: 'rejected' },
+        { where: { id: 'test-uuid' } },
+      )
+    })
+
+    test('updates status without reason', async () => {
+      const model = createMockModel()
+      const consumer = new PendingRcaConsumer(logger, model)
+
+      await consumer.markRejected('test-uuid')
+
+      expect(model.update).toHaveBeenCalledWith(
+        { status: 'rejected' },
+        { where: { id: 'test-uuid' } },
+      )
+    })
+  })
+})

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -30,6 +30,8 @@ import {
   GatewayDipsServiceClientImpl,
 } from '@graphprotocol/dips-proto/generated/gateway'
 import { IndexingAgreement } from '../indexer-management/models/indexing-agreement'
+import { PendingRcaProposal } from '../indexer-management/models/pending-rca-proposal'
+import { PendingRcaConsumer } from './pending-rca-consumer'
 import { NetworkSpecification } from '../network-specification'
 import { BaseWallet } from 'ethers'
 
@@ -46,19 +48,28 @@ const normalizeAddressForDB = (address: string) => {
 export class DipsManager {
   declare gatewayDipsServiceClient: GatewayDipsServiceClientImpl
   declare gatewayDipsServiceMessagesCodec: GatewayDipsServiceMessagesCodec
+  declare pendingRcaConsumer: PendingRcaConsumer | null
   constructor(
     private logger: Logger,
     private models: IndexerManagementModels,
     private network: Network,
     private parent: AllocationManager | null,
+    pendingRcaModel?: typeof PendingRcaProposal,
   ) {
-    if (!this.network.specification.indexerOptions.dipperEndpoint) {
-      throw new Error('dipperEndpoint is not set')
+    // gRPC client — still needed for tryCancelAgreement() and DipsCollector
+    if (this.network.specification.indexerOptions.dipperEndpoint) {
+      this.gatewayDipsServiceClient = createGatewayDipsServiceClient(
+        this.network.specification.indexerOptions.dipperEndpoint,
+      )
+      this.gatewayDipsServiceMessagesCodec = new GatewayDipsServiceMessagesCodec()
     }
-    this.gatewayDipsServiceClient = createGatewayDipsServiceClient(
-      this.network.specification.indexerOptions.dipperEndpoint,
-    )
-    this.gatewayDipsServiceMessagesCodec = new GatewayDipsServiceMessagesCodec()
+
+    // Pending RCA consumer — new data source for ensureAgreementRules()
+    if (pendingRcaModel) {
+      this.pendingRcaConsumer = new PendingRcaConsumer(this.logger, pendingRcaModel)
+    } else {
+      this.pendingRcaConsumer = null
+    }
   }
   // Cancel an agreement associated to an allocation if it exists
   async tryCancelAgreement(allocationId: string) {
@@ -121,6 +132,81 @@ export class DipsManager {
       )
       return
     }
+
+    // Use PendingRcaConsumer if available, otherwise fall back to old IndexingAgreement model
+    if (this.pendingRcaConsumer) {
+      await this.ensureAgreementRulesFromRca()
+    } else {
+      await this.ensureAgreementRulesFromLegacy()
+    }
+  }
+
+  private async ensureAgreementRulesFromRca() {
+    const proposals = await this.pendingRcaConsumer!.getPendingProposals()
+    this.logger.debug(
+      `Ensuring indexing rules for ${proposals.length} pending RCA proposal${
+        proposals.length === 1 ? '' : 's'
+      }`,
+    )
+
+    for (const proposal of proposals) {
+      const subgraphDeploymentID = proposal.subgraphDeploymentId
+      this.logger.info(
+        `Checking if indexing rule exists for proposal ${
+          proposal.id
+        }, deployment ${subgraphDeploymentID.toString()}`,
+      )
+
+      const ruleExists = await this.parent!.matchingRuleExists(
+        this.logger,
+        subgraphDeploymentID,
+      )
+
+      const allDeploymentRules = await this.models.IndexingRule.findAll({
+        where: {
+          identifierType: SubgraphIdentifierType.DEPLOYMENT,
+        },
+      })
+      const blocklistedRule = allDeploymentRules.find(
+        (rule) =>
+          new SubgraphDeploymentID(rule.identifier).bytes32 ===
+            subgraphDeploymentID.bytes32 &&
+          rule.decisionBasis === IndexingDecisionBasis.NEVER,
+      )
+
+      if (blocklistedRule) {
+        this.logger.info(
+          `Blocklisted deployment ${subgraphDeploymentID.toString()}, rejecting proposal`,
+        )
+        await this.pendingRcaConsumer!.markRejected(proposal.id, 'deployment blocklisted')
+      } else if (!ruleExists) {
+        this.logger.info(
+          `Creating indexing rule for proposal ${
+            proposal.id
+          }, deployment ${subgraphDeploymentID.toString()}`,
+        )
+        const indexingRule = {
+          identifier: subgraphDeploymentID.ipfsHash,
+          allocationAmount: formatGRT(
+            this.network.specification.indexerOptions.dipsAllocationAmount,
+          ),
+          identifierType: SubgraphIdentifierType.DEPLOYMENT,
+          decisionBasis: IndexingDecisionBasis.DIPS,
+          protocolNetwork: this.network.specification.networkIdentifier,
+          autoRenewal: true,
+          allocationLifetime: Math.max(
+            Number(proposal.minSecondsPerCollection),
+            Number(proposal.maxSecondsPerCollection),
+          ),
+          requireSupported: false,
+        } as Partial<IndexingRuleAttributes>
+
+        await upsertIndexingRule(this.logger, this.models, indexingRule)
+      }
+    }
+  }
+
+  private async ensureAgreementRulesFromLegacy() {
     // Get all the indexing agreements that are not cancelled
     const indexingAgreements = await this.models.IndexingAgreement.findAll({
       where: {
@@ -144,7 +230,7 @@ export class DipsManager {
         }, deployment ${subgraphDeploymentID.toString()}`,
       )
       // If there is not yet an indexingRule that deems this deployment worth allocating to, make one
-      const ruleExists = await this.parent.matchingRuleExists(
+      const ruleExists = await this.parent!.matchingRuleExists(
         this.logger,
         subgraphDeploymentID,
       )

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -32,8 +32,12 @@ import {
 import { IndexingAgreement } from '../indexer-management/models/indexing-agreement'
 import { PendingRcaProposal } from '../indexer-management/models/pending-rca-proposal'
 import { PendingRcaConsumer } from './pending-rca-consumer'
+import { DecodedRcaProposal } from './types'
+import { tryParseCustomError } from '../utils'
+import { uniqueAllocationID, horizonAllocationIdProof } from '../allocations/keys'
+import { encodeStartServiceData } from '@graphprotocol/toolshed'
 import { NetworkSpecification } from '../network-specification'
-import { BaseWallet } from 'ethers'
+import { BaseWallet, Signer } from 'ethers'
 
 const DIPS_COLLECTION_INTERVAL = 60_000
 
@@ -141,6 +145,38 @@ export class DipsManager {
     }
   }
 
+  private async getDipsAllocationAmount(
+    subgraphDeploymentId: SubgraphDeploymentID,
+  ): Promise<{ amount: bigint; isDenied: boolean }> {
+    const isDenied = await this.network.contracts.RewardsManager.isDenied(
+      subgraphDeploymentId.bytes32,
+    )
+
+    if (isDenied) {
+      return {
+        amount: BigInt(this.network.specification.indexerOptions.dipsAllocationAmount),
+        isDenied,
+      }
+    }
+
+    // Rewarded subgraph: use rule's allocationAmount or defaultAllocationAmount
+    const rule = await this.models.IndexingRule.findOne({
+      where: {
+        identifier: subgraphDeploymentId.ipfsHash,
+        identifierType: SubgraphIdentifierType.DEPLOYMENT,
+      },
+    })
+
+    if (rule?.allocationAmount) {
+      return { amount: BigInt(rule.allocationAmount), isDenied }
+    }
+
+    return {
+      amount: BigInt(this.network.specification.indexerOptions.defaultAllocationAmount),
+      isDenied,
+    }
+  }
+
   private async ensureAgreementRulesFromRca() {
     const proposals = await this.pendingRcaConsumer!.getPendingProposals()
     this.logger.debug(
@@ -185,11 +221,10 @@ export class DipsManager {
             proposal.id
           }, deployment ${subgraphDeploymentID.toString()}`,
         )
+        const { amount } = await this.getDipsAllocationAmount(subgraphDeploymentID)
         const indexingRule = {
           identifier: subgraphDeploymentID.ipfsHash,
-          allocationAmount: formatGRT(
-            this.network.specification.indexerOptions.dipsAllocationAmount,
-          ),
+          allocationAmount: formatGRT(amount),
           identifierType: SubgraphIdentifierType.DEPLOYMENT,
           decisionBasis: IndexingDecisionBasis.DIPS,
           protocolNetwork: this.network.specification.networkIdentifier,
@@ -202,6 +237,287 @@ export class DipsManager {
         } as Partial<IndexingRuleAttributes>
 
         await upsertIndexingRule(this.logger, this.models, indexingRule)
+      }
+    }
+  }
+
+  async acceptPendingProposals(activeAllocations: Allocation[]): Promise<void> {
+    if (!this.pendingRcaConsumer) {
+      return
+    }
+    const consumer = this.pendingRcaConsumer
+
+    const proposals = await consumer.getPendingProposals()
+    if (proposals.length === 0) {
+      return
+    }
+
+    this.logger.info('Processing pending RCA proposals for on-chain acceptance', {
+      count: proposals.length,
+    })
+
+    for (const proposal of proposals) {
+      try {
+        await this.processProposal(consumer, proposal, activeAllocations)
+      } catch (error) {
+        this.logger.error('Unexpected error processing proposal', {
+          proposalId: proposal.id,
+          error,
+        })
+      }
+    }
+  }
+
+  private async processProposal(
+    consumer: PendingRcaConsumer,
+    proposal: DecodedRcaProposal,
+    activeAllocations: Allocation[],
+  ): Promise<void> {
+    const now = BigInt(Math.floor(Date.now() / 1000))
+
+    if (proposal.deadline <= now) {
+      this.logger.info('Rejecting proposal: deadline expired', {
+        proposalId: proposal.id,
+        deadline: proposal.deadline.toString(),
+        now: now.toString(),
+      })
+      await consumer.markRejected(proposal.id, 'deadline_expired')
+      await this.cleanupDipsRule(consumer, proposal)
+      return
+    }
+
+    const allocation = activeAllocations.find(
+      (a) => a.subgraphDeployment.id.bytes32 === proposal.subgraphDeploymentId.bytes32,
+    )
+
+    if (allocation) {
+      await this.acceptWithExistingAllocation(consumer, proposal, allocation)
+    } else {
+      await this.acceptWithNewAllocation(consumer, proposal, activeAllocations)
+    }
+  }
+
+  private async acceptWithExistingAllocation(
+    consumer: PendingRcaConsumer,
+    proposal: DecodedRcaProposal,
+    allocation: Allocation,
+  ): Promise<void> {
+    this.logger.info('Accepting proposal with existing allocation', {
+      proposalId: proposal.id,
+      allocationId: allocation.id,
+      deployment: proposal.subgraphDeploymentId.ipfsHash,
+    })
+
+    try {
+      const receipt = await this.network.transactionManager.executeTransaction(
+        async () =>
+          this.network.contracts.SubgraphService.acceptIndexingAgreement.estimateGas(
+            allocation.id,
+            proposal.signedRca,
+          ),
+        async (gasLimit) =>
+          this.network.contracts.SubgraphService.acceptIndexingAgreement(
+            allocation.id,
+            proposal.signedRca,
+            { gasLimit },
+          ),
+        this.logger.child({
+          function: 'SubgraphService.acceptIndexingAgreement',
+          proposalId: proposal.id,
+        }),
+      )
+
+      if (receipt === 'paused' || receipt === 'unauthorized') {
+        this.logger.warn(
+          'Skipping proposal acceptance: network is paused or unauthorized',
+          { proposalId: proposal.id, status: receipt },
+        )
+        return
+      }
+
+      await consumer.markAccepted(proposal.id)
+      this.logger.info('Proposal accepted on-chain', {
+        proposalId: proposal.id,
+        allocationId: allocation.id,
+        txHash: receipt.hash,
+      })
+    } catch (error) {
+      await this.handleAcceptError(consumer, proposal, error)
+    }
+  }
+
+  private async acceptWithNewAllocation(
+    consumer: PendingRcaConsumer,
+    proposal: DecodedRcaProposal,
+    activeAllocations: Allocation[],
+  ): Promise<void> {
+    this.logger.info('Accepting proposal with new allocation (multicall)', {
+      proposalId: proposal.id,
+      deployment: proposal.subgraphDeploymentId.ipfsHash,
+    })
+
+    try {
+      const currentEpoch = await this.network.contracts.EpochManager.currentEpoch()
+
+      // Include both active and on-chain (closed) allocation IDs to avoid collisions
+      const excludeIds = activeAllocations.map((a) => a.id)
+      let allocationSigner: Signer | undefined
+      let allocationId: Address | undefined
+
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const result = uniqueAllocationID(
+          this.network.transactionManager.wallet.mnemonic!.phrase,
+          Number(currentEpoch),
+          proposal.subgraphDeploymentId,
+          excludeIds,
+        )
+
+        // Verify allocation doesn't already exist on-chain (e.g. closed allocations)
+        const onchainAllocation =
+          await this.network.contracts.SubgraphService.getAllocation(result.allocationId)
+        if (onchainAllocation.createdAt === 0n) {
+          allocationSigner = result.allocationSigner
+          allocationId = result.allocationId
+          break
+        }
+
+        this.logger.debug(
+          'Generated allocation ID already exists on-chain, trying next',
+          {
+            proposalId: proposal.id,
+            allocationId: result.allocationId,
+            attempt,
+          },
+        )
+        excludeIds.push(result.allocationId)
+      }
+
+      if (!allocationSigner || !allocationId) {
+        this.logger.warn('Could not generate unique allocation ID after 10 attempts', {
+          proposalId: proposal.id,
+        })
+        return
+      }
+
+      // Generate allocation proof
+      const chainId = Number(this.network.specification.networkIdentifier.split(':')[1])
+      const proof = await horizonAllocationIdProof(
+        allocationSigner,
+        chainId,
+        this.network.specification.indexerOptions.address,
+        allocationId,
+        this.network.contracts.SubgraphService.target.toString(),
+      )
+
+      // Build startService calldata
+      const { amount, isDenied } = await this.getDipsAllocationAmount(
+        proposal.subgraphDeploymentId,
+      )
+      this.logger.info('Determined allocation amount for DIPS agreement', {
+        proposalId: proposal.id,
+        deployment: proposal.subgraphDeploymentId.ipfsHash,
+        amount: amount.toString(),
+        isDenied,
+      })
+      const encodedStartData = encodeStartServiceData(
+        proposal.subgraphDeploymentId.bytes32,
+        amount,
+        allocationId,
+        proof,
+      )
+      const startServiceTx =
+        await this.network.contracts.SubgraphService.startService.populateTransaction(
+          this.network.specification.indexerOptions.address,
+          encodedStartData,
+        )
+
+      // Build acceptIndexingAgreement calldata
+      const acceptTx =
+        await this.network.contracts.SubgraphService.acceptIndexingAgreement.populateTransaction(
+          allocationId,
+          proposal.signedRca,
+        )
+
+      // Atomic multicall
+      const calldata = [startServiceTx.data!, acceptTx.data!]
+      const receipt = await this.network.transactionManager.executeTransaction(
+        async () =>
+          this.network.contracts.SubgraphService.multicall.estimateGas(calldata),
+        async (gasLimit) =>
+          this.network.contracts.SubgraphService.multicall(calldata, { gasLimit }),
+        this.logger.child({
+          function: 'SubgraphService.multicall(startService+acceptIndexingAgreement)',
+          proposalId: proposal.id,
+        }),
+      )
+
+      if (receipt === 'paused' || receipt === 'unauthorized') {
+        this.logger.warn(
+          'Skipping proposal acceptance: network is paused or unauthorized',
+          { proposalId: proposal.id, status: receipt },
+        )
+        return
+      }
+
+      await consumer.markAccepted(proposal.id)
+      this.logger.info('Proposal accepted on-chain with new allocation', {
+        proposalId: proposal.id,
+        allocationId,
+        txHash: receipt.hash,
+      })
+    } catch (error) {
+      await this.handleAcceptError(consumer, proposal, error)
+    }
+  }
+
+  private async handleAcceptError(
+    consumer: PendingRcaConsumer,
+    proposal: DecodedRcaProposal,
+    error: unknown,
+  ): Promise<void> {
+    if (this.isDeterministicError(error)) {
+      const parsedError = tryParseCustomError(error)
+      this.logger.warn('Rejecting proposal: deterministic contract error', {
+        proposalId: proposal.id,
+        error: parsedError,
+      })
+      await consumer.markRejected(proposal.id, String(parsedError))
+      await this.cleanupDipsRule(consumer, proposal)
+    } else {
+      this.logger.warn('Transient error accepting proposal, will retry', {
+        proposalId: proposal.id,
+        error,
+      })
+    }
+  }
+
+  private isDeterministicError(error: unknown): boolean {
+    const typedError = error as { code?: string }
+    return typedError?.code === 'CALL_EXCEPTION'
+  }
+
+  private async cleanupDipsRule(
+    consumer: PendingRcaConsumer,
+    proposal: DecodedRcaProposal,
+  ): Promise<void> {
+    const otherProposalsForDeployment = await consumer.getPendingProposalsForDeployment(
+      proposal.subgraphDeploymentId.bytes32,
+    )
+
+    if (otherProposalsForDeployment.length === 0) {
+      const rule = await this.models.IndexingRule.findOne({
+        where: {
+          identifier: proposal.subgraphDeploymentId.ipfsHash,
+          identifierType: SubgraphIdentifierType.DEPLOYMENT,
+          decisionBasis: IndexingDecisionBasis.DIPS,
+        },
+      })
+      if (rule) {
+        await this.models.IndexingRule.destroy({ where: { id: rule.id } })
+        this.logger.info('Removed DIPS indexing rule after rejection', {
+          proposalId: proposal.id,
+          deployment: proposal.subgraphDeploymentId.ipfsHash,
+        })
       }
     }
   }

--- a/packages/indexer-common/src/indexing-fees/index.ts
+++ b/packages/indexer-common/src/indexing-fees/index.ts
@@ -1,1 +1,3 @@
 export * from './dips'
+export * from './types'
+export * from './pending-rca-consumer'

--- a/packages/indexer-common/src/indexing-fees/pending-rca-consumer.ts
+++ b/packages/indexer-common/src/indexing-fees/pending-rca-consumer.ts
@@ -31,6 +31,13 @@ export class PendingRcaConsumer {
     return decoded
   }
 
+  async getPendingProposalsForDeployment(
+    deploymentBytes32: string,
+  ): Promise<DecodedRcaProposal[]> {
+    const all = await this.getPendingProposals()
+    return all.filter((p) => p.subgraphDeploymentId.bytes32 === deploymentBytes32)
+  }
+
   async markAccepted(id: string): Promise<void> {
     await this.model.update({ status: 'accepted' }, { where: { id } })
   }

--- a/packages/indexer-common/src/indexing-fees/pending-rca-consumer.ts
+++ b/packages/indexer-common/src/indexing-fees/pending-rca-consumer.ts
@@ -1,0 +1,76 @@
+import { Logger, SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import {
+  decodeSignedRCA,
+  decodeAcceptIndexingAgreementMetadata,
+  decodeIndexingAgreementTermsV1,
+} from '@graphprotocol/toolshed'
+import { PendingRcaProposal } from '../indexer-management/models/pending-rca-proposal'
+import { DecodedRcaProposal } from './types'
+
+export class PendingRcaConsumer {
+  constructor(
+    private logger: Logger,
+    private model: typeof PendingRcaProposal,
+  ) {}
+
+  async getPendingProposals(): Promise<DecodedRcaProposal[]> {
+    const rows = await this.model.findAll({
+      where: { status: 'pending' },
+    })
+
+    const decoded: DecodedRcaProposal[] = []
+    for (const row of rows) {
+      try {
+        decoded.push(this.decodeRow(row))
+      } catch (error) {
+        this.logger.warn(`Failed to decode pending RCA proposal ${row.id}, skipping`, {
+          error,
+        })
+      }
+    }
+    return decoded
+  }
+
+  async markAccepted(id: string): Promise<void> {
+    await this.model.update({ status: 'accepted' }, { where: { id } })
+  }
+
+  async markRejected(id: string, reason?: string): Promise<void> {
+    await this.model.update({ status: 'rejected' }, { where: { id } })
+    if (reason) {
+      this.logger.info(`Rejected proposal ${id}: ${reason}`)
+    }
+  }
+
+  private decodeRow(row: PendingRcaProposal): DecodedRcaProposal {
+    const signedPayload = new Uint8Array(row.signed_payload)
+    const signedRca = decodeSignedRCA(signedPayload)
+    const { rca } = signedRca
+
+    const metadata = decodeAcceptIndexingAgreementMetadata(rca.metadata)
+    const terms = decodeIndexingAgreementTermsV1(metadata.terms)
+
+    return {
+      id: row.id,
+      status: row.status,
+      createdAt: row.created_at,
+
+      signedRca,
+      signedPayload,
+      payer: rca.payer,
+      serviceProvider: rca.serviceProvider,
+      dataService: rca.dataService,
+      deadline: rca.deadline,
+      endsAt: rca.endsAt,
+      maxInitialTokens: rca.maxInitialTokens,
+      maxOngoingTokensPerSecond: rca.maxOngoingTokensPerSecond,
+      minSecondsPerCollection: rca.minSecondsPerCollection,
+      maxSecondsPerCollection: rca.maxSecondsPerCollection,
+      nonce: rca.nonce,
+
+      subgraphDeploymentId: new SubgraphDeploymentID(metadata.subgraphDeploymentId),
+      tokensPerSecond: terms.tokensPerSecond,
+      tokensPerEntityPerSecond: terms.tokensPerEntityPerSecond,
+    }
+  }
+}

--- a/packages/indexer-common/src/indexing-fees/types.ts
+++ b/packages/indexer-common/src/indexing-fees/types.ts
@@ -1,0 +1,28 @@
+import { SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { SignedRCA } from '@graphprotocol/toolshed'
+
+export interface DecodedRcaProposal {
+  // From DB row
+  id: string
+  status: string
+  createdAt: Date
+
+  // Decoded from signed_payload (via toolshed)
+  signedRca: SignedRCA
+  signedPayload: Uint8Array
+  payer: string
+  serviceProvider: string
+  dataService: string
+  deadline: bigint
+  endsAt: bigint
+  maxInitialTokens: bigint
+  maxOngoingTokensPerSecond: bigint
+  minSecondsPerCollection: bigint
+  maxSecondsPerCollection: bigint
+  nonce: bigint
+
+  // Decoded from metadata (via toolshed)
+  subgraphDeploymentId: SubgraphDeploymentID
+  tokensPerSecond: bigint
+  tokensPerEntityPerSecond: bigint
+}

--- a/packages/indexer-common/src/network-specification.ts
+++ b/packages/indexer-common/src/network-specification.ts
@@ -74,7 +74,7 @@ export const IndexerOptions = z
     legacyMnemonics: z.array(z.string()).default([]),
     enableDips: z.boolean().default(false),
     dipperEndpoint: z.string().url().optional(),
-    dipsAllocationAmount: GRT().default(1),
+    dipsAllocationAmount: GRT().default(0),
     dipsEpochsMargin: positiveNumber().default(1),
   })
   .strict()


### PR DESCRIPTION
Add PendingRcaConsumer to read pending RCA proposals from the shared pending_rca_proposals table (populated by indexer-rs), decode SignedRCA bytes via toolshed, and feed decoded proposals into the agent's reconciliation loop for indexing rule creation.

- Sequelize model (read-only, defined after sync to avoid schema ownership)
- PendingRcaConsumer class with getPendingProposals/markAccepted/markRejected
- DecodedRcaProposal interface with all decoded fields
- ensureAgreementRules branches between new RCA path and legacy fallback
- Migration 23 creates pending_rca_proposals table with IF NOT EXISTS guard
- Threading: start.ts -> client.ts -> actions.ts -> allocations.ts -> dips.ts
- Unit tests with real ABI encode/decode round-trips