### PR TITLE
perf: create index for tap receipts

### DIFF
--- a/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
+++ b/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
@@ -11,6 +11,7 @@ interface Context {
 }
 
 const INDEX_NAME = 'tap_horizon_receipts_collection_id'
+const INDEX_NAME_TEXT = 'tap_horizon_receipts_collection_text_id'
 
 export async function up({ context }: Context): Promise<void> {
   const { queryInterface, logger } = context
@@ -25,6 +26,13 @@ export async function up({ context }: Context): Promise<void> {
     },
   )
   logger.info(`Created index ${INDEX_NAME}`)
+
+  logger.info(`Creating composite index ${INDEX_NAME_TEXT} on tap_horizon_receipts`)
+  await queryInterface.sequelize.query(`
+    CREATE INDEX CONCURRENTLY ${INDEX_NAME_TEXT}
+    ON tap_horizon_receipts (CAST(collection_id AS TEXT), id)
+  `)
+  logger.info(`Created index ${INDEX_NAME_TEXT}`)
 }
 
 export async function down({ context }: Context): Promise<void> {
@@ -32,4 +40,7 @@ export async function down({ context }: Context): Promise<void> {
 
   logger.info(`Dropping index ${INDEX_NAME}`)
   await queryInterface.removeIndex('tap_horizon_receipts', INDEX_NAME)
+
+  logger.info(`Dropping index ${INDEX_NAME_TEXT}`)
+  await queryInterface.removeIndex('tap_horizon_receipts', INDEX_NAME_TEXT)
 }

--- a/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
+++ b/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
@@ -27,7 +27,9 @@ export async function up({ context }: Context): Promise<void> {
   )
   logger.info(`Created index ${INDEX_NAME}`)
 
-  logger.info(`Creating composite index ${INDEX_NAME_TEXT} on tap_horizon_receipts`)
+  logger.info(
+    `Creating composite index ${INDEX_NAME_TEXT} on tap_horizon_receipts`,
+  )
   await queryInterface.sequelize.query(`
     CREATE INDEX CONCURRENTLY ${INDEX_NAME_TEXT}
     ON tap_horizon_receipts (CAST(collection_id AS TEXT), id)

--- a/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
+++ b/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-indexes.ts
@@ -27,6 +27,8 @@ export async function up({ context }: Context): Promise<void> {
   )
   logger.info(`Created index ${INDEX_NAME}`)
 
+  // This index can be removed if the indexer is running indexer-service v2.1.1
+  // TODO: once there is sufficient indexer coverage remove it
   logger.info(
     `Creating composite index ${INDEX_NAME_TEXT} on tap_horizon_receipts`,
   )

--- a/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-receipts-composite-index.ts
+++ b/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-receipts-composite-index.ts
@@ -1,0 +1,42 @@
+import { Logger } from '@graphprotocol/common-ts'
+import { QueryInterface } from 'sequelize'
+
+interface MigrationContext {
+  queryInterface: QueryInterface
+  logger: Logger
+}
+
+interface Context {
+  context: MigrationContext
+}
+
+const INDEX_NAME = 'tap_horizon_receipts_aggregation_idx'
+
+export async function up({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.info(`Creating composite index ${INDEX_NAME} on tap_horizon_receipts`)
+  await queryInterface.addIndex(
+    'tap_horizon_receipts',
+    [
+      'collection_id',
+      'service_provider',
+      'payer',
+      'data_service',
+      'signer_address',
+      'timestamp_ns',
+    ],
+    {
+      name: INDEX_NAME,
+      concurrently: true,
+    },
+  )
+  logger.info(`Created index ${INDEX_NAME}`)
+}
+
+export async function down({ context }: Context): Promise<void> {
+  const { queryInterface, logger } = context
+
+  logger.info(`Dropping index ${INDEX_NAME}`)
+  await queryInterface.removeIndex('tap_horizon_receipts', INDEX_NAME)
+}

--- a/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-receipts-composite-index.ts
+++ b/packages/indexer-agent/src/db/migrations/24-add-tap-horizon-receipts-composite-index.ts
@@ -10,7 +10,7 @@ interface Context {
   context: MigrationContext
 }
 
-const INDEX_NAME = 'tap_horizon_receipts_aggregation_idx'
+const INDEX_NAME = 'tap_horizon_receipts_collection_id'
 
 export async function up({ context }: Context): Promise<void> {
   const { queryInterface, logger } = context
@@ -18,14 +18,7 @@ export async function up({ context }: Context): Promise<void> {
   logger.info(`Creating composite index ${INDEX_NAME} on tap_horizon_receipts`)
   await queryInterface.addIndex(
     'tap_horizon_receipts',
-    [
-      'collection_id',
-      'service_provider',
-      'payer',
-      'data_service',
-      'signer_address',
-      'timestamp_ns',
-    ],
+    ['collection_id', 'id'],
     {
       name: INDEX_NAME,
       concurrently: true,


### PR DESCRIPTION
Add composite indexes on `tap_horizon_receipts` to improve query performance for collection based lookups. Creates `tap_horizon_receipts_collection_id` on `(collection_id, id)` and `tap_horizon_receipts_collection_text_id` on `(CAST(collection_id AS TEXT), id)`.
