### PR TITLE
fix: stop direct closes from cancelling live agreements

### DIFF
--- a/packages/indexer-cli/src/__tests__/indexing-agreement-notices.unit.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexing-agreement-notices.unit.test.ts
@@ -1,0 +1,77 @@
+import {
+  activeAgreementRevertGuidance,
+  closedAllocationAgreementNotice,
+  isDipsManagedRule,
+  queuedUnallocateAgreementWarning,
+} from '../indexing-agreement-notices'
+import {
+  IndexingDecisionBasis,
+  IndexingRuleAttributes,
+} from '@graphprotocol/indexer-common'
+
+const DEPLOYMENT = 'QmXZiV6S13ha6QXq4dmaM3TB4CHcDxBMvGexSNu9Kc28EH'
+
+describe('isDipsManagedRule', () => {
+  it('matches only rules with the DIPS decision basis', () => {
+    expect(
+      isDipsManagedRule({
+        decisionBasis: IndexingDecisionBasis.DIPS,
+      } as Partial<IndexingRuleAttributes>),
+    ).toBe(true)
+    for (const basis of [
+      IndexingDecisionBasis.ALWAYS,
+      IndexingDecisionBasis.NEVER,
+      IndexingDecisionBasis.OFFCHAIN,
+      IndexingDecisionBasis.RULES,
+    ]) {
+      expect(
+        isDipsManagedRule({ decisionBasis: basis } as Partial<IndexingRuleAttributes>),
+      ).toBe(false)
+    }
+    expect(isDipsManagedRule(null)).toBe(false)
+    expect(isDipsManagedRule(undefined)).toBe(false)
+  })
+})
+
+describe('notices', () => {
+  it('names the opt-out command after a close on a DIPS deployment', () => {
+    const notice = closedAllocationAgreementNotice(DEPLOYMENT, 'arbitrum-one')
+    expect(notice).toContain(
+      `graph indexer rules never ${DEPLOYMENT} --network arbitrum-one`,
+    )
+    expect(notice).toContain('payments for it stop')
+  })
+
+  it('names the action cancel command after queueing an unallocate', () => {
+    const warning = queuedUnallocateAgreementWarning(42, 'arbitrum-one')
+    expect(warning).toContain('graph indexer actions cancel 42 --network arbitrum-one')
+  })
+})
+
+describe('activeAgreementRevertGuidance', () => {
+  it('translates the close-guard revert into the opt-out command', () => {
+    const guidance = activeAgreementRevertGuidance(
+      'Error: execution reverted (unknown custom error) SubgraphServiceAllocationHasActiveAgreement(0x3ec9, 0x7f31)',
+      DEPLOYMENT,
+      'arbitrum-one',
+    )
+    expect(guidance).toContain(
+      `graph indexer rules never ${DEPLOYMENT} --network arbitrum-one`,
+    )
+  })
+
+  it('falls back to a placeholder when the deployment is unknown', () => {
+    const guidance = activeAgreementRevertGuidance(
+      'SubgraphServiceAllocationHasActiveAgreement',
+      undefined,
+      'arbitrum-one',
+    )
+    expect(guidance).toContain('<deployment>')
+  })
+
+  it('leaves unrelated errors alone', () => {
+    expect(
+      activeAgreementRevertGuidance('Error: nonce too low', DEPLOYMENT, 'arbitrum-one'),
+    ).toBeNull()
+  })
+})

--- a/packages/indexer-cli/src/__tests__/indexing-agreement-notices.unit.test.ts
+++ b/packages/indexer-cli/src/__tests__/indexing-agreement-notices.unit.test.ts
@@ -1,77 +1,15 @@
-import {
-  activeAgreementRevertGuidance,
-  closedAllocationAgreementNotice,
-  isDipsManagedRule,
-  queuedUnallocateAgreementWarning,
-} from '../indexing-agreement-notices'
-import {
-  IndexingDecisionBasis,
-  IndexingRuleAttributes,
-} from '@graphprotocol/indexer-common'
-
-const DEPLOYMENT = 'QmXZiV6S13ha6QXq4dmaM3TB4CHcDxBMvGexSNu9Kc28EH'
-
-describe('isDipsManagedRule', () => {
-  it('matches only rules with the DIPS decision basis', () => {
-    expect(
-      isDipsManagedRule({
-        decisionBasis: IndexingDecisionBasis.DIPS,
-      } as Partial<IndexingRuleAttributes>),
-    ).toBe(true)
-    for (const basis of [
-      IndexingDecisionBasis.ALWAYS,
-      IndexingDecisionBasis.NEVER,
-      IndexingDecisionBasis.OFFCHAIN,
-      IndexingDecisionBasis.RULES,
-    ]) {
-      expect(
-        isDipsManagedRule({ decisionBasis: basis } as Partial<IndexingRuleAttributes>),
-      ).toBe(false)
-    }
-    expect(isDipsManagedRule(null)).toBe(false)
-    expect(isDipsManagedRule(undefined)).toBe(false)
-  })
-})
-
-describe('notices', () => {
-  it('names the opt-out command after a close on a DIPS deployment', () => {
-    const notice = closedAllocationAgreementNotice(DEPLOYMENT, 'arbitrum-one')
-    expect(notice).toContain(
-      `graph indexer rules never ${DEPLOYMENT} --network arbitrum-one`,
-    )
-    expect(notice).toContain('payments for it stop')
-  })
-
-  it('names the action cancel command after queueing an unallocate', () => {
-    const warning = queuedUnallocateAgreementWarning(42, 'arbitrum-one')
-    expect(warning).toContain('graph indexer actions cancel 42 --network arbitrum-one')
-  })
-})
+import { activeAgreementRevertGuidance } from '../indexing-agreement-notices'
 
 describe('activeAgreementRevertGuidance', () => {
   it('translates the close-guard revert into the opt-out command', () => {
     const guidance = activeAgreementRevertGuidance(
-      'Error: execution reverted (unknown custom error) SubgraphServiceAllocationHasActiveAgreement(0x3ec9, 0x7f31)',
-      DEPLOYMENT,
-      'arbitrum-one',
+      'Error: execution reverted: SubgraphServiceAllocationHasActiveAgreement(0x3ec9, 0x7f31)',
     )
-    expect(guidance).toContain(
-      `graph indexer rules never ${DEPLOYMENT} --network arbitrum-one`,
-    )
-  })
-
-  it('falls back to a placeholder when the deployment is unknown', () => {
-    const guidance = activeAgreementRevertGuidance(
-      'SubgraphServiceAllocationHasActiveAgreement',
-      undefined,
-      'arbitrum-one',
-    )
-    expect(guidance).toContain('<deployment>')
+    expect(guidance).toContain('active indexing agreement')
+    expect(guidance).toContain('graph indexer rules never')
   })
 
   it('leaves unrelated errors alone', () => {
-    expect(
-      activeAgreementRevertGuidance('Error: nonce too low', DEPLOYMENT, 'arbitrum-one'),
-    ).toBeNull()
+    expect(activeAgreementRevertGuidance('Error: nonce too low')).toBeNull()
   })
 })

--- a/packages/indexer-cli/src/commands/indexer/actions/queue.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/queue.ts
@@ -9,15 +9,9 @@ import {
   getRawPositionalArgs,
 } from '../../../command-helpers'
 import { buildActionInput, queueActions, validateActionType } from '../../../actions'
-import { indexingRule } from '../../../rules'
-import {
-  isDipsManagedRule,
-  queuedUnallocateAgreementWarning,
-} from '../../../indexing-agreement-notices'
 import {
   ActionInput,
   ActionStatus,
-  ActionType,
   resolveChainAlias,
 } from '@graphprotocol/indexer-common'
 
@@ -135,29 +129,6 @@ module.exports = {
         'source',
         'reason',
       ])
-
-      if (actionInputParams.type === ActionType.UNALLOCATE && queuedAction.length > 0) {
-        try {
-          const rule = await indexingRule(
-            client,
-            {
-              identifier: actionInputParams.deploymentID,
-              protocolNetwork: actionInputParams.protocolNetwork,
-            },
-            false,
-          )
-          if (isDipsManagedRule(rule)) {
-            print.warning(
-              queuedUnallocateAgreementWarning(
-                queuedAction[0].id,
-                resolveChainAlias(actionInputParams.protocolNetwork),
-              ),
-            )
-          }
-        } catch (ruleError) {
-          print.info(`Could not check for an indexing agreement rule: ${ruleError}`)
-        }
-      }
     } catch (error) {
       actionSpinner.fail(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/actions/queue.ts
+++ b/packages/indexer-cli/src/commands/indexer/actions/queue.ts
@@ -9,9 +9,15 @@ import {
   getRawPositionalArgs,
 } from '../../../command-helpers'
 import { buildActionInput, queueActions, validateActionType } from '../../../actions'
+import { indexingRule } from '../../../rules'
+import {
+  isDipsManagedRule,
+  queuedUnallocateAgreementWarning,
+} from '../../../indexing-agreement-notices'
 import {
   ActionInput,
   ActionStatus,
+  ActionType,
   resolveChainAlias,
 } from '@graphprotocol/indexer-common'
 
@@ -129,6 +135,29 @@ module.exports = {
         'source',
         'reason',
       ])
+
+      if (actionInputParams.type === ActionType.UNALLOCATE && queuedAction.length > 0) {
+        try {
+          const rule = await indexingRule(
+            client,
+            {
+              identifier: actionInputParams.deploymentID,
+              protocolNetwork: actionInputParams.protocolNetwork,
+            },
+            false,
+          )
+          if (isDipsManagedRule(rule)) {
+            print.warning(
+              queuedUnallocateAgreementWarning(
+                queuedAction[0].id,
+                resolveChainAlias(actionInputParams.protocolNetwork),
+              ),
+            )
+          }
+        } catch (ruleError) {
+          print.info(`Could not check for an indexing agreement rule: ${ruleError}`)
+        }
+      }
     } catch (error) {
       actionSpinner.fail(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { closeAllocation } from '../../../allocations'
+import { activeAgreementRevertGuidance } from '../../../indexing-agreement-notices'
 import {
   validatePOI,
   printObjectOrArray,
@@ -20,7 +21,7 @@ ${chalk.dim('Options:')}
 
   -h, --help                    Show usage information
   -n, --network <network>       The network to close the allocation on: mainnet, arbitrum-one, sepolia or arbitrum sepolia
-  -f, --force                   Bypass POI accuracy checks and submit transaction with provided data
+  -f, --force                   Bypass POI accuracy checks and the indexing agreement guard, then submit with provided data
   -o, --output table|json|yaml  Choose the output format: table (default), JSON, or YAML
   -w, --wrap [N]                Wrap the output to a specific width (default: 0, no wrapping)
 
@@ -114,6 +115,10 @@ module.exports = {
       )
     } catch (error) {
       spinner.fail(error.toString())
+      const guidance = activeAgreementRevertGuidance(error.toString())
+      if (guidance) {
+        print.warning(guidance)
+      }
       process.exitCode = 1
       return
     }

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -1,23 +1,15 @@
 import { GluegunToolbox } from 'gluegun'
 import chalk from 'chalk'
-import gql from 'graphql-tag'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { closeAllocation } from '../../../allocations'
-import { indexingRule } from '../../../rules'
-import {
-  isDipsManagedRule,
-  closedAllocationAgreementNotice,
-  activeAgreementRevertGuidance,
-} from '../../../indexing-agreement-notices'
 import {
   validatePOI,
   printObjectOrArray,
   extractProtocolNetworkOption,
   getRawPositionalArgs,
 } from '../../../command-helpers'
-import { resolveChainAlias } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold(
@@ -102,55 +94,15 @@ module.exports = {
 
       const config = loadValidatedConfig()
       const client = await createIndexerManagementClient({ url: config.api })
-
-      // Fetched before the close so the DIPS notice (and the revert guidance
-      // below) can name the deployment; the close result does not carry it.
-      let deployment: string | undefined
-      try {
-        const result = await client
-          .query(
-            gql`
-              query allocations($filter: AllocationFilter!) {
-                allocations(filter: $filter) {
-                  id
-                  subgraphDeployment
-                }
-              }
-            `,
-            { filter: { allocation: id, protocolNetwork } },
-          )
-          .toPromise()
-        deployment = result.data?.allocations?.[0]?.subgraphDeployment
-      } catch (lookupError) {
-        print.info(`Could not look up the allocation's deployment: ${lookupError}`)
-      }
-      const networkAlias = resolveChainAlias(protocolNetwork)
-
-      let closeResult
-      try {
-        closeResult = await closeAllocation(
-          client,
-          id,
-          poi,
-          blockNumber,
-          publicPOI,
-          toForce,
-          protocolNetwork,
-        )
-      } catch (closeError) {
-        const guidance = activeAgreementRevertGuidance(
-          closeError.toString(),
-          deployment,
-          networkAlias,
-        )
-        if (guidance) {
-          spinner.fail('Allocation close blocked by the network')
-          print.warning(guidance)
-          process.exitCode = 1
-          return
-        }
-        throw closeError
-      }
+      const closeResult = await closeAllocation(
+        client,
+        id,
+        poi,
+        blockNumber,
+        publicPOI,
+        toForce,
+        protocolNetwork,
+      )
 
       spinner.succeed('Allocation closed')
       printObjectOrArray(
@@ -160,21 +112,6 @@ module.exports = {
         ['allocation', 'allocatedTokens', 'indexingRewards'],
         wrapWidth,
       )
-
-      if (deployment) {
-        try {
-          const rule = await indexingRule(
-            client,
-            { identifier: deployment, protocolNetwork },
-            false,
-          )
-          if (isDipsManagedRule(rule)) {
-            print.warning(closedAllocationAgreementNotice(deployment, networkAlias))
-          }
-        } catch (ruleError) {
-          print.info(`Could not check for an indexing agreement rule: ${ruleError}`)
-        }
-      }
     } catch (error) {
       spinner.fail(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/commands/indexer/allocations/close.ts
+++ b/packages/indexer-cli/src/commands/indexer/allocations/close.ts
@@ -1,15 +1,23 @@
 import { GluegunToolbox } from 'gluegun'
 import chalk from 'chalk'
+import gql from 'graphql-tag'
 
 import { loadValidatedConfig } from '../../../config'
 import { createIndexerManagementClient } from '../../../client'
 import { closeAllocation } from '../../../allocations'
+import { indexingRule } from '../../../rules'
+import {
+  isDipsManagedRule,
+  closedAllocationAgreementNotice,
+  activeAgreementRevertGuidance,
+} from '../../../indexing-agreement-notices'
 import {
   validatePOI,
   printObjectOrArray,
   extractProtocolNetworkOption,
   getRawPositionalArgs,
 } from '../../../command-helpers'
+import { resolveChainAlias } from '@graphprotocol/indexer-common'
 
 const HELP = `
 ${chalk.bold(
@@ -94,15 +102,55 @@ module.exports = {
 
       const config = loadValidatedConfig()
       const client = await createIndexerManagementClient({ url: config.api })
-      const closeResult = await closeAllocation(
-        client,
-        id,
-        poi,
-        blockNumber,
-        publicPOI,
-        toForce,
-        protocolNetwork,
-      )
+
+      // Fetched before the close so the DIPS notice (and the revert guidance
+      // below) can name the deployment; the close result does not carry it.
+      let deployment: string | undefined
+      try {
+        const result = await client
+          .query(
+            gql`
+              query allocations($filter: AllocationFilter!) {
+                allocations(filter: $filter) {
+                  id
+                  subgraphDeployment
+                }
+              }
+            `,
+            { filter: { allocation: id, protocolNetwork } },
+          )
+          .toPromise()
+        deployment = result.data?.allocations?.[0]?.subgraphDeployment
+      } catch (lookupError) {
+        print.info(`Could not look up the allocation's deployment: ${lookupError}`)
+      }
+      const networkAlias = resolveChainAlias(protocolNetwork)
+
+      let closeResult
+      try {
+        closeResult = await closeAllocation(
+          client,
+          id,
+          poi,
+          blockNumber,
+          publicPOI,
+          toForce,
+          protocolNetwork,
+        )
+      } catch (closeError) {
+        const guidance = activeAgreementRevertGuidance(
+          closeError.toString(),
+          deployment,
+          networkAlias,
+        )
+        if (guidance) {
+          spinner.fail('Allocation close blocked by the network')
+          print.warning(guidance)
+          process.exitCode = 1
+          return
+        }
+        throw closeError
+      }
 
       spinner.succeed('Allocation closed')
       printObjectOrArray(
@@ -112,6 +160,21 @@ module.exports = {
         ['allocation', 'allocatedTokens', 'indexingRewards'],
         wrapWidth,
       )
+
+      if (deployment) {
+        try {
+          const rule = await indexingRule(
+            client,
+            { identifier: deployment, protocolNetwork },
+            false,
+          )
+          if (isDipsManagedRule(rule)) {
+            print.warning(closedAllocationAgreementNotice(deployment, networkAlias))
+          }
+        } catch (ruleError) {
+          print.info(`Could not check for an indexing agreement rule: ${ruleError}`)
+        }
+      }
     } catch (error) {
       spinner.fail(error.toString())
       process.exitCode = 1

--- a/packages/indexer-cli/src/indexing-agreement-notices.ts
+++ b/packages/indexer-cli/src/indexing-agreement-notices.ts
@@ -1,4 +1,7 @@
-import { IndexingDecisionBasis, IndexingRuleAttributes } from '@graphprotocol/indexer-common'
+import {
+  IndexingDecisionBasis,
+  IndexingRuleAttributes,
+} from '@graphprotocol/indexer-common'
 
 // The network settles an indexing agreement inside the allocation close itself
 // (SubgraphService cancels it, or reverts the close when its guard is enabled).

--- a/packages/indexer-cli/src/indexing-agreement-notices.ts
+++ b/packages/indexer-cli/src/indexing-agreement-notices.ts
@@ -1,0 +1,53 @@
+import { IndexingDecisionBasis, IndexingRuleAttributes } from '@graphprotocol/indexer-common'
+
+// The network settles an indexing agreement inside the allocation close itself
+// (SubgraphService cancels it, or reverts the close when its guard is enabled).
+// These notices surface that at the terminal instead of only in the agent log.
+
+export function isDipsManagedRule(
+  rule: Partial<IndexingRuleAttributes> | null | undefined,
+): boolean {
+  return rule?.decisionBasis === IndexingDecisionBasis.DIPS
+}
+
+export function closedAllocationAgreementNotice(
+  deployment: string,
+  network: string,
+): string {
+  return [
+    'This deployment is managed by an indexing agreement (DIPS).',
+    'Closing an allocation cancels any agreement bound to it on-chain, and payments for it stop.',
+    'Future agreement proposals remain allowed; to opt out of those as well:',
+    '',
+    `  graph indexer rules never ${deployment} --network ${network}`,
+  ].join('\n')
+}
+
+export function queuedUnallocateAgreementWarning(
+  actionID: number,
+  network: string,
+): string {
+  return [
+    'This deployment is managed by an indexing agreement (DIPS).',
+    'When this unallocate executes, the network will cancel any agreement bound to the',
+    'allocation and payments for it will stop. To back out before it executes:',
+    '',
+    `  graph indexer actions cancel ${actionID} --network ${network}`,
+  ].join('\n')
+}
+
+export function activeAgreementRevertGuidance(
+  errorMessage: string,
+  deployment: string | undefined,
+  network: string,
+): string | null {
+  if (!errorMessage.includes('SubgraphServiceAllocationHasActiveAgreement')) {
+    return null
+  }
+  return [
+    'The network blocked this close: the allocation has an active indexing agreement.',
+    'Cancel the agreement first by opting the deployment out:',
+    '',
+    `  graph indexer rules never ${deployment ?? '<deployment>'} --network ${network}`,
+  ].join('\n')
+}

--- a/packages/indexer-cli/src/indexing-agreement-notices.ts
+++ b/packages/indexer-cli/src/indexing-agreement-notices.ts
@@ -1,49 +1,7 @@
-import {
-  IndexingDecisionBasis,
-  IndexingRuleAttributes,
-} from '@graphprotocol/indexer-common'
-
-// The network settles an indexing agreement inside the allocation close itself
-// (SubgraphService cancels it, or reverts the close when its guard is enabled).
-// These notices surface that at the terminal instead of only in the agent log.
-
-export function isDipsManagedRule(
-  rule: Partial<IndexingRuleAttributes> | null | undefined,
-): boolean {
-  return rule?.decisionBasis === IndexingDecisionBasis.DIPS
-}
-
-export function closedAllocationAgreementNotice(
-  deployment: string,
-  network: string,
-): string {
-  return [
-    'This deployment is managed by an indexing agreement (DIPS).',
-    'Closing an allocation cancels any agreement bound to it on-chain, and payments for it stop.',
-    'Future agreement proposals remain allowed; to opt out of those as well:',
-    '',
-    `  graph indexer rules never ${deployment} --network ${network}`,
-  ].join('\n')
-}
-
-export function queuedUnallocateAgreementWarning(
-  actionID: number,
-  network: string,
-): string {
-  return [
-    'This deployment is managed by an indexing agreement (DIPS).',
-    'When this unallocate executes, the network will cancel any agreement bound to the',
-    'allocation and payments for it will stop. To back out before it executes:',
-    '',
-    `  graph indexer actions cancel ${actionID} --network ${network}`,
-  ].join('\n')
-}
-
-export function activeAgreementRevertGuidance(
-  errorMessage: string,
-  deployment: string | undefined,
-  network: string,
-): string | null {
+// SubgraphService reverts a close on an allocation with an active indexing
+// agreement when its close guard is enabled; translate that raw revert into
+// the command that resolves it instead of leaving an opaque error string.
+export function activeAgreementRevertGuidance(errorMessage: string): string | null {
   if (!errorMessage.includes('SubgraphServiceAllocationHasActiveAgreement')) {
     return null
   }
@@ -51,6 +9,6 @@ export function activeAgreementRevertGuidance(
     'The network blocked this close: the allocation has an active indexing agreement.',
     'Cancel the agreement first by opting the deployment out:',
     '',
-    `  graph indexer rules never ${deployment ?? '<deployment>'} --network ${network}`,
+    '  graph indexer rules never <deployment> --network <network>',
   ].join('\n')
 }

--- a/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
+++ b/packages/indexer-common/src/__tests__/dips-agreement-protection.test.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ActionInput, ActionStatus, ActionType, validateActionInputs } from '../actions'
+import {
+  ActionInput,
+  ActionStatus,
+  ActionType,
+  assertSafeToCloseAllocation,
+  validateActionInputs,
+} from '../actions'
 import { AllocationStatus } from '../allocations'
 
 const mockAllocation = {
@@ -85,5 +91,46 @@ describe('validateActionInputs DIPS agreement protection', () => {
     ).resolves.toBeUndefined()
 
     expect(monitor.hasCollectableDipsAgreement).not.toHaveBeenCalled()
+  })
+})
+
+// The same guard is shared with the direct closeAllocation resolver, so it is
+// also covered on its own, outside the action-validation wrapper.
+describe('assertSafeToCloseAllocation', () => {
+  const allocationID = baseAction.allocationID as string
+
+  it('rejects an unforced close when the agreement can still collect', async () => {
+    const monitor = createMockNetworkMonitor(true)
+    const logger = createMockLogger()
+
+    await expect(
+      assertSafeToCloseAllocation(monitor as any, allocationID, false, logger as any),
+    ).rejects.toThrow(/DIPS agreement that can still collect fees/)
+  })
+
+  it('allows a forced close but records a warning', async () => {
+    const monitor = createMockNetworkMonitor(true)
+    const logger = createMockLogger()
+
+    await expect(
+      assertSafeToCloseAllocation(monitor as any, allocationID, true, logger as any),
+    ).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Force-closing allocation with a collectable DIPS agreement',
+      expect.objectContaining({ allocationId: allocationID }),
+    )
+  })
+
+  it('allows a close when nothing is collectable, forced or not', async () => {
+    for (const force of [false, true]) {
+      const monitor = createMockNetworkMonitor(false)
+      const logger = createMockLogger()
+
+      await expect(
+        assertSafeToCloseAllocation(monitor as any, allocationID, force, logger as any),
+      ).resolves.toBeUndefined()
+      expect(logger.warn).not.toHaveBeenCalled()
+    }
   })
 })

--- a/packages/indexer-common/src/actions.ts
+++ b/packages/indexer-common/src/actions.ts
@@ -106,6 +106,30 @@ export const isValidActionInput = (
   )
 }
 
+// Closing an allocation that still owes DIPS fees cancels a live agreement
+// on-chain or strands fees a canceled agreement hasn't finished collecting,
+// so every close path shares this guard; force acknowledges the loss.
+export const assertSafeToCloseAllocation = async (
+  networkMonitor: NetworkMonitor,
+  allocationID: string,
+  force: boolean,
+  logger: Logger,
+): Promise<void> => {
+  const hasAgreement = await networkMonitor.hasCollectableDipsAgreement(allocationID)
+  if (hasAgreement && !force) {
+    throw new Error(
+      `Allocation ${allocationID} has a DIPS agreement that can still collect fees. ` +
+        `Closing it now would cancel a live agreement on-chain, or strand fees that a ` +
+        `canceled agreement has not finished collecting. Use force=true to proceed anyway.`,
+    )
+  }
+  if (hasAgreement && force) {
+    logger.warn('Force-closing allocation with a collectable DIPS agreement', {
+      allocationId: allocationID,
+    })
+  }
+}
+
 export const validateActionInputs = async (
   actions: ActionInput[],
   networkMonitor: NetworkMonitor,
@@ -181,26 +205,13 @@ export const validateActionInputs = async (
         )
       }
 
-      // Block closing an allocation that still owes DIPS fees: SubgraphService.collect
-      // requires the allocation open, so an early close would cancel a live agreement
-      // on-chain or strand fees a canceled agreement hasn't finished collecting.
       if (action.type === ActionType.UNALLOCATE && action.allocationID) {
-        const hasAgreement = await networkMonitor.hasCollectableDipsAgreement(
+        await assertSafeToCloseAllocation(
+          networkMonitor,
           action.allocationID,
+          action.force ?? false,
+          logger,
         )
-        if (hasAgreement && !action.force) {
-          throw new Error(
-            `Allocation ${action.allocationID} has a DIPS agreement that can still collect fees. ` +
-              `Closing it now would cancel a live agreement on-chain, or strand fees that a ` +
-              `canceled agreement has not finished collecting. Use force=true to proceed anyway.`,
-          )
-        }
-        if (hasAgreement && action.force) {
-          logger.warn('Force-closing allocation with a collectable DIPS agreement', {
-            allocationId: action.allocationID,
-            actionType: action.type,
-          })
-        }
       }
     }
   }

--- a/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
+++ b/packages/indexer-common/src/indexer-management/resolvers/allocations.ts
@@ -16,6 +16,7 @@ import {
 import {
   Allocation,
   AllocationStatus,
+  assertSafeToCloseAllocation,
   CloseAllocationResult,
   CreateAllocationResult,
   encodeCollectData,
@@ -909,6 +910,10 @@ export default {
     const network = extractNetwork(protocolNetwork, multiNetworks)
     const networkMonitor = network.networkMonitor
     const allocationData = await networkMonitor.allocation(allocation)
+
+    // Same guard the queued unallocate path applies in validateActionInputs:
+    // an unforced close must not cancel a collectable DIPS agreement on-chain.
+    await assertSafeToCloseAllocation(networkMonitor, allocation, force, logger)
 
     try {
       logger.debug('Resolving POI')


### PR DESCRIPTION
This PR makes `graph indexer allocations close` refuse to close an allocation whose indexing agreement (DIPS) can still collect fees, unless `--force` is passed. The queued path already had this protection: queueing an unallocate rejects the action with an explanation when a collectable agreement exists. The direct close mutation had no such check and went straight to the on-chain transaction, and since the network cancels an allocation's active agreement as part of the close, the unguarded door could silently end a paid agreement.

The check now lives in 1 shared function, `assertSafeToCloseAllocation`, called by both the action validation (behavior unchanged, existing tests still pass) and the closeAllocation mutation (new behavior, covered by new tests). Forcing past the guard logs a warning, matching the queued path, and the close command's `--force` help text now says so. The CLI also translates the network's own close-guard revert (`SubgraphServiceAllocationHasActiveAgreement`) into the `rules never` command that resolves it, instead of printing a raw revert string. Companion to #1245, which keeps the post-close never rule off DIPS-managed deployments.
