### PR TITLE
fix: allow a zero slippage tolerance when collecting payments

### DIFF
--- a/packages/indexer-common/src/__tests__/network-specification.test.ts
+++ b/packages/indexer-common/src/__tests__/network-specification.test.ts
@@ -108,4 +108,16 @@ describe('Specificaiton parts parsing', () => {
       geoCoordinates: [60.16952, 24.93545], // Must be numbers
     })
   })
+
+  test('Indexer Options accepts zero dips collection slippage', () => {
+    // 0 is a valid setting: tolerate no shortfall when collecting (strictest stop-loss).
+    const parsed = IndexerOptions.parse({
+      address: '0xdf9CAc44924C21a6c874ee3C727b1c9Ccd5b58cc',
+      mnemonic: 'any valid string can work',
+      url: 'http://example.com',
+      geoCoordinates: [60.16952, 24.93545],
+      dipsCollectionSlippage: 0,
+    })
+    expect(parsed.dipsCollectionSlippage).toBe(0)
+  })
 })

--- a/packages/indexer-common/src/network-specification.ts
+++ b/packages/indexer-common/src/network-specification.ts
@@ -77,7 +77,7 @@ export const IndexerOptions = z
     ravCollectionInterval: positiveNumber().default(14400),
     dipsEpochsMargin: positiveNumber().default(1),
     dipsCollectionTarget: positiveNumber().min(1).max(90).default(50),
-    dipsCollectionSlippage: positiveNumber().min(0).max(100).default(1),
+    dipsCollectionSlippage: z.number().nonnegative().max(100).finite().default(1),
     dipsAcceptanceInterval: positiveNumber().default(5),
   })
   .strict()


### PR DESCRIPTION
## TL;DR

A payment-collection setting that bounds how much the indexer will accept losing versus the expected amount could not be set to zero, even though zero — accept no loss at all — is a valid, strict choice. This change makes the setting accept zero while still capping it at 100.

## Motivation

When an indexer collects a payment for indexing work, the payer's on-chain agreement caps can make the amount actually collectable come in below what the indexer expected to earn. A setting bounds the indexer's stop-loss: the largest share of the expected amount it will accept losing before it aborts the collection.

Today that setting's validation rejects a value of zero, so an operator who wants a strict zero-tolerance policy — collect the full expected amount or nothing — cannot configure it and the agent refuses to start. The command-line help already advertises the range as 0 to 100, so the rejection also contradicts the documented range. This change lets the setting accept zero while keeping the cap at 100.

## Summary

- Let the collection-slippage setting accept 0 (no loss tolerated), keeping the 0-100 range.
- Fix the validator, which paired a "greater than zero" rule with a dead "zero or more" rule.
- Add a test asserting a zero value now parses.
