### PR TITLE
fix: prevent agent creating orphan DIPs allocations

### DIFF
--- a/packages/indexer-agent/src/__tests__/agent.ts
+++ b/packages/indexer-agent/src/__tests__/agent.ts
@@ -444,6 +444,39 @@ describe('reconcileDeploymentAllocationAction', () => {
       network,
     )
   })
+
+  // DipsManager owns DIPS allocation creation; reconcile racing it produces orphan allocations.
+  it('skips createAllocation for DIPS-basis rules with no active allocation', async () => {
+    const agent = createAgent()
+    const operator = createOperator()
+    const network = createNetwork()
+
+    const dipsDecision = new AllocationDecision(
+      deployment,
+      {
+        identifier: deployment.ipfsHash,
+        identifierType: SubgraphIdentifierType.DEPLOYMENT,
+        allocationAmount: '1000',
+        decisionBasis: IndexingDecisionBasis.DIPS,
+      } as IndexingRuleAttributes,
+      true,
+      ActivationCriteria.DIPS,
+      'eip155:42161',
+    )
+
+    await agent.reconcileDeploymentAllocationAction(
+      dipsDecision,
+      [],
+      10,
+      28,
+      network,
+      operator,
+      false,
+    )
+
+    expect(operator.createAllocation).not.toHaveBeenCalled()
+    expect(network.networkMonitor.closedAllocations).not.toHaveBeenCalled()
+  })
 })
 
 describe('addIndexingPaymentsSubgraphToTarget function', () => {

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -1083,6 +1083,14 @@ export class Agent {
                 safety: deploymentAllocationDecision.ruleMatch.rule?.safety,
               },
             )
+          } else if (
+            deploymentAllocationDecision.ruleMatch.rule?.decisionBasis ===
+            IndexingDecisionBasis.DIPS
+          ) {
+            // DipsManager creates DIPS allocations atomically with acceptance; reconcile would race it.
+            logger.debug(
+              'Deferring allocation creation to DipsManager for DIPS-basis deployment',
+            )
           } else {
             // Fetch the latest closed allocation, if any
             const mostRecentlyClosedAllocation = (


### PR DESCRIPTION
## TL;DR

When dipper sends a DIPs proposal, the agent's normal reconcile loop and the DIPs accept path both try to create the on-chain allocation. The reconcile loop typically wins, the DIPs accept multicall then reverts because the allocation already exists, and the indexer ends up with an on-chain allocation that has no paying agreement behind it. This change makes reconcile defer to the DIPs accept path so allocation creation always happens atomically with agreement acceptance.

## Motivation

When dipper sends a DIPs proposal, the agent writes a local indexing rule for that deployment and then two background loops act on it. The reconcile loop sees the rule and asks the chain for its own allocation, while the DIPs accept path sends a single bundled transaction that creates the allocation and accepts the paying agreement together. Reconcile usually wins the race, and when the bundled transaction lands the chain rejects it because the allocation is already there, so the agreement is never accepted. The indexer ends up indexing the subgraph with an on-chain allocation but no paying agreement behind it, and a later cleanup pass quietly marks the orphan allocation as something the indexer is meant to keep.

## Summary

- Skip the reconcile create-allocation path when the matching rule is DIPS-basis.
- DipsManager still owns DIPS allocation creation through its atomic multicall.
- Unit test asserts reconcile does not call createAllocation for a fresh DIPS rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)