### PR TITLE
chore: toolshed 1.2.1-dips.2, multi-arch agent image, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -9,48 +9,111 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  IMAGE: ghcr.io/graphprotocol/indexer-agent
+
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    name: Build (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       packages: write
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: ghcr.io/graphprotocol/indexer-agent
-          tag-sha: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{github.repository_owner}}
-          password: ${{secrets.GITHUB_TOKEN}}
-      - name: Setup python
-        uses: actions/setup-python@v4
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker labels
+        id: meta
+        uses: docker/metadata-action@v6
         with:
-          python-version: '3.11'
-      - name: Set up Node.js v20
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: 20
-      - name: Build and push Indexer Agent image
-        id: docker_build
-        uses: docker/build-push-action@v2
+          images: ${{ env.IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.indexer-agent
-          # Enabling the line below restricts Docker images to only be built for branches
-          # push: ${{github.event_name != 'pull_request'}}
-          push: true
-          tags: ${{steps.docker_meta.outputs.tags}}
-          labels: ${{steps.docker_meta.outputs.labels}}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: NPM_TOKEN=${{secrets.graphprotocol_npm_token}}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge into multi-arch manifest
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=sha
+            type=ref,event=tag
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/indexer-agent-image.yml
+++ b/.github/workflows/indexer-agent-image.yml
@@ -32,11 +32,11 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -44,13 +44,13 @@ jobs:
 
       - name: Docker labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile.indexer-agent
@@ -68,7 +68,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: github.event_name != 'pull_request'
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -79,20 +79,23 @@ jobs:
   merge:
     name: Merge into multi-arch manifest
     needs: build
-    if: github.event_name != 'pull_request'
+    if: |
+      !cancelled()
+      && needs.build.result == 'success'
+      && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -100,13 +103,14 @@ jobs:
 
       - name: Docker tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE }}
           tags: |
             type=sha
             type=ref,event=tag
 
+      # Glob `*` expands to digest-named files written by the build job's Export digest step.
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -26,7 +26,7 @@
     "@bufbuild/protobuf": "2.2.3",
     "@graphprotocol/common-ts": "3.0.1",
     "@graphprotocol/dips-proto": "0.3.0",
-    "@graphprotocol/toolshed": "1.2.1-dips.1",
+    "@graphprotocol/toolshed": "1.2.1-dips.2",
     "@grpc/grpc-js": "^1.12.6",
     "@semiotic-labs/tap-contracts-bindings": "2.0.0",
     "@thi.ng/heaps": "1.2.38",

--- a/packages/indexer-common/package.json
+++ b/packages/indexer-common/package.json
@@ -26,7 +26,7 @@
     "@bufbuild/protobuf": "2.2.3",
     "@graphprotocol/common-ts": "3.0.1",
     "@graphprotocol/dips-proto": "0.3.0",
-    "@graphprotocol/toolshed": "1.2.0-dips.0",
+    "@graphprotocol/toolshed": "1.2.1-dips.1",
     "@grpc/grpc-js": "^1.12.6",
     "@semiotic-labs/tap-contracts-bindings": "2.0.0",
     "@thi.ng/heaps": "1.2.38",

--- a/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/accept-proposals.test.ts
@@ -43,6 +43,7 @@ function createMockProposal(
         maxOngoingTokensPerSecond: 100n,
         minSecondsPerCollection: 3600n,
         maxSecondsPerCollection: 86400n,
+        conditions: 0n,
         nonce: 42n,
         metadata: '0x',
       },

--- a/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
+++ b/packages/indexer-common/src/indexing-fees/__tests__/pending-rca-consumer.test.ts
@@ -5,7 +5,7 @@ import { PendingRcaProposal } from '../../indexer-management/models/pending-rca-
 
 // ABI tuple types matching toolshed's recurring-collector.js
 const RCA_TUPLE =
-  'tuple(uint64 deadline, uint64 endsAt, address payer, address dataService, address serviceProvider, uint256 maxInitialTokens, uint256 maxOngoingTokensPerSecond, uint32 minSecondsPerCollection, uint32 maxSecondsPerCollection, uint256 nonce, bytes metadata)'
+  'tuple(uint64 deadline, uint64 endsAt, address payer, address dataService, address serviceProvider, uint256 maxInitialTokens, uint256 maxOngoingTokensPerSecond, uint32 minSecondsPerCollection, uint32 maxSecondsPerCollection, uint16 conditions, uint256 nonce, bytes metadata)'
 const SIGNED_RCA_TUPLE = `tuple(${RCA_TUPLE} rca, bytes signature)`
 const ACCEPT_METADATA_TUPLE =
   'tuple(bytes32 subgraphDeploymentId, uint8 version, bytes terms)'
@@ -62,6 +62,7 @@ function encodeTestPayload(overrides?: {
           maxOngoingTokensPerSecond: 100n,
           minSecondsPerCollection: overrides?.minSecondsPerCollection ?? 3600,
           maxSecondsPerCollection: overrides?.maxSecondsPerCollection ?? 86400,
+          conditions: 0n,
           nonce: 42n,
           metadata: metadataEncoded,
         },

--- a/packages/indexer-common/src/indexing-fees/dips.ts
+++ b/packages/indexer-common/src/indexing-fees/dips.ts
@@ -407,12 +407,14 @@ export class DipsManager {
         async () =>
           this.network.contracts.SubgraphService.acceptIndexingAgreement.estimateGas(
             allocation.id,
-            proposal.signedRca,
+            proposal.signedRca.rca,
+            proposal.signedRca.signature,
           ),
         async (gasLimit) =>
           this.network.contracts.SubgraphService.acceptIndexingAgreement(
             allocation.id,
-            proposal.signedRca,
+            proposal.signedRca.rca,
+            proposal.signedRca.signature,
             { gasLimit },
           ),
         this.logger.child({
@@ -529,7 +531,8 @@ export class DipsManager {
       const acceptTx =
         await this.network.contracts.SubgraphService.acceptIndexingAgreement.populateTransaction(
           allocationId,
-          proposal.signedRca,
+          proposal.signedRca.rca,
+          proposal.signedRca.signature,
         )
 
       // Atomic multicall

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,10 +612,10 @@
     split2 "^3.1.1"
     through2 "^3.0.1"
 
-"@graphprotocol/toolshed@1.2.1-dips.1":
-  version "1.2.1-dips.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.1-dips.1.tgz#ec4ccac30734ca359d11ee7c9ee1f9cf50e0208d"
-  integrity sha512-Uh78GLIRHVwr8fWlM9J+8QxDCr+BMXa0nTaNx7tEr+m04e+j8sDX0J1QgSVacq0veaq4j8HackqNm0W6kbD7Iw==
+"@graphprotocol/toolshed@1.2.1-dips.2":
+  version "1.2.1-dips.2"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.1-dips.2.tgz#0772e76888141c9235a66dda5204c99ef877e8ca"
+  integrity sha512-LO7SANPH2HLe01M+D60MuYESqxlq7bywzegHpiLqCz94JEI7q/iDG15SUr2Hwr42mreJ+1fD5U03ASQbo5ZpUQ==
   dependencies:
     "@graphprotocol/address-book" "^1.2.0"
     "@graphprotocol/interfaces" "^0.7.1-dips.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@graphprotocol/address-book@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/address-book/-/address-book-1.1.0.tgz#935dc7a58f426e5b838059fbc778fe208b234d78"
-  integrity sha512-38NiutGOWdDIYgB/3kGp/7LxPRCNomipjo1hGlaj6RvyydySooVSmb3A+j84faUso+uhYxt8+9y1EFN7XVnT7Q==
+"@graphprotocol/address-book@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/address-book/-/address-book-1.2.0.tgz#abcd7dd186111ad22ad0dfd9040794930975594b"
+  integrity sha512-eJgZ0b/BSe3tzXRbrIImjh63NfGwZ3BA71TESvDWE6tB84D6PqbZ7/E4cA1VLPQi3ge1DQ8I+LpypjDOjhKp2A==
 
 "@graphprotocol/common-ts@3.0.1":
   version "3.0.1"
@@ -590,10 +590,10 @@
   dependencies:
     "@bufbuild/protobuf" "^2.2.3"
 
-"@graphprotocol/interfaces@^0.7.0-dips.0":
-  version "0.7.0-dips.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/interfaces/-/interfaces-0.7.0-dips.0.tgz#0b325ad8e02051c51418c301b294dbb97110ca39"
-  integrity sha512-H82KvrO5OvFapKJQOkmYY/IPINz3ytwbg6D4G0VevIs01+SP30yE8nlJxLGDifnHC8ETNZN6B3iCz/DpiW77wQ==
+"@graphprotocol/interfaces@^0.7.1-dips.0":
+  version "0.7.1-dips.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/interfaces/-/interfaces-0.7.1-dips.0.tgz#3423652b7b789c258739817308efff017a68336d"
+  integrity sha512-+oufdy5LfXFRj8Sv+N0C9JcfjuY1vOpQ2eqv8/f3v2OzAcGWPA3GoMSZEcPdBETC2uqvpPGIzhJWaD/Rekc65A==
 
 "@graphprotocol/issuance@^1.0.0":
   version "1.0.0"
@@ -612,13 +612,13 @@
     split2 "^3.1.1"
     through2 "^3.0.1"
 
-"@graphprotocol/toolshed@1.2.0-dips.0":
-  version "1.2.0-dips.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.0-dips.0.tgz#b4855b0ceec6370d919c74d8fa56dbd3053b40f4"
-  integrity sha512-QAaZtc0XT2sC/e1T5DTat51FaZiH8UrzVnDS4II/YUsV0zIVjTfCwWvbBLn684FEC9bXfIDVnh7D7tB6vy4tOw==
+"@graphprotocol/toolshed@1.2.1-dips.1":
+  version "1.2.1-dips.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/toolshed/-/toolshed-1.2.1-dips.1.tgz#ec4ccac30734ca359d11ee7c9ee1f9cf50e0208d"
+  integrity sha512-Uh78GLIRHVwr8fWlM9J+8QxDCr+BMXa0nTaNx7tEr+m04e+j8sDX0J1QgSVacq0veaq4j8HackqNm0W6kbD7Iw==
   dependencies:
-    "@graphprotocol/address-book" "^1.1.0"
-    "@graphprotocol/interfaces" "^0.7.0-dips.0"
+    "@graphprotocol/address-book" "^1.2.0"
+    "@graphprotocol/interfaces" "^0.7.1-dips.0"
     "@graphprotocol/issuance" "^1.0.0"
     "@nomicfoundation/hardhat-ethers" "^3.1.0"
     debug "^4.4.0"


### PR DESCRIPTION
Bundles a few small chores ahead of further DIPS work:

- **toolshed bump → 1.2.1-dips.2** (from 1.2.0-dips.0): picks up audit-fix-2 RCA ABI surface from graphprotocol/contracts.
  - dips.1 — `recurring-collector` decoder helpers; `conditions` field on RCA tuple; transitive `interfaces@0.7.1-dips.0` (3-arg `acceptIndexingAgreement`, 11-field `RecurringCollectionAgreement`) and `address-book@1.2.0`. Required adapting `indexer-common` to the new RCA type.
  - dips.2 — RC EIP-712 typestrings + condition bitmask constants. Purely additive.
- **multi-arch indexer-agent image** — build `linux/amd64,linux/arm64` for the published agent image.
- **dependabot** — monthly updates for GitHub Actions.