### PR TITLE
feat: stop unpaid indexing after a DIPs agreement is canceled

### DIFF
--- a/packages/indexer-common/src/__tests__/dips-agreement-collection-protection.test.ts
+++ b/packages/indexer-common/src/__tests__/dips-agreement-collection-protection.test.ts
@@ -46,10 +46,10 @@ const createMonitor = (opts: {
   )
 }
 
-describe('NetworkMonitor.hasActiveDipsAgreement', () => {
+describe('NetworkMonitor.hasCollectableDipsAgreement', () => {
   it('returns false when no indexing-payments subgraph is configured', async () => {
     const monitor = createMonitor({ agreements: null })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(false)
   })
 
   it('protects an Accepted agreement without consulting the collector', async () => {
@@ -58,7 +58,7 @@ describe('NetworkMonitor.hasActiveDipsAgreement', () => {
       agreements: [{ id: AGREEMENT_ID, state: 'Accepted' }],
       getCollectionInfo,
     })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(true)
     expect(getCollectionInfo).not.toHaveBeenCalled()
   })
 
@@ -68,7 +68,7 @@ describe('NetworkMonitor.hasActiveDipsAgreement', () => {
       agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
       getCollectionInfo,
     })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(true)
     expect(getCollectionInfo).toHaveBeenCalledWith(AGREEMENT_ID)
   })
 
@@ -78,7 +78,7 @@ describe('NetworkMonitor.hasActiveDipsAgreement', () => {
       agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
       getCollectionInfo,
     })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(false)
   })
 
   it('keeps protecting when the collector call fails, to avoid stranding fees', async () => {
@@ -87,11 +87,11 @@ describe('NetworkMonitor.hasActiveDipsAgreement', () => {
       agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
       getCollectionInfo,
     })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(true)
   })
 
   it('returns false when there are no protecting agreements for the allocation', async () => {
     const monitor = createMonitor({ agreements: [] })
-    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+    expect(await monitor.hasCollectableDipsAgreement(ALLOCATION_ID)).toBe(false)
   })
 })

--- a/packages/indexer-common/src/__tests__/dips-agreement-collection-protection.test.ts
+++ b/packages/indexer-common/src/__tests__/dips-agreement-collection-protection.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NetworkMonitor } from '../indexer-management/monitor'
+
+const ALLOCATION_ID = '0x1234567890123456789012345678901234567890'
+const AGREEMENT_ID = '0xabcdef000000000000000000000000ab'
+
+const createLogger = () =>
+  ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    child: jest.fn().mockReturnThis(),
+  }) as any
+
+const createMonitor = (opts: {
+  agreements?: { id: string; state: string }[] | null
+  getCollectionInfo?: jest.Mock
+}) => {
+  // agreements === null models "no indexing-payments subgraph configured".
+  const indexingPaymentsSubgraph =
+    opts.agreements === null
+      ? undefined
+      : ({
+          checkedQuery: jest
+            .fn()
+            .mockResolvedValue({ data: { indexingAgreements: opts.agreements } }),
+        } as any)
+  const contracts = {
+    RecurringCollector: {
+      getCollectionInfo:
+        opts.getCollectionInfo ?? jest.fn().mockResolvedValue([false, 0n, 0]),
+    },
+  } as any
+  return new NetworkMonitor(
+    'eip155:421614',
+    contracts,
+    {} as any, // indexerOptions
+    createLogger(),
+    {} as any, // graphNode
+    {} as any, // networkSubgraph
+    {} as any, // ethereum provider
+    {} as any, // epochSubgraph
+    indexingPaymentsSubgraph,
+  )
+}
+
+describe('NetworkMonitor.hasActiveDipsAgreement', () => {
+  it('returns false when no indexing-payments subgraph is configured', async () => {
+    const monitor = createMonitor({ agreements: null })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+  })
+
+  it('protects an Accepted agreement without consulting the collector', async () => {
+    const getCollectionInfo = jest.fn()
+    const monitor = createMonitor({
+      agreements: [{ id: AGREEMENT_ID, state: 'Accepted' }],
+      getCollectionInfo,
+    })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+    expect(getCollectionInfo).not.toHaveBeenCalled()
+  })
+
+  it('protects a payer-canceled agreement while the collector reports collectable fees', async () => {
+    const getCollectionInfo = jest.fn().mockResolvedValue([true, 120n, 0])
+    const monitor = createMonitor({
+      agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
+      getCollectionInfo,
+    })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+    expect(getCollectionInfo).toHaveBeenCalledWith(AGREEMENT_ID)
+  })
+
+  it('releases a payer-canceled agreement once the collector reports it fully drained', async () => {
+    const getCollectionInfo = jest.fn().mockResolvedValue([false, 0n, 1])
+    const monitor = createMonitor({
+      agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
+      getCollectionInfo,
+    })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+  })
+
+  it('keeps protecting when the collector call fails, to avoid stranding fees', async () => {
+    const getCollectionInfo = jest.fn().mockRejectedValue(new Error('rpc down'))
+    const monitor = createMonitor({
+      agreements: [{ id: AGREEMENT_ID, state: 'CanceledByPayer' }],
+      getCollectionInfo,
+    })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(true)
+  })
+
+  it('returns false when there are no protecting agreements for the allocation', async () => {
+    const monitor = createMonitor({ agreements: [] })
+    expect(await monitor.hasActiveDipsAgreement(ALLOCATION_ID)).toBe(false)
+  })
+})

--- a/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
+++ b/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
@@ -8,7 +8,7 @@ const mockAllocation = {
 }
 
 const createMockNetworkMonitor = (hasAgreement: boolean) => ({
-  hasActiveDipsAgreement: jest.fn().mockResolvedValue(hasAgreement),
+  hasCollectableDipsAgreement: jest.fn().mockResolvedValue(hasAgreement),
   allocation: jest.fn().mockResolvedValue(mockAllocation),
   subgraphDeployment: jest.fn().mockResolvedValue({}),
 })
@@ -84,6 +84,6 @@ describe('validateActionInputs DIPS agreement protection', () => {
       validateActionInputs([action], monitor as any, logger as any),
     ).resolves.toBeUndefined()
 
-    expect(monitor.hasActiveDipsAgreement).not.toHaveBeenCalled()
+    expect(monitor.hasCollectableDipsAgreement).not.toHaveBeenCalled()
   })
 })

--- a/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
+++ b/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
@@ -35,16 +35,16 @@ const baseAction: ActionInput = {
 }
 
 describe('validateActionInputs DIPS agreement protection', () => {
-  it('should reject UNALLOCATE with active DIPS agreement when force is not set', async () => {
+  it('should reject UNALLOCATE with a collectable DIPS agreement when force is not set', async () => {
     const monitor = createMockNetworkMonitor(true)
     const logger = createMockLogger()
 
     await expect(
       validateActionInputs([baseAction], monitor as any, logger as any),
-    ).rejects.toThrow(/active DIPS agreement/)
+    ).rejects.toThrow(/DIPS agreement that can still collect fees/)
   })
 
-  it('should allow UNALLOCATE with active DIPS agreement when force is true', async () => {
+  it('should allow UNALLOCATE with a collectable DIPS agreement when force is true', async () => {
     const monitor = createMockNetworkMonitor(true)
     const logger = createMockLogger()
 
@@ -55,12 +55,12 @@ describe('validateActionInputs DIPS agreement protection', () => {
     ).resolves.toBeUndefined()
 
     expect(logger.warn).toHaveBeenCalledWith(
-      'Force-closing allocation with active DIPS agreement',
+      'Force-closing allocation with a collectable DIPS agreement',
       expect.objectContaining({ allocationId: action.allocationID }),
     )
   })
 
-  it('should allow UNALLOCATE with no active DIPS agreement', async () => {
+  it('should allow UNALLOCATE with no collectable DIPS agreement', async () => {
     const monitor = createMockNetworkMonitor(false)
     const logger = createMockLogger()
 

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -185,7 +185,7 @@ export const validateActionInputs = async (
 
       // Check for active DIPS agreement on UNALLOCATE
       if (action.type === ActionType.UNALLOCATE && action.allocationID) {
-        const hasAgreement = await networkMonitor.hasActiveDipsAgreement(
+        const hasAgreement = await networkMonitor.hasCollectableDipsAgreement(
           action.allocationID,
         )
         if (hasAgreement && !action.force) {

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -56,10 +56,8 @@ export interface ActionInput {
 
 const ZERO_POI = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
-// Validates POI-related fields.
-// Zero POI is a sentinel meaning "no POI to submit", so publicPOI and
-// poiBlockNumber are not required in that case (nor when POI is omitted).
-// When POI is a real value, publicPOI and poiBlockNumber are required.
+// Zero POI is a sentinel for "no POI to submit", so publicPOI and poiBlockNumber
+// are optional then (and when POI is omitted); a real POI requires both.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const hasValidPOIParams = (variableToCheck: any): boolean => {
   if (variableToCheck.poi === undefined || variableToCheck.poi === ZERO_POI) {
@@ -183,12 +181,9 @@ export const validateActionInputs = async (
         )
       }
 
-      // An allocation is protected from closing while it still owes a DIPS payment.
-      // Closing it makes SubgraphService.collect revert (collect requires the
-      // allocation to be open), so a canceled agreement must keep its allocation
-      // alive until its final fees have been collected. Two cases protect:
-      //   - an Accepted agreement: still live, closing would cancel it on-chain;
-      //   - a payer-canceled agreement whose fees aren't fully collected yet.
+      // Block closing an allocation that still owes DIPS fees: SubgraphService.collect
+      // requires the allocation open, so an early close would cancel a live agreement
+      // on-chain or strand fees a canceled agreement hasn't finished collecting.
       if (action.type === ActionType.UNALLOCATE && action.allocationID) {
         const hasAgreement = await networkMonitor.hasCollectableDipsAgreement(
           action.allocationID,

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -183,7 +183,12 @@ export const validateActionInputs = async (
         )
       }
 
-      // Check for active DIPS agreement on UNALLOCATE
+      // An allocation is protected from closing while it still owes a DIPS payment.
+      // Closing it makes SubgraphService.collect revert (collect requires the
+      // allocation to be open), so a canceled agreement must keep its allocation
+      // alive until its final fees have been collected. Two cases protect:
+      //   - an Accepted agreement: still live, closing would cancel it on-chain;
+      //   - a payer-canceled agreement whose fees aren't fully collected yet.
       if (action.type === ActionType.UNALLOCATE && action.allocationID) {
         const hasAgreement = await networkMonitor.hasCollectableDipsAgreement(
           action.allocationID,

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -195,13 +195,13 @@ export const validateActionInputs = async (
         )
         if (hasAgreement && !action.force) {
           throw new Error(
-            `Allocation ${action.allocationID} has an active DIPS agreement. ` +
-              `Closing this allocation will cancel the agreement on-chain. ` +
-              `Use force=true to proceed anyway.`,
+            `Allocation ${action.allocationID} has a DIPS agreement that can still collect fees. ` +
+              `Closing it now would cancel a live agreement on-chain, or strand fees that a ` +
+              `canceled agreement has not finished collecting. Use force=true to proceed anyway.`,
           )
         }
         if (hasAgreement && action.force) {
-          logger.warn('Force-closing allocation with active DIPS agreement', {
+          logger.warn('Force-closing allocation with a collectable DIPS agreement', {
             allocationId: action.allocationID,
             actionType: action.type,
           })

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -62,20 +62,58 @@ export class NetworkMonitor {
     if (!this.indexingPaymentsSubgraph) {
       return false
     }
+    // An allocation is protected from closing while it still owes a DIPS payment.
+    // Closing it makes SubgraphService.collect revert (collect requires the
+    // allocation to be open), so a canceled agreement must keep its allocation
+    // alive until its final fees have been collected. Two cases protect:
+    //   - an Accepted agreement: still live, closing would cancel it on-chain;
+    //   - a payer-canceled agreement whose fees aren't fully collected yet.
     const result = await this.indexingPaymentsSubgraph.checkedQuery(
       gql`
         query indexingAgreements($allocationId: Bytes!) {
           indexingAgreements(
             where: { allocationId: $allocationId, state_in: [Accepted, CanceledByPayer] }
-            first: 1
           ) {
             id
+            state
           }
         }
       `,
       { allocationId: allocationId.toLowerCase() },
     )
-    return (result.data?.indexingAgreements?.length ?? 0) > 0
+    const agreements: { id: string; state: string }[] =
+      result.data?.indexingAgreements ?? []
+
+    // Any still-active agreement protects the allocation outright.
+    if (agreements.some((agreement) => agreement.state === 'Accepted')) {
+      return true
+    }
+
+    // For payer-canceled agreements, defer to the on-chain collector: it reports
+    // fees as collectable until the collection window is fully drained. Protect
+    // while anything remains; release once drained so the allocation can close.
+    for (const agreement of agreements.filter(
+      (agreement) => agreement.state === 'CanceledByPayer',
+    )) {
+      try {
+        const [isCollectable] = await this.contracts.RecurringCollector.getCollectionInfo(
+          agreement.id,
+        )
+        if (isCollectable) {
+          return true
+        }
+      } catch (err) {
+        // Can't confirm the agreement is drained → keep protecting (fail safe);
+        // closing now would risk stranding uncollected fees.
+        this.logger.warn(
+          'Could not read DIPS collection info; keeping allocation protected',
+          { allocationId, agreementId: agreement.id, err },
+        )
+        return true
+      }
+    }
+
+    return false
   }
 
   poiDisputeMonitoringEnabled(): boolean {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -62,12 +62,6 @@ export class NetworkMonitor {
     if (!this.indexingPaymentsSubgraph) {
       return false
     }
-    // An allocation is protected from closing while it still owes a DIPS payment.
-    // Closing it makes SubgraphService.collect revert (collect requires the
-    // allocation to be open), so a canceled agreement must keep its allocation
-    // alive until its final fees have been collected. Two cases protect:
-    //   - an Accepted agreement: still live, closing would cancel it on-chain;
-    //   - a payer-canceled agreement whose fees aren't fully collected yet.
     const result = await this.indexingPaymentsSubgraph.checkedQuery(
       gql`
         query indexingAgreements($allocationId: Bytes!) {

--- a/packages/indexer-common/src/indexer-management/monitor.ts
+++ b/packages/indexer-common/src/indexer-management/monitor.ts
@@ -57,7 +57,7 @@ export class NetworkMonitor {
     private indexingPaymentsSubgraph?: SubgraphClient,
   ) {}
 
-  async hasActiveDipsAgreement(allocationId: string): Promise<boolean> {
+  async hasCollectableDipsAgreement(allocationId: string): Promise<boolean> {
     // No DIPS subgraph configured → no agreement can exist
     if (!this.indexingPaymentsSubgraph) {
       return false


### PR DESCRIPTION
## TL;DR

When a payer cancels a DIPs agreement, the indexer used to keep its allocation open indefinitely, indexing a subgraph it would no longer be paid for. This lets that allocation close once the agreement's final payment has been collected, so the indexer stops doing unpaid work and frees the stake. It waits for the final payment first, because the payment can only be collected while the allocation is still open.

## Motivation

A DIPs agreement pays an indexer to index a particular subgraph, and while the agreement is live the indexer's allocation for it is protected from being closed. When the payer cancels the agreement, that protection used to stay in place forever, so the allocation never closed and the indexer carried on indexing — with its stake locked in place — for a subgraph nobody was paying for.

The allocation can't simply close on cancellation, though: the final payment for work already done can only be collected while the allocation is still open, so closing too early would forfeit it. This change keeps the allocation protected only until that final payment has been collected, then releases it so the indexer's normal housekeeping can close it and put the stake to use elsewhere.

## Summary

- A canceled agreement's allocation stays protected only until its final payment is collected.
- Protection consults the payment contract, which reports fees as collectable until fully drained.
- Once nothing is left to collect, the allocation is freed and normal housekeeping closes it.
- An active, uncanceled agreement still protects its allocation exactly as before.
- If the collectable amount can't be read, the allocation stays protected, to avoid losing fees.
