### PR TITLE
fix(cli): make POI parameters optional for action queue commands

### DIFF
--- a/packages/indexer-cli/src/__tests__/actions.unit.test.ts
+++ b/packages/indexer-cli/src/__tests__/actions.unit.test.ts
@@ -49,7 +49,7 @@ describe('buildActionInput', () => {
     expect(result.publicPOI).toBe(zeroPOI)
     expect(result.force).toBe(false)
     expect(result.allocationID).toBe('0xallocationId')
-    expect(result.poiBlockNumber).toBeUndefined()
+    expect(result.poiBlockNumber).toBe(0)
   })
 })
 

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -50,14 +50,18 @@ function normalizePOIParams(
   }
 
   let normalizedPublicPoi = publicPOI
-  if (!publicPOI || normalizedPublicPoi === '0' || normalizedPublicPoi === '0x0') {
+  if (
+    publicPOI !== undefined ||
+    normalizedPublicPoi === '0' ||
+    normalizedPublicPoi === '0x0'
+  ) {
     normalizedPublicPoi = zeroPOI
   }
 
-  let poiBlockNumber = 0
-  if (blockNumber !== undefined) {
-    poiBlockNumber = parseInt(blockNumber, 10)
-    if (isNaN(poiBlockNumber)) {
+  let normalizedBlockNumber: number | undefined = 0
+  if (blockNumber !== undefined && blockNumber !== '0') {
+    normalizedBlockNumber = parseInt(blockNumber, 10)
+    if (isNaN(normalizedBlockNumber)) {
       throw new Error(`Invalid block number: ${blockNumber}`)
     }
   }
@@ -65,7 +69,7 @@ function normalizePOIParams(
   return {
     poi: normalizedPoi,
     publicPOI: normalizedPublicPoi,
-    poiBlockNumber: poiBlockNumber,
+    poiBlockNumber: normalizedBlockNumber,
   }
 }
 

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -49,17 +49,18 @@ function normalizePOIParams(
     normalizedPoi = zeroPOI
   }
 
-  let normalizedPublicPoi = publicPOI
+  let normalizedPublicPoi = zeroPOI
   if (
-    publicPOI !== undefined ||
-    normalizedPublicPoi === '0' ||
-    normalizedPublicPoi === '0x0'
+    normalizedPoi !== zeroPOI &&
+    publicPOI !== undefined &&
+    publicPOI !== '0' &&
+    publicPOI !== '0x0'
   ) {
-    normalizedPublicPoi = zeroPOI
+    normalizedPublicPoi = publicPOI
   }
 
   let normalizedBlockNumber: number | undefined = 0
-  if (blockNumber !== undefined && blockNumber !== '0') {
+  if (normalizedPoi !== zeroPOI && blockNumber !== undefined && blockNumber !== '0') {
     normalizedBlockNumber = parseInt(blockNumber, 10)
     if (isNaN(normalizedBlockNumber)) {
       throw new Error(`Invalid block number: ${blockNumber}`)

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -49,22 +49,25 @@ function normalizePOIParams(
     normalizedPoi = zeroPOI
   }
 
-  let normalizedPublicPoi = zeroPOI
-  if (
-    normalizedPoi !== zeroPOI &&
-    publicPOI !== undefined &&
-    publicPOI !== '0' &&
-    publicPOI !== '0x0'
-  ) {
-    normalizedPublicPoi = publicPOI
+  // Normalize publicPOI: convert '0' or '0x0' to zeroPOI
+  let normalizedPublicPoi: string | undefined = publicPOI
+  if (publicPOI === '0' || publicPOI === '0x0') {
+    normalizedPublicPoi = zeroPOI
   }
 
-  let normalizedBlockNumber: number | undefined = 0
-  if (normalizedPoi !== zeroPOI && blockNumber !== undefined && blockNumber !== '0') {
+  // Normalize blockNumber: parse to number if provided
+  let normalizedBlockNumber: number | undefined = undefined
+  if (blockNumber !== undefined) {
     normalizedBlockNumber = parseInt(blockNumber, 10)
     if (isNaN(normalizedBlockNumber)) {
       throw new Error(`Invalid block number: ${blockNumber}`)
     }
+  }
+
+  // When POI is zero, default publicPOI and blockNumber to zero as well
+  if (normalizedPoi === zeroPOI) {
+    normalizedPublicPoi = normalizedPublicPoi ?? zeroPOI
+    normalizedBlockNumber = normalizedBlockNumber ?? 0
   }
 
   return {

--- a/packages/indexer-cli/src/actions.ts
+++ b/packages/indexer-cli/src/actions.ts
@@ -50,11 +50,11 @@ function normalizePOIParams(
   }
 
   let normalizedPublicPoi = publicPOI
-  if (normalizedPublicPoi === '0' || normalizedPublicPoi === '0x0') {
+  if (!publicPOI || normalizedPublicPoi === '0' || normalizedPublicPoi === '0x0') {
     normalizedPublicPoi = zeroPOI
   }
 
-  let poiBlockNumber: number | undefined = undefined
+  let poiBlockNumber = 0
   if (blockNumber !== undefined) {
     poiBlockNumber = parseInt(blockNumber, 10)
     if (isNaN(poiBlockNumber)) {
@@ -65,7 +65,7 @@ function normalizePOIParams(
   return {
     poi: normalizedPoi,
     publicPOI: normalizedPublicPoi,
-    poiBlockNumber,
+    poiBlockNumber: poiBlockNumber,
   }
 }
 

--- a/packages/indexer-common/src/__tests__/actions.test.ts
+++ b/packages/indexer-common/src/__tests__/actions.test.ts
@@ -139,7 +139,7 @@ describe('Action Validation', () => {
 
       expect(isValidActionInput(missingDeploymentID)).toBe(false)
 
-      // With POI provided, must also have publicPOI and poiBlockNumber
+      // With POI provided (publicPOI and poiBlockNumber are optional)
       const withPoiButMissingPublicPOI = {
         ...baseAction,
         type: ActionType.PRESENT_POI,
@@ -149,7 +149,7 @@ describe('Action Validation', () => {
         isLegacy: false,
       }
 
-      expect(isValidActionInput(withPoiButMissingPublicPOI)).toBe(false)
+      expect(isValidActionInput(withPoiButMissingPublicPOI)).toBe(true)
 
       // With all POI fields provided
       const withAllPoiFields = {

--- a/packages/indexer-common/src/__tests__/actions.test.ts
+++ b/packages/indexer-common/src/__tests__/actions.test.ts
@@ -139,8 +139,8 @@ describe('Action Validation', () => {
 
       expect(isValidActionInput(missingDeploymentID)).toBe(false)
 
-      // With POI provided (publicPOI and poiBlockNumber are optional)
-      const withPoiButMissingPublicPOI = {
+      // With non-zero POI provided, publicPOI and poiBlockNumber are required
+      const withNonZeroPoiButMissingPublicPOI = {
         ...baseAction,
         type: ActionType.PRESENT_POI,
         deploymentID: 'Qmtest',
@@ -149,7 +149,19 @@ describe('Action Validation', () => {
         isLegacy: false,
       }
 
-      expect(isValidActionInput(withPoiButMissingPublicPOI)).toBe(true)
+      expect(isValidActionInput(withNonZeroPoiButMissingPublicPOI)).toBe(false)
+
+      // With zero POI, publicPOI and poiBlockNumber are optional
+      const withZeroPoi = {
+        ...baseAction,
+        type: ActionType.PRESENT_POI,
+        deploymentID: 'Qmtest',
+        allocationID: '0x1234567890123456789012345678901234567890',
+        poi: '0x' + '00'.repeat(32),
+        isLegacy: false,
+      }
+
+      expect(isValidActionInput(withZeroPoi)).toBe(true)
 
       // With all POI fields provided
       const withAllPoiFields = {

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -74,11 +74,7 @@ export const isValidActionInput = (
         'deploymentID' in variableToCheck && 'allocationID' in variableToCheck
 
       if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams =
-          hasActionParams &&
-          'poi' in variableToCheck &&
-          'publicPOI' in variableToCheck &&
-          'poiBlockNumber' in variableToCheck
+        hasActionParams = hasActionParams && 'poi' in variableToCheck
       }
       break
     case ActionType.REALLOCATE:
@@ -88,11 +84,7 @@ export const isValidActionInput = (
         'amount' in variableToCheck
 
       if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams =
-          hasActionParams &&
-          'poi' in variableToCheck &&
-          'publicPOI' in variableToCheck &&
-          'poiBlockNumber' in variableToCheck
+        hasActionParams = hasActionParams && 'poi' in variableToCheck
       }
       break
     case ActionType.RESIZE:
@@ -106,11 +98,7 @@ export const isValidActionInput = (
         'deploymentID' in variableToCheck && 'allocationID' in variableToCheck
 
       if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams =
-          hasActionParams &&
-          'poi' in variableToCheck &&
-          'publicPOI' in variableToCheck &&
-          'poiBlockNumber' in variableToCheck
+        hasActionParams = hasActionParams && 'poi' in variableToCheck
       }
       break
   }

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -57,6 +57,26 @@ export interface ActionInput {
   isLegacy: boolean
 }
 
+const ZERO_POI = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+// Validates POI-related fields for non-legacy actions.
+// When POI is zero, publicPOI and poiBlockNumber are optional.
+// When POI is non-zero, all three fields are required.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const hasValidPOIParams = (variableToCheck: any): boolean => {
+  if (variableToCheck.isLegacy || variableToCheck.poi === undefined) {
+    return true
+  }
+  if (variableToCheck.poi === ZERO_POI) {
+    return 'poi' in variableToCheck
+  }
+  return (
+    'poi' in variableToCheck &&
+    'publicPOI' in variableToCheck &&
+    'poiBlockNumber' in variableToCheck
+  )
+}
+
 export const isValidActionInput = (
   /* eslint-disable @typescript-eslint/no-explicit-any */
   variableToCheck: any,
@@ -71,21 +91,16 @@ export const isValidActionInput = (
       break
     case ActionType.UNALLOCATE:
       hasActionParams =
-        'deploymentID' in variableToCheck && 'allocationID' in variableToCheck
-
-      if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams = hasActionParams && 'poi' in variableToCheck
-      }
+        'deploymentID' in variableToCheck &&
+        'allocationID' in variableToCheck &&
+        hasValidPOIParams(variableToCheck)
       break
     case ActionType.REALLOCATE:
       hasActionParams =
         'deploymentID' in variableToCheck &&
         'allocationID' in variableToCheck &&
-        'amount' in variableToCheck
-
-      if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams = hasActionParams && 'poi' in variableToCheck
-      }
+        'amount' in variableToCheck &&
+        hasValidPOIParams(variableToCheck)
       break
     case ActionType.RESIZE:
       hasActionParams =
@@ -95,11 +110,9 @@ export const isValidActionInput = (
       break
     case ActionType.PRESENT_POI:
       hasActionParams =
-        'deploymentID' in variableToCheck && 'allocationID' in variableToCheck
-
-      if (!variableToCheck.isLegacy && variableToCheck.poi !== undefined) {
-        hasActionParams = hasActionParams && 'poi' in variableToCheck
-      }
+        'deploymentID' in variableToCheck &&
+        'allocationID' in variableToCheck &&
+        hasValidPOIParams(variableToCheck)
       break
   }
   return (


### PR DESCRIPTION
## Summary

Make `publicPOI` and `poiBlockNumber` truly optional when queuing UNALLOCATE, REALLOCATE, or PRESENT_POI actions through the indexer CLI. Previously, omitting these positional arguments caused the action to be rejected by the server's `isValidActionInput` check because GraphQL serialization strips `undefined` fields from the payload.

### CLI normalization (`packages/indexer-cli/src/actions.ts`)

- default `publicPOI` to zero-filled bytes when not provided
- default `poiBlockNumber` to `0` when `blockNumber` is not provided
- check `blockNumber` for explicit `undefined` instead of truthiness so `"0"` is parsed correctly

### Server-side validation (`packages/indexer-common/src/actions.ts`)

- relax UNALLOCATE / REALLOCATE / PRESENT_POI validation to only require the `poi` field when a POI is supplied
- treat `publicPOI` and `poiBlockNumber` as optional fields

### Tests

- update CLI normalize test to expect `poiBlockNumber` of `0`
- update server validation test to accept `poi` without `publicPOI`

## Test plan

- [x] CLI unit tests pass for `normalizes zero POI values for PRESENT_POI`
- [x] Server validation tests pass for the relaxed POI input checks
- [x] Manual: `graph indexer actions queue unallocate <deploymentID> <allocationID> 0x0 true --network arbitrum-one` succeeds without specifying a block number
- [x] Manual: same command with an explicit block number argument still works