### PR TITLE
fix: collect indexing rewards once per epoch, not every 15 min

### DIFF
--- a/packages/indexer-agent/src/__tests__/agent.ts
+++ b/packages/indexer-agent/src/__tests__/agent.ts
@@ -442,6 +442,7 @@ describe('reconcileDeploymentAllocationAction', () => {
       expect.anything(),
       [activeAllocations[0]],
       network,
+      10,
     )
   })
 

--- a/packages/indexer-agent/src/agent.ts
+++ b/packages/indexer-agent/src/agent.ts
@@ -8,7 +8,9 @@ import {
   timer,
 } from '@graphprotocol/common-ts'
 import {
+  ActionManager,
   ActionStatus,
+  ActionType,
   Allocation,
   AllocationManagementMode,
   allocationRewardsPool,
@@ -20,6 +22,7 @@ import {
   IndexingRuleAttributes,
   Network,
   POIDisputeAttributes,
+  presentPOIReasonEpoch,
   RewardsPool,
   Subgraph,
   SubgraphDeployment,
@@ -1023,7 +1026,62 @@ export class Agent {
         }
       },
     )
+
+    // Rewards accrue per block, so a second present-POI the same epoch collects only
+    // the little earned since the last and mostly wastes gas. Skip allocations already
+    // harvested this epoch.
+    const harvestedThisEpoch = await this.allocationsHarvestedInEpoch(
+      deploymentAllocationDecision.deployment.ipfsHash,
+      network.specification.networkIdentifier,
+      epoch,
+    )
+    expiredAllocations = expiredAllocations.filter(allocation => {
+      if (harvestedThisEpoch.has(allocation.id)) {
+        logger.debug(
+          'Allocation already harvested this epoch, skipping presentPOI',
+          {
+            allocation: allocation.id,
+            epoch,
+          },
+        )
+        return false
+      }
+      return true
+    })
+
     return expiredAllocations
+  }
+
+  // Returns the set of allocation ids that already had a successful present-POI
+  // scheduled for the current epoch, read from the actions table.
+  async allocationsHarvestedInEpoch(
+    deploymentID: string,
+    protocolNetwork: string,
+    epoch: number,
+  ): Promise<Set<string>> {
+    const actionManager = this.indexerManagement.actionManager
+    if (!actionManager) {
+      return new Set()
+    }
+    const recentPresentPOIActions = await ActionManager.fetchActions(
+      actionManager.models,
+      null,
+      {
+        type: ActionType.PRESENT_POI,
+        status: ActionStatus.SUCCESS,
+        protocolNetwork,
+      },
+    )
+    return new Set(
+      recentPresentPOIActions
+        .filter(
+          action =>
+            action.deploymentID === deploymentID &&
+            action.allocationID !== null &&
+            presentPOIReasonEpoch(action.reason) === epoch,
+        )
+        .map(action => action.allocationID as string),
+    )
   }
 
   async reconcileDeploymentAllocationAction(
@@ -1125,6 +1183,7 @@ export class Agent {
                 logger,
                 expiringAllocations,
                 network,
+                epoch,
               )
             }
           }

--- a/packages/indexer-common/src/__tests__/actions.test.ts
+++ b/packages/indexer-common/src/__tests__/actions.test.ts
@@ -1,4 +1,11 @@
-import { ActionInput, ActionStatus, ActionType, isValidActionInput } from '../actions'
+import {
+  ActionInput,
+  ActionStatus,
+  ActionType,
+  isValidActionInput,
+  presentPOIReason,
+  presentPOIReasonEpoch,
+} from '../actions'
 
 describe('Action Validation', () => {
   describe('isValidActionInput', () => {
@@ -244,5 +251,18 @@ describe('Action Validation', () => {
 
       expect(isValidActionInput(noType)).toBe(false)
     })
+  })
+})
+
+describe('present-POI reason encoding', () => {
+  test('round-trips the epoch through the reason string', () => {
+    expect(presentPOIReasonEpoch(presentPOIReason(853))).toBe(853)
+    expect(presentPOIReasonEpoch(presentPOIReason(0))).toBe(0)
+  })
+
+  test('returns undefined for a reason without an epoch', () => {
+    expect(presentPOIReasonEpoch('presentPOI:staleness-prevention')).toBeUndefined()
+    expect(presentPOIReasonEpoch('some-other-reason')).toBeUndefined()
+    expect(presentPOIReasonEpoch(null)).toBeUndefined()
   })
 })

--- a/packages/indexer-common/src/__tests__/present-poi-scheduling.test.ts
+++ b/packages/indexer-common/src/__tests__/present-poi-scheduling.test.ts
@@ -61,7 +61,7 @@ describe('presentPOIForAllocations', () => {
       id: '0x0000000000000000000000000000000000000002',
     })
 
-    await operator.presentPOIForAllocations(mockLogger, [alloc1, alloc2], network)
+    await operator.presentPOIForAllocations(mockLogger, [alloc1, alloc2], network, 853)
 
     expect(queueActionSpy).toHaveBeenCalledTimes(2)
     expect(queueActionSpy).toHaveBeenCalledWith(
@@ -71,7 +71,7 @@ describe('presentPOIForAllocations', () => {
           allocationID: alloc1.id,
           deploymentID: deployment.ipfsHash,
         }),
-        reason: 'presentPOI:staleness-prevention',
+        reason: 'presentPOI:staleness-prevention:epoch=853',
         protocolNetwork: 'eip155:421614',
       }),
       false,
@@ -87,7 +87,7 @@ describe('presentPOIForAllocations', () => {
   })
 
   it('should not queue anything when no allocations are passed', async () => {
-    await operator.presentPOIForAllocations(mockLogger, [], network)
+    await operator.presentPOIForAllocations(mockLogger, [], network, 853)
     expect(queueActionSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -256,6 +256,22 @@ export enum ActionType {
   RESIZE = 'resize',
 }
 
+// Rewards accrue per block, so a present-POI mid-epoch collects only what accrued
+// since the last and mostly wastes gas; one per epoch suffices. We record the epoch
+// in the action `reason` so the agent can skip allocations already harvested this epoch.
+const PRESENT_POI_REASON_PREFIX = 'presentPOI:staleness-prevention'
+
+export function presentPOIReason(epoch: number): string {
+  return `${PRESENT_POI_REASON_PREFIX}:epoch=${epoch}`
+}
+
+// Returns the epoch encoded in a present-POI action `reason`, or undefined if
+// the reason carries no epoch (e.g. an action queued before this field existed).
+export function presentPOIReasonEpoch(reason: string | null): number | undefined {
+  const match = reason?.match(/:epoch=(\d+)$/)
+  return match ? Number(match[1]) : undefined
+}
+
 export enum ActionStatus {
   QUEUED = 'queued',
   APPROVED = 'approved',

--- a/packages/indexer-common/src/operator.ts
+++ b/packages/indexer-common/src/operator.ts
@@ -17,6 +17,7 @@ import {
   Action,
   POIDisputeAttributes,
   DipsManager,
+  presentPOIReason,
 } from '@graphprotocol/indexer-common'
 import { Logger, formatGRT } from '@graphprotocol/common-ts'
 import { hexlify } from 'ethers'
@@ -569,11 +570,13 @@ export class Operator {
     network: {
       specification: { networkIdentifier: string }
     },
+    epoch: number,
   ): Promise<void> {
     for (const allocation of expiringAllocations) {
       logger.info('Scheduling presentPOI for Horizon allocation', {
         allocationId: allocation.id,
         deployment: allocation.subgraphDeployment.id.ipfsHash,
+        epoch,
       })
 
       await this.queueAction(
@@ -584,7 +587,7 @@ export class Operator {
             poi: undefined,
           },
           type: ActionType.PRESENT_POI,
-          reason: 'presentPOI:staleness-prevention',
+          reason: presentPOIReason(epoch),
           protocolNetwork: network.specification.networkIdentifier,
         },
         false,


### PR DESCRIPTION
## TL;DR

An indexer that keeps an allocation open collects its indexing rewards periodically without closing it, and today the agent fires one of those collections roughly every fifteen minutes. Since rewards accrue continuously and a single collection per epoch still gathers everything earned in that epoch, this change spaces the collections out to at most once per epoch. It is an efficiency fix that cuts redundant gas — the total rewards an indexer earns are unchanged.

## Motivation

When an indexer keeps an allocation open for a long time, the agent periodically collects the indexing rewards it has earned without closing the allocation. Those rewards accrue continuously, so collecting once an epoch rather than every few minutes still gathers everything earned in between — the indexer just receives it in fewer, larger batches.

Today the agent re-collects on every reconciliation pass; the only thing holding it back is an unrelated fifteen-minute window that stops the same action being queued twice in quick succession, so the cadence tracks wall-clock time rather than epochs. On a network with day-long epochs that can mean up to ninety-six collections a day where one per epoch would gather the same rewards, and since every collection is its own on-chain transaction the indexer pays that gas over and over for no extra earnings.

## Summary

- Tag each rewards collection with the epoch it was made in.
- Skip any allocation already collected in the current epoch before collecting again.
- A new epoch makes the allocation eligible again, so it collects at most once per epoch.
- Leave the existing fifteen-minute throttle in place for all other action types.
