### PR TITLE
fix(allocations): pass SubgraphService as rewards issuer in Horizon mode

### DIFF
--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -2271,7 +2271,7 @@ export class AllocationManager {
         } else {
           if (isHorizon) {
             rewards = await this.network.contracts.RewardsManager.getRewards(
-              this.network.contracts.HorizonStaking.target,
+              this.network.contracts.SubgraphService.target,
               action.allocationID,
             )
           } else {


### PR DESCRIPTION
The RewardsManager auth check requires the rewards issuer argument to equal subgraphService. Passing HorizonStaking instead triggers "Not a rewards issuer" revert during stakeUsageSummary, which blocks unallocate/reallocate/resize actions from ever being submitted.