### PR TITLE
ci: add workflow_dispatch trigger to image workflows

### DIFF
--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -1,6 +1,7 @@
 name: Indexer Agent Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/indexer-cli-image.yml
+++ b/.github/workflows/indexer-cli-image.yml
@@ -1,6 +1,7 @@
 name: Indexer CLI Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Allows on-demand image builds from any branch via gh workflow run, producing :sha-<short> tags for downstream integration testing without widening the push-trigger branches list. Applied to both indexer-agent-image.yml and indexer-cli-image.yml for parity.