### PR TITLE
build: add docker-compose.yml and justfile for local image builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  indexer-agent:
+    image: ghcr.io/graphprotocol/indexer-agent:${TAG:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer-agent
+
+  indexer-cli:
+    image: ghcr.io/graphprotocol/indexer-cli:${TAG:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer-cli

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+# Build the indexer-agent and indexer-cli images locally.
+# Defaults to tagging `ghcr.io/graphprotocol/{indexer-agent,indexer-cli}:local`.
+# Override the tag with: `just build-image sha-abc1234`
+build-image tag="local":
+    TAG={{tag}} docker compose build


### PR DESCRIPTION
Adds a root docker-compose.yml that wraps the existing Dockerfile.indexer-agent and Dockerfile.indexer-cli, and a justfile with a build-image recipe so consumers can produce
ghcr.io/graphprotocol/indexer-{agent,cli}:local (or an override tag) with a single command.

This unblocks the local-network integration branch from needing host-absolute INDEXER_AGENT_SOURCE_ROOT overlays: downstream wrappers can consume the locally-built image by tag instead.