### PR TITLE
fix(cli): preserve hex positional args as strings by re-parsing argv

### DIFF
--- a/packages/indexer-cli/package.json
+++ b/packages/indexer-cli/package.json
@@ -39,12 +39,14 @@
     "isomorphic-fetch": "3.0.0",
     "table": "6.7.5",
     "yaml": "1.10.2",
-    "wrap-ansi": "7.0.0"
+    "wrap-ansi": "7.0.0",
+    "yargs-parser": "21.1.1"
   },
   "devDependencies": {
     "@types/isomorphic-fetch": "0.0.36",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/wrap-ansi": "3.0.0",
+    "@types/yargs-parser": "21.0.3",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",
     "eslint": "8.49.0",

--- a/packages/indexer-cli/src/command-helpers.ts
+++ b/packages/indexer-cli/src/command-helpers.ts
@@ -28,6 +28,7 @@
 
 import { table, getBorderCharacters } from 'table'
 import wrapAnsi from 'wrap-ansi'
+import yargsParse from 'yargs-parser'
 
 export enum OutputFormat {
   Table = 'table',
@@ -62,6 +63,27 @@ export const fixParameters = (
   } else {
     return parameters.array
   }
+}
+
+/**
+ * Re-parses process.argv with number parsing disabled to recover positional
+ * arguments as strings. gluegun uses yargs-parser internally and converts hex
+ * strings (e.g. 0x0, 0x...0010) to numbers before our commands see them,
+ * making the conversion irreversible. Re-parsing with 'parse-numbers: false'
+ * and taking the last N positionals (N = parametersArray.length) restores
+ * the original strings, since gluegun strips the subcommand prefix from
+ * parameters.array but our re-parse includes it.
+ */
+export function getRawPositionalArgs(parametersArray: unknown[]): string[] {
+  const raw = yargsParse(process.argv.slice(2), {
+    configuration: { 'parse-numbers': false },
+  })
+  // raw._ includes the full subcommand path (e.g. ['indexer', 'allocations', 'close', ...])
+  // while parameters.array has already had the command path stripped by gluegun.
+  // Taking the last N elements (N = parameters.array.length) removes the command path
+  // and gives us only the user-provided positional arguments.
+  const positionals = raw._ as string[]
+  return positionals.slice(positionals.length - parametersArray.length)
 }
 
 export const formatData = (

--- a/packages/indexer-cli/src/commands/indexer/actions/queue.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/queue.ts
@@ -6,6 +6,7 @@ import { createIndexerManagementClient } from '../../../client'
 import {
   requireProtocolNetworkOption,
   printObjectOrArray,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 import { buildActionInput, queueActions, validateActionType } from '../../../actions'
 import {
@@ -67,7 +68,7 @@ module.exports = {
     }
 
     const [type, targetDeployment, param1, param2, param3, param4, param5, param6] =
-      parameters.array || []
+      getRawPositionalArgs(parameters.array || [])
 
     let actionInputParams: ActionInput
     try {

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -8,6 +8,7 @@ import {
   validatePOI,
   printObjectOrArray,
   extractProtocolNetworkOption,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 
 const HELP = `
@@ -58,7 +59,7 @@ module.exports = {
     }
 
     const [id, unformattedPoi, unformattedBlockNumber, unformattedPublicPOI] =
-      parameters.array || []
+      getRawPositionalArgs(parameters.array || [])
 
     if (id === undefined) {
       spinner.fail(`Missing required argument: 'id'`)

--- a/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/collect.ts
@@ -4,7 +4,10 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { submitCollectReceiptsJob } from '../../../allocations'
-import { extractProtocolNetworkOption } from '../../../command-helpers'
+import {
+  extractProtocolNetworkOption,
+  getRawPositionalArgs,
+} from '../../../command-helpers'
 
 const HELP = `
 ${chalk.bold('graph indexer allocations collect')} [options] <network> <id>
@@ -41,7 +44,7 @@ module.exports = {
       return
     }
 
-    const [id] = parameters.array || []
+    const [id] = getRawPositionalArgs(parameters.array || [])
 
     if (id === undefined) {
       spinner.fail(`Missing required argument: 'id'`)

--- a/packages/indexer-cli/src/commands/indexer/allocations/create.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/create.ts
@@ -8,6 +8,7 @@ import { processIdentifier, SubgraphIdentifierType } from '@graphprotocol/indexe
 import {
   extractProtocolNetworkOption,
   printObjectOrArray,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 
 const HELP = `
@@ -49,7 +50,7 @@ module.exports = {
       return
     }
 
-    const [deploymentID, amount, indexNode] = parameters.array || []
+    const [deploymentID, amount, indexNode] = getRawPositionalArgs(parameters.array || [])
 
     try {
       const protocolNetwork = extractProtocolNetworkOption(parameters.options, true)

--- a/packages/indexer-cli/src/commands/indexer/allocations/present-poi.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/present-poi.ts
@@ -8,6 +8,7 @@ import {
   extractProtocolNetworkOption,
   printObjectOrArray,
   validatePOI,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 
 const HELP = `
@@ -62,7 +63,7 @@ module.exports = {
     }
 
     const [id, unformattedPoi, unformattedBlockNumber, unformattedPublicPOI] =
-      parameters.array || []
+      getRawPositionalArgs(parameters.array || [])
 
     if (id === undefined) {
       spinner.fail(`Missing required argument: 'id'`)

--- a/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/reallocate.ts
@@ -8,6 +8,7 @@ import {
   extractProtocolNetworkOption,
   printObjectOrArray,
   validatePOI,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 
 const HELP = `
@@ -57,8 +58,9 @@ module.exports = {
       return
     }
 
-    // eslint-disable-next-line prefer-const
-    let [id, amount, poi, unformattedBlockNumber, publicPOI] = parameters.array || []
+    const [id, amount, poi, unformattedBlockNumber, publicPOI] = getRawPositionalArgs(
+      parameters.array || [],
+    )
 
     if (id === undefined) {
       spinner.fail(`Missing required argument: 'id'`)

--- a/packages/indexer-cli/src/commands/indexer/allocations/resize.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/resize.ts
@@ -7,6 +7,7 @@ import { resizeAllocation } from '../../../allocations'
 import {
   extractProtocolNetworkOption,
   printObjectOrArray,
+  getRawPositionalArgs,
 } from '../../../command-helpers'
 
 const HELP = `
@@ -54,7 +55,7 @@ module.exports = {
       return
     }
 
-    const [id, amount] = parameters.array || []
+    const [id, amount] = getRawPositionalArgs(parameters.array || [])
 
     if (id === undefined) {
       spinner.fail(`Missing required argument: 'id'`)

--- a/packages/indexer-cli/src/commands/indexer/disputes/get.ts
+++ b/packages/indexer-cli/src/commands/indexer/disputes/get.ts
@@ -4,7 +4,11 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { disputes, printDisputes } from '../../../disputes'
-import { parseOutputFormat, extractProtocolNetworkOption } from '../../../command-helpers'
+import {
+  parseOutputFormat,
+  extractProtocolNetworkOption,
+  getRawPositionalArgs,
+} from '../../../command-helpers'
 
 const HELP = `
 ${chalk.bold(
@@ -26,7 +30,9 @@ module.exports = {
     const { print, parameters } = toolbox
 
     const { h, help, o, output } = parameters.options
-    const [status, minAllocationClosedEpoch] = parameters.array || []
+    const [status, minAllocationClosedEpoch] = getRawPositionalArgs(
+      parameters.array || [],
+    )
     const outputFormat = parseOutputFormat(print, o || output || 'table')
 
     if (help || h) {

--- a/packages/indexer-cli/src/commands/indexer/provision/add.ts
+++ b/packages/indexer-cli/src/commands/indexer/provision/add.ts
@@ -3,7 +3,10 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { extractProtocolNetworkOption } from '../../../command-helpers'
+import {
+  extractProtocolNetworkOption,
+  getRawPositionalArgs,
+} from '../../../command-helpers'
 import gql from 'graphql-tag'
 import { IndexerProvision, printIndexerProvisions } from '../../../provisions'
 
@@ -35,7 +38,7 @@ module.exports = {
       return
     }
 
-    const [amount] = parameters.array || []
+    const [amount] = getRawPositionalArgs(parameters.array || [])
 
     try {
       if (!amount) {

--- a/packages/indexer-cli/src/commands/indexer/provision/thaw.ts
+++ b/packages/indexer-cli/src/commands/indexer/provision/thaw.ts
@@ -3,7 +3,10 @@ import chalk from 'chalk'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
-import { extractProtocolNetworkOption } from '../../../command-helpers'
+import {
+  extractProtocolNetworkOption,
+  getRawPositionalArgs,
+} from '../../../command-helpers'
 import gql from 'graphql-tag'
 import { IndexerProvision, printIndexerProvisions } from '../../../provisions'
 
@@ -35,7 +38,7 @@ module.exports = {
       return
     }
 
-    const [amount] = parameters.array || []
+    const [amount] = getRawPositionalArgs(parameters.array || [])
 
     try {
       if (!amount) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,7 +2852,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/yargs-parser@*":
+"@types/yargs-parser@*", "@types/yargs-parser@21.0.3":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==


### PR DESCRIPTION
Resolves https://github.com/graphprotocol/indexer/issues/1186

### Problem  
gluegun uses yargs-parser internally to parse CLI arguments. yargs-parser converts hex strings to numbers before the command handlers see them.

```
graph-indexer indexer allocations close 0xallocationId "0x0000000000000000000000000000000000000000000000000000000000000010" --network mainnet
[ '0xallocationId', 16 ]
```

This caused two bugs in v0.25.6/7:
 1. Zero POI normalization silently skipped — normalizePOIParams used strict equality (=== '0'), but gluegun delivered integer 0. Since 0 === '0' is false, the normalization was skipped and the raw integer was forwarded to the GraphQL mutation which expects a String.
 2. Non-zero hex POIs corrupted — any hex POI value passed as a CLI arg would be converted to an imprecise float, making it impossible to recover the original 32-byte hex string downstream.

Note: v0.25.4 used loose equality (== '0') which accidentally caught the integer case, but the refactor to normalizePOIParams in v0.25.6 switched to ===, reintroducing the bug.

### What this PR does:

Adds `getRawPositionalArgs()` in `command-helpers.ts` which re-parses `process.argv` with `parse-numbers: false`, bypassing yargs-parser's number coercion.