### PR TITLE
test: retry tests that flake on transient RPC connection drops

### DIFF
--- a/packages/indexer-common/src/allocations/__tests__/tap.test.ts
+++ b/packages/indexer-common/src/allocations/__tests__/tap.test.ts
@@ -25,6 +25,10 @@ import { hexlify, verifyTypedData } from 'ethers'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const __DATABASE__: any
 declare const __LOG_LEVEL__: never
+
+// This suite reaches a live RPC endpoint, whose transient connection drops (socket hang
+// up, ECONNRESET) would otherwise fail CI, so failed tests retry up to 2 times.
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
 let logger: Logger
 let tapCollector: TapCollector
 let metrics: Metrics

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/cost-models.test.ts
@@ -18,6 +18,10 @@ import { defineQueryFeeModels } from '../../../query-fees/models'
 declare const __DATABASE__: any
 declare const __LOG_LEVEL__: never
 
+// This suite reaches a live RPC endpoint, whose transient connection drops (socket hang
+// up, ECONNRESET) would otherwise fail CI, so failed tests retry up to 2 times.
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const SET_COST_MODEL_MUTATION = gql`
   mutation setCostModel($costModel: CostModelInput!) {
     setCostModel(costModel: $costModel) {

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/indexing-rules.test.ts
@@ -26,6 +26,10 @@ declare const __DATABASE__: any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const __LOG_LEVEL__: any
 
+// This suite reaches a live RPC endpoint, whose transient connection drops (socket hang
+// up, ECONNRESET) would otherwise fail CI, so failed tests retry up to 2 times.
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const SET_INDEXING_RULE_MUTATION = gql`
   mutation setIndexingRule($rule: IndexingRuleInput!) {
     setIndexingRule(rule: $rule) {
@@ -258,7 +262,6 @@ describe('Indexing rules', () => {
       protocolNetwork: 'eip155:421614',
     }
 
-    // Write the original
     await expect(
       client.mutation(SET_INDEXING_RULE_MUTATION, { rule: originalInput }).toPromise(),
     ).resolves.toHaveProperty('data.setIndexingRule', original)
@@ -324,7 +327,6 @@ describe('Indexing rules', () => {
       protocolNetwork: 'eip155:421614',
     }
 
-    // Write the original
     await expect(
       client.mutation(SET_INDEXING_RULE_MUTATION, { rule: originalInput }).toPromise(),
     ).resolves.toHaveProperty('data.setIndexingRule', original)

--- a/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.test.ts
+++ b/packages/indexer-common/src/indexer-management/__tests__/resolvers/poi-disputes.test.ts
@@ -21,6 +21,10 @@ declare const __DATABASE__: any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const __LOG_LEVEL__: any
 
+// This suite reaches a live RPC endpoint, whose transient connection drops (socket hang
+// up, ECONNRESET) would otherwise fail CI, so failed tests retry up to 2 times.
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const STORE_POI_DISPUTES_MUTATION = gql`
   mutation storeDisputes($disputes: [POIDisputeInput!]!) {
     storeDisputes(disputes: $disputes) {


### PR DESCRIPTION
This PR makes failed tests retry up to 2 times in the 4 indexer-common suites that talk to a live Arbitrum Sepolia RPC endpoint (tap, cost-models, indexing-rules, and poi-disputes), so a momentary connection drop no longer fails a CI run. Each failure is still logged before retrying, so the flakes stay visible in job logs rather than being silently absorbed, and a genuinely broken test still fails after 3 attempts.

The motivation is concrete: over the last 2 days, 4 CI node jobs across 3 runs on 2 unrelated PRs failed with transient transport errors from that endpoint (socket hang up in poi-disputes, ECONNRESET in indexing-rules), each time in a different test, and each time green on rerun. Retries happen through jest, which re-runs the per-test setup hooks, so each attempt starts from the same clean database state the first attempt had.