### PR TITLE
chore(indexer-common): bump @graphprotocol/toolshed to 1.2.1-dips.1

### DIFF
--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -1,6 +1,7 @@
 name: Indexer Agent Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/indexer-cli-image.yml
+++ b/.github/workflows/indexer-cli-image.yml
@@ -1,6 +1,7 @@
 name: Indexer CLI Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -26,7 +26,7 @@
     "@bufbuild/protobuf": "2.2.3",
     "@graphprotocol/common-ts": "3.0.1",
     "@graphprotocol/dips-proto": "0.3.0",
-    "@graphprotocol/toolshed": "1.2.0-dips.0",
+    "@graphprotocol/toolshed": "1.2.1-dips.1",
     "@grpc/grpc-js": "^1.12.6",
     "@semiotic-labs/tap-contracts-bindings": "2.0.0",
     "@thi.ng/heaps": "1.2.38",

--- a/packages/indexer-common/src/indexing-fees/__tests__/offer-monitor.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/offer-monitor.test.ts
@@ -13,9 +13,7 @@ describe('OfferMonitor', () => {
     const subgraph = { query } as never
     const monitor = new OfferMonitor(logger, subgraph)
 
-    const exists = await monitor.offerExists(
-      'bea99452-e465-e9d9-8a79-2356edcc7e92',
-    )
+    const exists = await monitor.offerExists('bea99452-e465-e9d9-8a79-2356edcc7e92')
 
     expect(exists).toBe(true)
     expect(query).toHaveBeenCalledTimes(1)
@@ -41,23 +39,17 @@ describe('OfferMonitor', () => {
     const subgraph = { query } as never
     const monitor = new OfferMonitor(logger, subgraph)
 
-    const exists = await monitor.offerExists(
-      'bea99452-e465-e9d9-8a79-2356edcc7e92',
-    )
+    const exists = await monitor.offerExists('bea99452-e465-e9d9-8a79-2356edcc7e92')
 
     expect(exists).toBe(false)
   })
 
   it('treats subgraph errors as transient (not yet on-chain)', async () => {
-    const query = jest
-      .fn()
-      .mockResolvedValue({ error: new Error('subgraph hiccup') })
+    const query = jest.fn().mockResolvedValue({ error: new Error('subgraph hiccup') })
     const subgraph = { query } as never
     const monitor = new OfferMonitor(logger, subgraph)
 
-    const exists = await monitor.offerExists(
-      'bea99452-e465-e9d9-8a79-2356edcc7e92',
-    )
+    const exists = await monitor.offerExists('bea99452-e465-e9d9-8a79-2356edcc7e92')
 
     expect(exists).toBe(false)
   })

--- a/packages/indexer-common/src/indexing-fees/__tests__/sweep-allocations.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/sweep-allocations.test.ts
@@ -185,4 +185,3 @@ describe('DipsManager.sweepDipsAllocations', () => {
     expect(destroy).not.toHaveBeenCalled()
   })
 })
-

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -291,14 +291,11 @@ export class DipsManager {
         subgraphDeploymentID,
       )
     } catch (err) {
-      this.logger.warn(
-        'graphNode.ensure failed, leaving proposal pending for retry',
-        {
-          proposalId: proposal.id,
-          deployment: subgraphDeploymentID.toString(),
-          err,
-        },
-      )
+      this.logger.warn('graphNode.ensure failed, leaving proposal pending for retry', {
+        proposalId: proposal.id,
+        deployment: subgraphDeploymentID.toString(),
+        err,
+      })
       return false
     }
 
@@ -1312,8 +1309,7 @@ export class DipsManager {
     if (!this.network.indexingPaymentsSubgraph) {
       return { deployments: new Set(), blockTimestamp: null }
     }
-    const indexer =
-      this.network.specification.indexerOptions.address.toLowerCase()
+    const indexer = this.network.specification.indexerOptions.address.toLowerCase()
     const result = await this.network.indexingPaymentsSubgraph.query(
       gql`
         query selfAgreements($indexer: String!) {
@@ -1322,10 +1318,7 @@ export class DipsManager {
               timestamp
             }
           }
-          indexingAgreements(
-            where: { indexer: $indexer, state: Accepted }
-            first: 1000
-          ) {
+          indexingAgreements(where: { indexer: $indexer, state: Accepted }, first: 1000) {
             id
             subgraphDeploymentId
           }
@@ -1338,9 +1331,8 @@ export class DipsManager {
     }
     const data = result.data ?? {}
     const deployments = new Set<string>(
-      (data.indexingAgreements ?? []).map(
-        (a: { subgraphDeploymentId: string }) =>
-          a.subgraphDeploymentId.toLowerCase(),
+      (data.indexingAgreements ?? []).map((a: { subgraphDeploymentId: string }) =>
+        a.subgraphDeploymentId.toLowerCase(),
       ),
     )
     const blockTimestamp = data._meta?.block?.timestamp ?? null
@@ -1390,15 +1382,12 @@ export class DipsManager {
     const nowSeconds = Math.floor(Date.now() / 1000)
     const lag = nowSeconds - Number(blockTimestamp)
     if (lag > DIPS_SWEEP_STALENESS_THRESHOLD_SECONDS) {
-      logger.warn(
-        'Skipping DIPs allocation sweep: indexing-payments subgraph is stale',
-        {
-          subgraphTimestamp: blockTimestamp,
-          nowSeconds,
-          lagSeconds: lag,
-          thresholdSeconds: DIPS_SWEEP_STALENESS_THRESHOLD_SECONDS,
-        },
-      )
+      logger.warn('Skipping DIPs allocation sweep: indexing-payments subgraph is stale', {
+        subgraphTimestamp: blockTimestamp,
+        nowSeconds,
+        lagSeconds: lag,
+        thresholdSeconds: DIPS_SWEEP_STALENESS_THRESHOLD_SECONDS,
+      })
       return
     }
 

--- a/packages/indexer-common/src/indexing-fees/offer-monitor.ts
+++ b/packages/indexer-common/src/indexing-fees/offer-monitor.ts
@@ -43,18 +43,18 @@ export class OfferMonitor {
         id: toBytes16Id(agreementId),
       })
       if (result.error) {
-        this.logger.debug(
-          'Offer existence check failed (will retry on next tick)',
-          { agreementId, err: result.error },
-        )
+        this.logger.debug('Offer existence check failed (will retry on next tick)', {
+          agreementId,
+          err: result.error,
+        })
         return false
       }
       return Boolean(result.data?.offer)
     } catch (err) {
-      this.logger.debug(
-        'Offer existence check threw (will retry on next tick)',
-        { agreementId, err },
-      )
+      this.logger.debug('Offer existence check threw (will retry on next tick)', {
+        agreementId,
+        err,
+      })
       return false
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@graphprotocol/address-book@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/address-book/-/address-book-1.1.0.tgz#935dc7a58f426e5b838059fbc778fe208b234d78"
-  integrity sha512-38NiutGOWdDIYgB/3kGp/7LxPRCNomipjo1hGlaj6RvyydySooVSmb3A+j84faUso+uhYxt8+9y1EFN7XVnT7Q==
+"@graphprotocol/address-book@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/address-book/-/address-book-1.2.0.tgz#abcd7dd186111ad22ad0dfd9040794930975594b"
+  integrity sha512-eJgZ0b/BSe3tzXRbrIImjh63NfGwZ3BA71TESvDWE6tB84D6PqbZ7/E4cA1VLPQi3ge1DQ8I+LpypjDOjhKp2A==
 
 "@graphprotocol/common-ts@3.0.1":
   version "3.0.1"
@@ -590,10 +590,10 @@
   dependencies:
     "@bufbuild/protobuf" "^2.2.3"
 
-"@graphprotocol/interfaces@^0.7.0-dips.0":
-  version "0.7.0-dips.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/interfaces/-/interfaces-0.7.0-dips.0.tgz#0b325ad8e02051c51418c301b294dbb97110ca39"
-  integrity sha512-H82KvrO5OvFapKJQOkmYY/IPINz3ytwbg6D4G0VevIs01+SP30yE8nlJxLGDifnHC8ETNZN6B3iCz/DpiW77wQ==
+"@graphprotocol/interfaces@^0.7.1-dips.0":
+  version "0.7.1-dips.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/interfaces/-/interfaces-0.7.1-dips.0.tgz#3423652b7b789c258739817308efff017a68336d"
+  integrity sha512-+oufdy5LfXFRj8Sv+N0C9JcfjuY1vOpQ2eqv8/f3v2OzAcGWPA3GoMSZEcPdBETC2uqvpPGIzhJWaD/Rekc65A==
 
 "@graphprotocol/issuance@^1.0.0":
   version "1.0.0"
@@ -612,13 +612,13 @@
     split2 "^3.1.1"
     through2 "^3.0.1"
 
-"@graphprotocol/toolshed@1.2.0-dips.0":
-  version "1.2.0-dips.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.0-dips.0.tgz#b4855b0ceec6370d919c74d8fa56dbd3053b40f4"
-  integrity sha512-QAaZtc0XT2sC/e1T5DTat51FaZiH8UrzVnDS4II/YUsV0zIVjTfCwWvbBLn684FEC9bXfIDVnh7D7tB6vy4tOw==
+"@graphprotocol/toolshed@1.2.1-dips.1":
+  version "1.2.1-dips.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.1-dips.1.tgz#ec4ccac30734ca359d11ee7c9ee1f9cf50e0208d"
+  integrity sha512-Uh78GLIRHVwr8fWlM9J+8QxDCr+BMXa0nTaNx7tEr+m04e+j8sDX0J1QgSVacq0veaq4j8HackqNm0W6kbD7Iw==
   dependencies:
-    "@graphprotocol/address-book" "^1.1.0"
-    "@graphprotocol/interfaces" "^0.7.0-dips.0"
+    "@graphprotocol/address-book" "^1.2.0"
+    "@graphprotocol/interfaces" "^0.7.1-dips.0"
     "@graphprotocol/issuance" "^1.0.0"
     "@nomicfoundation/hardhat-ethers" "^3.1.0"
     debug "^4.4.0"


### PR DESCRIPTION
Picks up the audit-fix-2 RCA ABI surface published from graphprotocol/contracts deployment/testnet-dips/2024-04-28/audit-fix-2:

- toolshed 1.2.0-dips.0 -> 1.2.1-dips.1 (adds recurring-collector decoder helpers and conditions field to RCA tuple)
- interfaces transitively bumps to 0.7.1-dips.0 (3-arg acceptIndexingAgreement, 11-field RecurringCollectionAgreement)
- address-book transitively bumps to 1.2.0

yarn install + yarn prepare verified clean across all three workspace projects.