### PR TITLE
fix: keep the operator's allocate rule after an agent close

### DIFF
--- a/packages/indexer-common/src/indexer-management/__tests__/rule-preservation.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/rule-preservation.test.ts
@@ -1,0 +1,75 @@
+import { SubgraphDeploymentID } from '@graphprotocol/common-ts'
+import { findRuleRequestingAllocation } from '../allocations'
+import { IndexingDecisionBasis, IndexingRuleAttributes } from '../models'
+import { SubgraphIdentifierType } from '../../subgraphs'
+
+// Pure-function coverage for the guard that stops confirmUnallocate stamping a
+// `never` rule over an operator rule that currently requests allocation.
+describe('findRuleRequestingAllocation', () => {
+  const deployment = new SubgraphDeploymentID(
+    'QmXZiV6S13ha6QXq4dmaM3TB4CHcDxBMvGexSNu9Kc28EH',
+  )
+  const otherDeployment = new SubgraphDeploymentID(
+    'QmRKs2ZfuwvmZA3QAWmCqrGUjV9pxtBUDP3wuc6iVGnjA2',
+  )
+
+  const rule = (overrides: Partial<IndexingRuleAttributes>) =>
+    ({
+      identifier: deployment.ipfsHash,
+      identifierType: SubgraphIdentifierType.DEPLOYMENT,
+      decisionBasis: IndexingDecisionBasis.ALWAYS,
+      ...overrides,
+    }) as IndexingRuleAttributes
+
+  it('finds an always rule for the deployment', () => {
+    const found = findRuleRequestingAllocation([rule({})], deployment)
+    expect(found?.decisionBasis).toBe(IndexingDecisionBasis.ALWAYS)
+  })
+
+  it('finds a dips rule for the deployment', () => {
+    const found = findRuleRequestingAllocation(
+      [rule({ decisionBasis: IndexingDecisionBasis.DIPS })],
+      deployment,
+    )
+    expect(found?.decisionBasis).toBe(IndexingDecisionBasis.DIPS)
+  })
+
+  it('matches a rule whose identifier is stored in bytes32 form', () => {
+    const found = findRuleRequestingAllocation(
+      [rule({ identifier: deployment.bytes32 })],
+      deployment,
+    )
+    expect(found).toBeDefined()
+  })
+
+  it('ignores opt-out and default bases', () => {
+    for (const basis of [
+      IndexingDecisionBasis.NEVER,
+      IndexingDecisionBasis.OFFCHAIN,
+      IndexingDecisionBasis.RULES,
+    ]) {
+      expect(
+        findRuleRequestingAllocation([rule({ decisionBasis: basis })], deployment),
+      ).toBeUndefined()
+    }
+  })
+
+  it('ignores rules for other deployments', () => {
+    expect(
+      findRuleRequestingAllocation(
+        [rule({ identifier: otherDeployment.ipfsHash })],
+        deployment,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('ignores subgraph-type rules and returns undefined when no rules exist', () => {
+    expect(
+      findRuleRequestingAllocation(
+        [rule({ identifierType: SubgraphIdentifierType.SUBGRAPH })],
+        deployment,
+      ),
+    ).toBeUndefined()
+    expect(findRuleRequestingAllocation([], deployment)).toBeUndefined()
+  })
+})

--- a/packages/indexer-common/src/indexer-management/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/allocations.ts
@@ -140,6 +140,22 @@ export function encodeCollectData(allocationId: string, poiData: POIData): strin
   return encodeCollectIndexingRewardsData(allocationId, poiData.poi, encodedPOIMetadata)
 }
 
+// A queued close can outlive the rule that justified it. Find a deployment
+// rule that currently asks for allocation (operator `always` or DIPs-managed);
+// stamping `never` over it would also blocklist the deployment for DIPs.
+export function findRuleRequestingAllocation(
+  rules: IndexingRuleAttributes[],
+  deployment: SubgraphDeploymentID,
+): IndexingRuleAttributes | undefined {
+  return rules.find(
+    (rule) =>
+      rule.identifierType === SubgraphIdentifierType.DEPLOYMENT &&
+      new SubgraphDeploymentID(rule.identifier).bytes32 === deployment.bytes32 &&
+      (rule.decisionBasis === IndexingDecisionBasis.ALWAYS ||
+        rule.decisionBasis === IndexingDecisionBasis.DIPS),
+  )
+}
+
 export class AllocationManager {
   declare dipsManager: DipsManager | null
   constructor(
@@ -911,18 +927,38 @@ export class AllocationManager {
     })
     const allocation = await this.network.networkMonitor.allocation(allocationID)
 
-    // Upsert a rule so the agent keeps the deployment synced but doesn't allocate to it
-    logger.debug(
-      `Updating indexing rules so indexer-agent keeps the deployment synced but doesn't allocate to it`,
+    // The rule that justified this close may have changed while the action
+    // sat in the queue: an operator flipping the deployment back to `always`
+    // (or DIPs taking it over) must not be overwritten with `never`.
+    const currentRules = await this.models.IndexingRule.findAll({
+      where: { protocolNetwork: this.network.specification.networkIdentifier },
+    })
+    const allocateRule = findRuleRequestingAllocation(
+      currentRules,
+      allocation.subgraphDeployment.id,
     )
-    const neverIndexingRule = {
-      identifier: allocation.subgraphDeployment.id.ipfsHash,
-      protocolNetwork: this.network.specification.networkIdentifier,
-      identifierType: SubgraphIdentifierType.DEPLOYMENT,
-      decisionBasis: IndexingDecisionBasis.NEVER,
-    } as Partial<IndexingRuleAttributes>
+    if (allocateRule) {
+      logger.info(
+        `Keeping the current indexing rule: it requests allocation, so skipping the never-rule stamp after this close`,
+        {
+          deployment: allocation.subgraphDeployment.id.ipfsHash,
+          currentDecisionBasis: allocateRule.decisionBasis,
+        },
+      )
+    } else {
+      // Upsert a rule so the agent keeps the deployment synced but doesn't allocate to it
+      logger.debug(
+        `Updating indexing rules so indexer-agent keeps the deployment synced but doesn't allocate to it`,
+      )
+      const neverIndexingRule = {
+        identifier: allocation.subgraphDeployment.id.ipfsHash,
+        protocolNetwork: this.network.specification.networkIdentifier,
+        identifierType: SubgraphIdentifierType.DEPLOYMENT,
+        decisionBasis: IndexingDecisionBasis.NEVER,
+      } as Partial<IndexingRuleAttributes>
 
-    await upsertIndexingRule(logger, this.models, neverIndexingRule)
+      await upsertIndexingRule(logger, this.models, neverIndexingRule)
+    }
 
     return {
       actionID,


### PR DESCRIPTION
This PR stops the indexer-agent from overwriting an operator's indexing rule after closing an allocation. When the agent closes one, it writes a do-not-allocate note so it will not recreate what it just closed. It wrote that note unconditionally. If the operator had changed the rule while the close waited in a queue, the note erased the change and also blocked DIPs payment offers for that deployment.

We hit this during local-network DIPs testing. The agent closed an allocation a test had just recreated, then wrote the note and blocklisted the deployment for payments. A companion PR, #1243, stops that wrongful close from being queued at all. This PR makes sure a close that still slips through cannot erase what the operator wants. Deliberate rule changes made through the CLI and management API are untouched. One behaviour change: after a close under a live always rule, the agent now recreates the allocation on its next pass. 6 new unit tests cover the guard.
