### PR TITLE
feat: on-chain acceptance fixes for DIPs recurring agreements

### DIFF
--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -717,9 +717,8 @@ export class Agent {
                 throw new Error('DipsManager is not available')
               }
 
-              await operator.dipsManager.acceptPendingProposals(
-                activeAllocations,
-              )
+              // Proposal acceptance is handled by the dedicated fast loop
+              // (startProposalAcceptanceLoop), not the reconciliation cycle.
 
               this.logger.debug(
                 `Matching agreement allocations for network ${network.specification.networkIdentifier}`,

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -178,6 +178,7 @@ export class AllocationManager {
         this,
         this.pendingRcaModel,
       )
+      this.dipsManager.startProposalAcceptanceLoop()
     }
   }
 

--- a/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
@@ -43,6 +43,7 @@ function createMockProposal(
         maxOngoingTokensPerSecond: 100n,
         minSecondsPerCollection: 3600n,
         maxSecondsPerCollection: 86400n,
+        conditions: 0n,
         nonce: 42n,
         metadata: '0x',
       },

--- a/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
@@ -4,9 +4,12 @@ import { PendingRcaConsumer } from '../pending-rca-consumer'
 import { DecodedRcaProposal } from '../types'
 import {
   Allocation,
+  AllocationManager,
   AllocationStatus,
   IndexerManagementModels,
+  IndexingDecisionBasis,
   Network,
+  SubgraphIdentifierType,
 } from '@graphprotocol/indexer-common'
 
 let logger: Logger
@@ -108,8 +111,15 @@ function createMockModels() {
       findOne: jest.fn().mockResolvedValue(null),
       findAll: jest.fn().mockResolvedValue([]),
       destroy: jest.fn().mockResolvedValue(1),
+      upsert: jest.fn().mockResolvedValue([{ id: 1 }, true]),
     },
   } as unknown as IndexerManagementModels
+}
+
+function createMockParent() {
+  return {
+    matchingRuleExists: jest.fn().mockResolvedValue(false),
+  } as unknown as AllocationManager
 }
 
 function createMockNetwork() {
@@ -168,9 +178,10 @@ function createDipsManager(
   network: Network,
   models: IndexerManagementModels,
   consumer: PendingRcaConsumer,
+  parent: AllocationManager = createMockParent(),
 ): DipsManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const dm = new DipsManager(logger, models, network, {} as any, null)
+  const dm = new DipsManager(logger, models, network, {} as any, parent)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(dm as any).pendingRcaConsumer = consumer
   return dm
@@ -590,6 +601,84 @@ describe('DipsManager.acceptPendingProposals', () => {
 
       await dm.acceptPendingProposals([])
 
+      expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
+    })
+  })
+
+  describe('rule creation ordering (race condition fix)', () => {
+    test('upserts the DIPS indexing rule before broadcasting acceptIndexingAgreement', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue({
+        hash: '0xtx',
+        status: 1,
+      })
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      const upsertOrder = (models.IndexingRule.upsert as jest.Mock).mock
+        .invocationCallOrder[0]
+      const executeOrder = (network.transactionManager.executeTransaction as jest.Mock)
+        .mock.invocationCallOrder[0]
+
+      expect(upsertOrder).toBeDefined()
+      expect(executeOrder).toBeDefined()
+      expect(upsertOrder).toBeLessThan(executeOrder)
+    })
+
+    test('skips rule upsert and rejects proposal when deployment is blocklisted', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      ;(consumer.getPendingProposalsForDeployment as jest.Mock).mockResolvedValue([])
+      const models = createMockModels()
+      ;(models.IndexingRule.findAll as jest.Mock).mockResolvedValue([
+        {
+          identifier: proposal.subgraphDeploymentId.ipfsHash,
+          identifierType: SubgraphIdentifierType.DEPLOYMENT,
+          decisionBasis: IndexingDecisionBasis.NEVER,
+        },
+      ])
+      const network = createMockNetwork()
+
+      const dm = createDipsManager(network, models, consumer)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(consumer.markRejected).toHaveBeenCalledWith(
+        proposal.id,
+        'deployment blocklisted',
+      )
+      expect(models.IndexingRule.upsert).not.toHaveBeenCalled()
+      expect(network.transactionManager.executeTransaction).not.toHaveBeenCalled()
+    })
+
+    test('skips rule upsert when parent reports a matching rule already exists', async () => {
+      const proposal = createMockProposal()
+      const allocation = createMockAllocation()
+      const consumer = createMockConsumer([proposal])
+      const models = createMockModels()
+      const network = createMockNetwork()
+      ;(network.transactionManager.executeTransaction as jest.Mock).mockResolvedValue({
+        hash: '0xtx',
+        status: 1,
+      })
+
+      const parent = {
+        matchingRuleExists: jest.fn().mockResolvedValue(true),
+      } as unknown as AllocationManager
+
+      const dm = createDipsManager(network, models, consumer, parent)
+
+      await dm.acceptPendingProposals([allocation])
+
+      expect(models.IndexingRule.upsert).not.toHaveBeenCalled()
+      expect(network.transactionManager.executeTransaction).toHaveBeenCalled()
       expect(consumer.markAccepted).toHaveBeenCalledWith(proposal.id)
     })
   })

--- a/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
@@ -5,7 +5,7 @@ import { PendingRcaProposal } from '../../indexer-management/models/pending-rca-
 
 // ABI tuple types matching toolshed's recurring-collector.js
 const RCA_TUPLE =
-  'tuple(uint64 deadline, uint64 endsAt, address payer, address dataService, address serviceProvider, uint256 maxInitialTokens, uint256 maxOngoingTokensPerSecond, uint32 minSecondsPerCollection, uint32 maxSecondsPerCollection, uint256 nonce, bytes metadata)'
+  'tuple(uint64 deadline, uint64 endsAt, address payer, address dataService, address serviceProvider, uint256 maxInitialTokens, uint256 maxOngoingTokensPerSecond, uint32 minSecondsPerCollection, uint32 maxSecondsPerCollection, uint16 conditions, uint256 nonce, bytes metadata)'
 const SIGNED_RCA_TUPLE = `tuple(${RCA_TUPLE} rca, bytes signature)`
 const ACCEPT_METADATA_TUPLE =
   'tuple(bytes32 subgraphDeploymentId, uint8 version, bytes terms)'
@@ -62,6 +62,7 @@ function encodeTestPayload(overrides?: {
           maxOngoingTokensPerSecond: 100n,
           minSecondsPerCollection: overrides?.minSecondsPerCollection ?? 3600,
           maxSecondsPerCollection: overrides?.maxSecondsPerCollection ?? 86400,
+          conditions: 0n,
           nonce: 42n,
           metadata: metadataEncoded,
         },

--- a/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
@@ -42,7 +42,7 @@ function encodeTestPayload(overrides?: {
     [
       {
         subgraphDeploymentId: TEST_DEPLOYMENT_BYTES32,
-        version: 1n,
+        version: 0n,
         terms: termsEncoded,
       },
     ],

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -9,6 +9,7 @@ import {
   ActionStatus,
   Allocation,
   AllocationManager,
+  AllocationStatus,
   DipsReceiptStatus,
   GraphNode,
   IndexerManagementModels,
@@ -45,6 +46,7 @@ import {
 import { CollectionTracker } from './collection-tracker'
 
 const DIPS_COLLECTION_INTERVAL = 60_000
+const DIPS_ACCEPTANCE_INTERVAL = 5_000
 
 const uuidToHex = (uuid: string) => {
   return `0x${uuid.replace(/-/g, '')}`
@@ -745,9 +747,20 @@ export class DipsManager {
   ): Promise<void> {
     if (this.isDeterministicError(error)) {
       const parsedError = tryParseCustomError(error)
+      const callException = error as {
+        reason?: string
+        data?: string
+        message?: string
+        transaction?: { to?: string; data?: string }
+      }
       this.logger.warn('Rejecting proposal: deterministic contract error', {
         proposalId: proposal.id,
+        deployment: proposal.subgraphDeploymentId.ipfsHash,
         error: parsedError,
+        revertReason: callException.reason ?? null,
+        revertData: callException.data ?? null,
+        errorMessage: callException.message ?? null,
+        contractTarget: callException.transaction?.to ?? null,
       })
       await consumer.markRejected(proposal.id, String(parsedError))
       await this.cleanupDipsRule(consumer, proposal)
@@ -1015,6 +1028,51 @@ export class DipsManager {
         )
       }
     }
+  }
+
+  startProposalAcceptanceLoop() {
+    if (!this.pendingRcaConsumer) {
+      this.logger.debug('No pending RCA consumer configured, skipping acceptance loop')
+      return
+    }
+    const consumer = this.pendingRcaConsumer
+
+    sequentialTimerMap(
+      {
+        logger: this.logger,
+        milliseconds: DIPS_ACCEPTANCE_INTERVAL,
+      },
+      async () => {
+        const proposals = await consumer.getPendingProposals()
+        if (proposals.length === 0) {
+          return
+        }
+
+        this.logger.info('Processing pending RCA proposals for on-chain acceptance', {
+          count: proposals.length,
+        })
+
+        const activeAllocations = await this.network.networkMonitor.allocations(
+          AllocationStatus.ACTIVE,
+        )
+
+        for (const proposal of proposals) {
+          try {
+            await this.processProposal(consumer, proposal, activeAllocations)
+          } catch (error) {
+            this.logger.error('Unexpected error processing proposal', {
+              proposalId: proposal.id,
+              error,
+            })
+          }
+        }
+      },
+      {
+        onError: (err) => {
+          this.logger.error('Failed to process pending RCA proposals', { err })
+        },
+      },
+    )
   }
 }
 

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -326,12 +326,14 @@ export class DipsManager {
         async () =>
           this.network.contracts.SubgraphService.acceptIndexingAgreement.estimateGas(
             allocation.id,
-            proposal.signedRca,
+            proposal.signedRca.rca,
+            proposal.signedRca.signature,
           ),
         async (gasLimit) =>
           this.network.contracts.SubgraphService.acceptIndexingAgreement(
             allocation.id,
-            proposal.signedRca,
+            proposal.signedRca.rca,
+            proposal.signedRca.signature,
             { gasLimit },
           ),
         this.logger.child({
@@ -448,7 +450,8 @@ export class DipsManager {
       const acceptTx =
         await this.network.contracts.SubgraphService.acceptIndexingAgreement.populateTransaction(
           allocationId,
-          proposal.signedRca,
+          proposal.signedRca.rca,
+          proposal.signedRca.signature,
         )
 
       // Atomic multicall

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -199,59 +199,70 @@ export class DipsManager {
     )
 
     for (const proposal of proposals) {
-      const subgraphDeploymentID = proposal.subgraphDeploymentId
+      await this.ensureDipsRuleForProposal(proposal)
+    }
+  }
+
+  private async ensureDipsRuleForProposal(
+    proposal: DecodedRcaProposal,
+  ): Promise<boolean> {
+    const subgraphDeploymentID = proposal.subgraphDeploymentId
+    this.logger.info(
+      `Checking if indexing rule exists for proposal ${
+        proposal.id
+      }, deployment ${subgraphDeploymentID.toString()}`,
+    )
+
+    const ruleExists = await this.parent!.matchingRuleExists(
+      this.logger,
+      subgraphDeploymentID,
+    )
+
+    const allDeploymentRules = await this.models.IndexingRule.findAll({
+      where: {
+        identifierType: SubgraphIdentifierType.DEPLOYMENT,
+      },
+    })
+    const blocklistedRule = allDeploymentRules.find(
+      (rule) =>
+        new SubgraphDeploymentID(rule.identifier).bytes32 ===
+          subgraphDeploymentID.bytes32 &&
+        rule.decisionBasis === IndexingDecisionBasis.NEVER,
+    )
+
+    if (blocklistedRule) {
       this.logger.info(
-        `Checking if indexing rule exists for proposal ${
+        `Blocklisted deployment ${subgraphDeploymentID.toString()}, rejecting proposal`,
+      )
+      await this.pendingRcaConsumer!.markRejected(proposal.id, 'deployment blocklisted')
+      return false
+    }
+
+    if (!ruleExists) {
+      this.logger.info(
+        `Creating indexing rule for proposal ${
           proposal.id
         }, deployment ${subgraphDeploymentID.toString()}`,
       )
+      const { amount } = await this.getDipsAllocationAmount(subgraphDeploymentID)
+      const indexingRule = {
+        identifier: subgraphDeploymentID.ipfsHash,
+        allocationAmount: formatGRT(amount),
+        identifierType: SubgraphIdentifierType.DEPLOYMENT,
+        decisionBasis: IndexingDecisionBasis.DIPS,
+        protocolNetwork: this.network.specification.networkIdentifier,
+        autoRenewal: true,
+        allocationLifetime: Math.max(
+          Number(proposal.minSecondsPerCollection),
+          Number(proposal.maxSecondsPerCollection),
+        ),
+        requireSupported: false,
+      } as Partial<IndexingRuleAttributes>
 
-      const ruleExists = await this.parent!.matchingRuleExists(
-        this.logger,
-        subgraphDeploymentID,
-      )
-
-      const allDeploymentRules = await this.models.IndexingRule.findAll({
-        where: {
-          identifierType: SubgraphIdentifierType.DEPLOYMENT,
-        },
-      })
-      const blocklistedRule = allDeploymentRules.find(
-        (rule) =>
-          new SubgraphDeploymentID(rule.identifier).bytes32 ===
-            subgraphDeploymentID.bytes32 &&
-          rule.decisionBasis === IndexingDecisionBasis.NEVER,
-      )
-
-      if (blocklistedRule) {
-        this.logger.info(
-          `Blocklisted deployment ${subgraphDeploymentID.toString()}, rejecting proposal`,
-        )
-        await this.pendingRcaConsumer!.markRejected(proposal.id, 'deployment blocklisted')
-      } else if (!ruleExists) {
-        this.logger.info(
-          `Creating indexing rule for proposal ${
-            proposal.id
-          }, deployment ${subgraphDeploymentID.toString()}`,
-        )
-        const { amount } = await this.getDipsAllocationAmount(subgraphDeploymentID)
-        const indexingRule = {
-          identifier: subgraphDeploymentID.ipfsHash,
-          allocationAmount: formatGRT(amount),
-          identifierType: SubgraphIdentifierType.DEPLOYMENT,
-          decisionBasis: IndexingDecisionBasis.DIPS,
-          protocolNetwork: this.network.specification.networkIdentifier,
-          autoRenewal: true,
-          allocationLifetime: Math.max(
-            Number(proposal.minSecondsPerCollection),
-            Number(proposal.maxSecondsPerCollection),
-          ),
-          requireSupported: false,
-        } as Partial<IndexingRuleAttributes>
-
-        await upsertIndexingRule(this.logger, this.models, indexingRule)
-      }
+      await upsertIndexingRule(this.logger, this.models, indexingRule)
     }
+
+    return true
   }
 
   async acceptPendingProposals(activeAllocations: Allocation[]): Promise<void> {
@@ -296,6 +307,15 @@ export class DipsManager {
       })
       await consumer.markRejected(proposal.id, 'deadline_expired')
       await this.cleanupDipsRule(consumer, proposal)
+      return
+    }
+
+    // Create the dips rule eagerly here rather than leaving it to the reconcile
+    // loop: the accept tx can confirm and clear the pending row before the next
+    // reconcile tick, which would leave the rule uncreated and graph-node never
+    // told to deploy the subgraph.
+    const shouldProceed = await this.ensureDipsRuleForProposal(proposal)
+    if (!shouldProceed) {
       return
     }
 


### PR DESCRIPTION
## Motivation

The indexer-agent's DIPs on-chain acceptance path had four issues preventing agreements from being accepted on-chain. These were discovered during local end-to-end testing of the full DIPs pipeline (dipper -> IISA -> proposal -> indexer-service -> agent -> SubgraphService contract).

## Summary

**1. Wrong contract in getRewards call**

`AllocationManager.stakeUsageSummary()` called `RewardsManager.getRewards(HorizonStaking, allocationId)` but `HorizonStaking` is not a registered rewards issuer -- `SubgraphService` is. Every allocation operation (including DIPs acceptance) reverted with "Not a rewards issuer".

**2. Acceptance latency exceeded RCA deadline**

Proposal acceptance was tied to the agent's 120s reconciliation loop, requiring 2+ cycles (240s+) before attempting on-chain acceptance. The RCA deadline is 300s, leaving insufficient slack. Added a dedicated `startProposalAcceptanceLoop()` that polls `pending_rca_proposals` every 5 seconds, independent of the reconciliation cycle.

**3. Opaque contract revert errors**

When on-chain acceptance failed, the log showed `error: null` because `tryParseCustomError` couldn't decode unknown custom errors. Added full revert context (reason, data, message, contract target) to the rejection log so the root cause is immediately visible.

**4. Indexing rule race condition**

The 5s acceptance loop added in item 2 above runs on a separate cadence from the agent's ~15s reconciliation tick, which created a race. `processProposal` clears the `pending_rca_proposals` row as soon as the acceptance receipt lands, but the `dips` indexing rule was only upserted by `ensureAgreementRules` on the next reconcile tick by iterating that same table. On fast chains the receipt consistently beats the next reconcile tick, so graph-node never gets told to deploy the subgraph and the agent spins on unallocate attempts for the just-created DIPs allocation.

Extracted the per-proposal rule logic into `ensureDipsRuleForProposal` and call it from `processProposal` before `executeTransaction(acceptIndexingAgreement)` fires. Reconciliation still calls the same helper as defense-in-depth.

Test metadata version updated to `0` to match `IndexingAgreementVersion.V1` (first Solidity enum variant = 0). See companion PRs: edgeandnode/dipper#583, graphprotocol/indexer-rs#983.

Generated with [Claude Code](https://claude.com/claude-code)